### PR TITLE
Dem text bounds

### DIFF
--- a/data/map.htm
+++ b/data/map.htm
@@ -53,7 +53,7 @@
     <script src="./leaflet/draw/src/edit/handler/EditToolbar.Delete.js"></script>
 </head>
 <body>
- <div id="map" style="width: 100%; height: 85%; border: 1px solid #ccc"></div>
+ <div id="map" style="width: 100%; height: 80%; border: 1px solid #ccc"></div>
 <script>
     // Get a valid key from our server
     var apiKey = "";
@@ -272,8 +272,8 @@
     }
 </script>
 
-<div id="data_entry" style="width: 100%; height: 15%; border: 1px solid #ccc">
-  <form>
+<div id="data_entry" style="width: 95%; height: 20%; border: 1px solid #ccc">
+  <form id="bounds" style="border-style: solid">
     <label for="south_lat">South</label>
     <input type="number" id="south_lat" name="south_lat" />
     <label for="west_lon">West</label>
@@ -282,6 +282,8 @@
     <input type="number" id="north_lat" name="north_lat" />
     <label for="east_lon">East</label>
     <input type="number" id="east_lon" name="east_lon" />
+  </form>
+  <form id="center_radius" style="border-style: solid;">
     <label for="center_lat">Center Lat</label>
     <input type="number" id="center_lat" name="center_lat" />
     <label for="center_lon">Center Lon</label>

--- a/data/map.htm
+++ b/data/map.htm
@@ -53,7 +53,7 @@
     <script src="./leaflet/draw/src/edit/handler/EditToolbar.Delete.js"></script>
 </head>
 <body>
- <div id="map" style="width: 100%; height: 100%; border: 1px solid #ccc"></div>
+ <div id="map" style="width: 100%; height: 90%; border: 1px solid #ccc"></div>
 <script>
     // Get a valid key from our server
     var apiKey = "";
@@ -121,30 +121,65 @@
     map.on(L.Draw.Event.CREATED, function (e) {
         mbrLayer.addLayer(e.layer);
         map.addLayer(mbrLayer);
-        console.log(mbr());
+        if(mbrLayer.getLayers().length > 0){
+          var b = mbrLayer.getLayers()[0]._bounds;
+          var bounds = fix_bounds([b._southWest.lng, b._northEast.lng, b._southWest.lat, b._northEast.lat]);
+          //set the input boxes at the bottom
+          document.getElementById("west_lon").value = bounds[0];
+          document.getElementById("east_lon").value = bounds[1];
+          document.getElementById("south_lat").value = bounds[2];
+          document.getElementById("north_lat").value = bounds[3];
+          console.log(bounds);
+        }
     });
