### PR TITLE
Dockerfile update to Ubuntu 20.04 and OpenFoam 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #     xhost +
 #     podman run -ti --rm \
 #                -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
-#                -v $HOME/MyWindNinjaRuns:/data \
+#                -v $HOME/MyWindNinjaRuns:/data:z \
 #                --env="QT_X11_NO_MITSHM=1" \
 #                --security-opt label=type:container_runtime_t \
 #                windninja:3.7.5 
@@ -54,7 +54,8 @@ RUN mkdir /opt/src && \
     cmake -D SUPRESS_WARNINGS=ON .. && \
     make -j4 && \
     make install && \
-    ldconfig
-CMD /usr/local/bin/WindNinja
+    ldconfig && \
+    echo "source /opt/openfoam8/etc/bashrc" >> /root/.bashrc
+CMD /usr/bin/bash -c /usr/local/bin/WindNinja
 VOLUME /data
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,60 @@
 # Copyright (c) Kyle Shannon
 # Distributed under the terms of the Modified BSD License.
-FROM ubuntu:16.04
+#
+# Note, to use this X11 application from within a container, you need to
+# allow X11 connections from other hosts as well as extra 
+# command line options on the docker (or podman) run line. To access data
+# from outside the narrow confines of the WindNinja container, you'll also
+# need to specify a volume mount. By default, this container uses "/data" as 
+# a working directory. For instance, as an unpriviledged user 
+# using podman: 
+# 
+#     mkdir $HOME/MyWindNinjaRuns
+#     xhost +
+#     podman run -ti --rm \
+#                -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+#                -v $HOME/MyWindNinjaRuns:/data \
+#                --env="QT_X11_NO_MITSHM=1" \
+#                --security-opt label=type:container_runtime_t \
+#                windninja:3.7.5 
+#
+FROM ubuntu:20.04
 
 MAINTAINER Kyle Shannon <kyle@pobox.com>
 
 USER root
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get install -y wget
-RUN sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
-RUN apt-get install -y apt-transport-https ca-certificates
-RUN apt-get install -y -qq software-properties-common && \
+RUN apt-get update && \
+    apt-get install -y wget gnupg2 && \
+    sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -" && \
+    apt-get install -y apt-transport-https ca-certificates && \
+    apt-get install -y -qq software-properties-common && \
     add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && \
     add-apt-repository http://dl.openfoam.org/ubuntu && \
+    add-apt-repository -y ppa:rock-core/qt4 && \
     apt-get update && \
-    apt-get install -y -qq \
+    apt-get install -y  \
         cmake \
         git \
         libgdal-dev \
-        qt4-dev-tools \
+        libqt4-dev \
         libqtwebkit-dev \
         libboost-program-options-dev \
         libboost-date-time-dev \
         libboost-test-dev \
-        openfoam4
+        openfoam8 && \
+    rm -rf /var/lib/apt/lists
 
-RUN mkdir /opt/src
-WORKDIR /opt/src
-RUN git clone http://github.com/firelab/windninja
-WORKDIR /opt/src/windninja
-RUN mkdir build
-WORKDIR /opt/src/windninja/build
-RUN cmake -D SUPRESS_WARNINGS=ON ..
-RUN make -j4
-RUN make install
-
-#RUN useradd -m -s /bin/bash -N -u 1000 ziggy
-#USER ziggy
-#WORKDIR /home/ziggy
-#RUN source /opt/openfoam4/etc/bashrc
+RUN mkdir /opt/src && \
+    cd /opt/src && \
+    git clone http://github.com/firelab/windninja && \
+    cd  /opt/src/windninja && \
+    mkdir build && \
+    cd  /opt/src/windninja/build && \
+    cmake -D SUPRESS_WARNINGS=ON .. && \
+    make -j4 && \
+    make install && \
+    ldconfig
+CMD /usr/local/bin/WindNinja
+VOLUME /data
+WORKDIR /data


### PR DESCRIPTION
Updated Dockerfile :

- Ubuntu 16.04 --> 20.04
- OpenFOAM 4 --> 8
- Consolidated RUN statements and removed /var/lib/apt/lists before saving a commit.
- Running WindNinja from `bash` shell, sourcing the OpenFOAM bashrc first.
- Basic documentation on how to run an X11 app from within a container on an SELinux-enforcing system--works on Fedora. (Saves five minutes of googling)

Note that attempting to run a simple conservation of energy + momentum simulation dumps core. However, this may be due to the fact I'm just building off of master rather than a tagged release, and OpenFOAM 8 just appeared today. It may or may not be due to packaging...