+
+    // the function evaluated by the C++ code to retrieve the selected box
     function mbr() {
-     if(mbrLayer.getLayers().length > 0){
-      var b = mbrLayer.getLayers()[0]._bounds;
-      b._southWest.lng = b._southWest.lng % 360;
-      if(b._southWest.lng < -180) {
-        b._southWest.lng += 360;
+      var b = [
+          document.getElementById("west_lon").value,
+          document.getElementById("east_lon").value,
+          document.getElementById("south_lat").value,
+          document.getElementById("north_lat").value
+      ];
+      console.log(b);
+      return fix_bounds(b);
+    }
+
+    function fix_bounds(bounds) {
+      // make shallow copy of array
+      // element ordering should be west, east, south, north
+      var b = bounds.slice(0) ;
+
+      // normalize longitudes to -180 - 180.
+      b[0] = b[0] % 360;
+      if(b[0] < -180) {
+        b[0] += 360;
       }
-      b._northEast.lng = b._northEast.lng % 360;
-      if(b._northEast.lng < -180) {
-        b._northEast.lng += 360;
+      b[1] = b[1] % 360;
+      if(b[1] < -180) {
+        b[1] += 360;
       }
       // switch to negative longitudes if needed
-      if(b._southWest.lng > 180){
-        b._southWest.lng -= 360;
+      if(b[0] > 180){
+        b[0] -= 360;
       }
-      if(b._northEast.lng > 180){
-        b._northEast.lng -= 360;
+      if(b[1] > 180){
+        b[1] -= 360;
       }
-      return [b._southWest.lng, b._northEast.lng, b._southWest.lat, b._northEast.lat];
-     }
-     return null;
+      return b;
     }
 </script>
+<div id="data_entry" style="width: 100%; height: 10%; border: 1px solid #ccc">
+  <form>
+    <label for="south_lat">South</label>
+    <input type="number" id="south_lat" name="south_lat" />
+    <label for="west_lon">West</label>
+    <input type="number" id="west_lon" name="west_lon" />
+    <label for="north_lat">North</label>
+    <input type="number" id="north_lat" name="north_lat" />
+    <label for="east_lon">East</label>
+    <input type="number" id="east_lon" name="east_lon" />
+  </form>
+</div>
 </body>
 </html>

--- a/data/map.htm
+++ b/data/map.htm
@@ -53,7 +53,7 @@
     <script src="./leaflet/draw/src/edit/handler/EditToolbar.Delete.js"></script>
 </head>
 <body>
- <div id="map" style="width: 100%; height: 90%; border: 1px solid #ccc"></div>
+ <div id="map" style="width: 100%; height: 85%; border: 1px solid #ccc"></div>
 <script>
     // Get a valid key from our server
     var apiKey = "";
@@ -125,13 +125,16 @@
           var b = e.layer._bounds;
           var bounds = fix_bounds([b._southWest.lng, b._northEast.lng, b._southWest.lat, b._northEast.lat]);
 
+          disable_listeners() ;
           //set the input boxes at the bottom
           document.getElementById("west_lon").value = bounds[0];
           document.getElementById("east_lon").value = bounds[1];
           document.getElementById("south_lat").value = bounds[2];
           document.getElementById("north_lat").value = bounds[3];
+          enable_listeners() ; 
 
           //draw the rectangle
+          clear_center_radius();
           update_rectangle();
           console.log(bounds);
     });
@@ -141,10 +144,10 @@
     // the function evaluated by the C++ code to retrieve the selected box
     function mbr() {
       var b = [
-          document.getElementById("west_lon").value,
-          document.getElementById("east_lon").value,
-          document.getElementById("south_lat").value,
-          document.getElementById("north_lat").value
+          document.getElementById("west_lon").valueAsNumber,
+          document.getElementById("east_lon").valueAsNumber,
+          document.getElementById("south_lat").valueAsNumber,
+          document.getElementById("north_lat").valueAsNumber
       ];
       console.log(b);
       return fix_bounds(b);
@@ -174,17 +177,35 @@
       return b;
     }
 
+    function clear_center_radius() {
+        console.log("clear_center_radius")
+        disable_listeners();
+        //set the input boxes at the bottom
+        document.getElementById("center_lat").value =  null ;
+        document.getElementById("center_lon").value =  null ;
+        document.getElementById("radius").value = null ;
+        enable_listeners() ; 
+    }
+
+    function update_text_bounds() {
+        console.log("update_text_bounds") ; 
+        clear_center_radius() ; 
+        update_rectangle() ;
+    }
+
+
     function update_rectangle() {
-      var bounds = [ [ document.getElementById("south_lat").value,
-                       document.getElementById("west_lon").value],
-                     [ document.getElementById("north_lat").value,
-                       document.getElementById("east_lon").value] ];
+      console.log("update_rectangle") ; 
+      var bounds = [ [ document.getElementById("south_lat").valueAsNumber,
+                       document.getElementById("west_lon").valueAsNumber],
+                     [ document.getElementById("north_lat").valueAsNumber,
+                       document.getElementById("east_lon").valueAsNumber] ];
 
       // if any of the text boxes are empty, disregard.
       for (var i = 0; i < bounds.length; i++) {
           var corner = bounds[i];
           for (var j = 0; j < corner.length; j++) { 
-             if (corner[j] == null || corner[j] == "") {
+             if (isNaN(corner[j])) {
                  return null ;
              }
           }
@@ -194,9 +215,64 @@
       txtboxLayer.clearLayers() ;
       L.rectangle(bounds).addTo(txtboxLayer);
     }
+
+    function update_center() { 
+        console.log("update_center");
+        var center_lat = document.getElementById("center_lat").valueAsNumber;
+        var center_lon = document.getElementById("center_lon").valueAsNumber;
+        var radius = document.getElementById("radius").valueAsNumber;
+
+        // if any boxes empty, skip
+        if (isNaN(center_lat)) return null ;
+        if (isNaN(center_lon)) return null ;
+        if (isNaN(radius)) return null ; 
+
+
+        // crude spherical earth distance calculation.
+        var delta_lat = radius / ( 2 * Math.PI * 3958.7613 / 360.);
+        var lat_rad = 3958.7613 * Math.cos(center_lat * Math.PI/180) ;
+        var delta_lon = radius / ( 2 * Math.PI * lat_rad / 360.);
+
+        console.log([delta_lat, delta_lon, lat_rad]);
+
+        //set the input boxes at the bottom
+        disable_listeners();
+        document.getElementById("west_lon").value = center_lon - delta_lon;
+        document.getElementById("east_lon").value = center_lon + delta_lon;
+        document.getElementById("south_lat").value = center_lat - delta_lat;
+        document.getElementById("north_lat").value = center_lat + delta_lat;
+        enable_listeners();
+
+        update_rectangle();
+    } 
+
+    function enable_listeners() {
+        // draw a new box whenever user types in coordinates
+        document.getElementById("west_lon").addEventListener("input", update_text_bounds);
+        document.getElementById("east_lon").addEventListener("input", update_text_bounds);
+        document.getElementById("south_lat").addEventListener("input", update_text_bounds);
+        document.getElementById("north_lat").addEventListener("input", update_text_bounds);
+    
+        // calculate new bounds whenever user types in center and radius
+        document.getElementById("center_lat").addEventListener("input", update_center);
+        document.getElementById("center_lon").addEventListener("input", update_center);
+        document.getElementById("radius").addEventListener("input", update_center);
+    }
+    function disable_listeners() {
+        // draw a new box whenever user types in coordinates
+        document.getElementById("west_lon").removeEventListener("input", update_text_bounds);
+        document.getElementById("east_lon").removeEventListener("input", update_text_bounds);
+        document.getElementById("south_lat").removeEventListener("input", update_text_bounds);
+        document.getElementById("north_lat").removeEventListener("input", update_text_bounds);
+    
+        // calculate new bounds whenever user types in center and radius
+        document.getElementById("center_lat").removeEventListener("input", update_center);
+        document.getElementById("center_lon").removeEventListener("input", update_center);
+        document.getElementById("radius").removeEventListener("input", update_center);
+    }
 </script>
 
-<div id="data_entry" style="width: 100%; height: 10%; border: 1px solid #ccc">
+<div id="data_entry" style="width: 100%; height: 15%; border: 1px solid #ccc">
   <form>
     <label for="south_lat">South</label>
     <input type="number" id="south_lat" name="south_lat" />
@@ -206,15 +282,17 @@
     <input type="number" id="north_lat" name="north_lat" />
     <label for="east_lon">East</label>
     <input type="number" id="east_lon" name="east_lon" />
+    <label for="center_lat">Center Lat</label>
+    <input type="number" id="center_lat" name="center_lat" />
+    <label for="center_lon">Center Lon</label>
+    <input type="number" id="center_lon" name="center_lon" />
+    <label for="radius">Radius (miles)</label>
+    <input type="number" id="radius" name="radius" />
   </form>
 </div>
 
 <script>
-    // draw a new box whenever user types in coordinates
-    document.getElementById("west_lon").addEventListener("input", update_rectangle);
-    document.getElementById("east_lon").addEventListener("input", update_rectangle);
-    document.getElementById("south_lat").addEventListener("input", update_rectangle);
-    document.getElementById("north_lat").addEventListener("input", update_rectangle);
+  enable_listeners();
 </script>
 </body>
 </html>

--- a/data/map.htm
+++ b/data/map.htm
@@ -124,10 +124,6 @@
             marker: false,
             circlemarker: false,
             rectangle: true
-        },
-        edit: {
-         featureGroup: mbrLayer,
-         remove: true
         }
     });
     map.addControl(drawControl);

--- a/data/map.htm
+++ b/data/map.htm
@@ -133,6 +133,8 @@
         }
     });
 
+
+
     // the function evaluated by the C++ code to retrieve the selected box
     function mbr() {
       var b = [
@@ -169,6 +171,7 @@
       return b;
     }
 </script>
+
 <div id="data_entry" style="width: 100%; height: 10%; border: 1px solid #ccc">
   <form>
     <label for="south_lat">South</label>
@@ -181,5 +184,16 @@
     <input type="number" id="east_lon" name="east_lon" />
   </form>
 </div>
+
+<script>
+    // clear the graphical "draw" box whenever user types in numbers directly
+    function update_bounds(e) {
+        mbrLayer.clearLayers();
+    };
+    document.getElementById("west_lon").addEventListener("input", update_bounds);
+    document.getElementById("east_lon").addEventListener("input", update_bounds);
+    document.getElementById("south_lat").addEventListener("input", update_bounds);
+    document.getElementById("north_lat").addEventListener("input", update_bounds);
+</script>
 </body>
 </html>

--- a/data/map.htm
+++ b/data/map.htm
@@ -96,6 +96,8 @@
     var map = new L.Map('map', {layers: [mbl], center: new L.LatLng(43.62455, -113.2971), zoom: 8});
     var mbrLayer = new L.FeatureGroup();
     map.addLayer(mbrLayer);
+    var txtboxLayer = new L.FeatureGroup();
+    map.addLayer(txtboxLayer) ;
 
     var drawControl = new L.Control.Draw({
         position: 'topright',
@@ -116,21 +118,22 @@
 
     map.on(L.Draw.Event.DRAWSTART, function (e) {
         mbrLayer.clearLayers();
+        txtboxLayer.clearLayers();
     });
 
     map.on(L.Draw.Event.CREATED, function (e) {
-        mbrLayer.addLayer(e.layer);
-        map.addLayer(mbrLayer);
-        if(mbrLayer.getLayers().length > 0){
-          var b = mbrLayer.getLayers()[0]._bounds;
+          var b = e.layer._bounds;
           var bounds = fix_bounds([b._southWest.lng, b._northEast.lng, b._southWest.lat, b._northEast.lat]);
+
           //set the input boxes at the bottom
           document.getElementById("west_lon").value = bounds[0];
           document.getElementById("east_lon").value = bounds[1];
           document.getElementById("south_lat").value = bounds[2];
           document.getElementById("north_lat").value = bounds[3];
+
+          //draw the rectangle
+          update_rectangle();
           console.log(bounds);
-        }
     });
 
 
@@ -170,6 +173,27 @@
       }
       return b;
     }
+
+    function update_rectangle() {
+      var bounds = [ [ document.getElementById("south_lat").value,
+                       document.getElementById("west_lon").value],
+                     [ document.getElementById("north_lat").value,
+                       document.getElementById("east_lon").value] ];
+
+      // if any of the text boxes are empty, disregard.
+      for (var i = 0; i < bounds.length; i++) {
+          var corner = bounds[i];
+          for (var j = 0; j < corner.length; j++) { 
+             if (corner[j] == null || corner[j] == "") {
+                 return null ;
+             }
+          }
+      }
+
+      // draw the box
+      txtboxLayer.clearLayers() ;
+      L.rectangle(bounds).addTo(txtboxLayer);
+    }
 </script>
 
 <div id="data_entry" style="width: 100%; height: 10%; border: 1px solid #ccc">
@@ -186,14 +210,11 @@
 </div>
 
 <script>
-    // clear the graphical "draw" box whenever user types in numbers directly
-    function update_bounds(e) {
-        mbrLayer.clearLayers();
-    };
-    document.getElementById("west_lon").addEventListener("input", update_bounds);
-    document.getElementById("east_lon").addEventListener("input", update_bounds);
-    document.getElementById("south_lat").addEventListener("input", update_bounds);
-    document.getElementById("north_lat").addEventListener("input", update_bounds);
+    // draw a new box whenever user types in coordinates
+    document.getElementById("west_lon").addEventListener("input", update_rectangle);
+    document.getElementById("east_lon").addEventListener("input", update_rectangle);
+    document.getElementById("south_lat").addEventListener("input", update_rectangle);
+    document.getElementById("north_lat").addEventListener("input", update_rectangle);
 </script>
 </body>
 </html>

--- a/data/map.htm
+++ b/data/map.htm
@@ -3,10 +3,26 @@
 <meta charset="UTF-8">
 <head>
  <style>
-  html, body {
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
+ body {
+   padding: 0 ;
+   margin:  0 ;
+ }
+ html, body {
+    height: 100% ;
+    width:  100% ;
+ }
+ #map {
+    height: 85% ;
+    width: 100% ;
+ }
+ .option_hdr {
+   font-size: 0.9em ;
+ }
+ .verbose {
+   font-size: .7em ;
+ }
+ label, input {
+   font-size: 0.8em;
  }
  </style>
     <title>Leaflet.draw drawing and editing tools</title>
@@ -53,7 +69,7 @@
     <script src="./leaflet/draw/src/edit/handler/EditToolbar.Delete.js"></script>
 </head>
 <body>
- <div id="map" style="width: 100%; height: 80%; border: 1px solid #ccc"></div>
+ <div id="map" style="border: 1px solid #ccc"></div>
 <script>
     // Get a valid key from our server
     var apiKey = "";
@@ -272,8 +288,16 @@
     }
 </script>
 
-<div id="data_entry" style="width: 95%; height: 20%; border: 1px solid #ccc">
+<div id="data_entry" style="border: 1px solid #ccc">
+  <p class="verbose">Define your bounding box using one of the following methods.</p>
+    <ol class="verbose">
+      <li>Draw a box on the map using the box icon in the upper right corner of the map.</li>
+      <li>Enter bounding box coordinates in decimal degrees.</li>
+      <li>Specify a center lat/lon in decimal degrees and a radius.</li>
+    </ol>
+  <p class="verbose">Once a bounding box is specified, the box will appear on the map and the coordinates will be displayed in the bounding box fields.</p>
   <form id="bounds" style="border-style: solid">
+    <p class="option_hdr">Bounding Box Coordinates:</p>
     <label for="south_lat">South</label>
     <input type="number" id="south_lat" name="south_lat" />
     <label for="west_lon">West</label>
@@ -284,6 +308,7 @@
     <input type="number" id="east_lon" name="east_lon" />
   </form>
   <form id="center_radius" style="border-style: solid;">
+    <p class="option_hdr">Point and Radius:</p>
     <label for="center_lat">Center Lat</label>
     <input type="number" id="center_lat" name="center_lat" />
     <label for="center_lon">Center Lon</label>


### PR DESCRIPTION
This addresses part of #336, involving reinstating some functionality removed a while back. 

I did not see the functionality previously. I chose to put the text fields in the `map.htm` file instead of the C++/QT code. There's four new boxes at the bottom of the downloader window which you can type lat/lon extents into. 

The box on the map updates with any change to the text fields or by the user drawing a new box. The text fields always display the extents to grab, whether the user typed them or drew a box. 

I do not have a center point and radius implemented. Check it out to see if this is what you want. If it is, we can add in more boxes.