### PR TITLE
FIx FILE and VSILFILE mismatch

### DIFF
--- a/src/ninja/KmlVector.cpp
+++ b/src/ninja/KmlVector.cpp
@@ -1179,7 +1179,7 @@ bool KmlVector::writeScreenOverlayDateTimeLegendWxModelRun(VSILFILE *fileOut)
     return true;
 }
 
-bool KmlVector::writeTurbulence(FILE *fileOut)
+bool KmlVector::writeTurbulence(VSILFILE *fileOut)
 {
 	double xPoint, yPoint;
 	double xCenter, yCenter;

--- a/src/ninja/KmlVector.h
+++ b/src/ninja/KmlVector.h
@@ -113,16 +113,16 @@ public:
 
     void orangeLegend();
 
-	bool writeHeader(FILE *fileOut);
-	bool writeRegion(FILE *fileOut);
-	bool writeStyles(FILE *fileOut);
-	bool writeHtmlLegend(FILE *fileOut);
-    bool writeScreenOverlayLegend(FILE *fileOut,std::string cScheme);
-	bool writeScreenOverlayDateTimeLegend(FILE *fileOut);
-	bool writeScreenOverlayDateTimeLegendWxModelRun(FILE *fileOut);
+	bool writeHeader(VSILFILE *fileOut);
+	bool writeRegion(VSILFILE *fileOut);
+	bool writeStyles(VSILFILE *fileOut);
+	bool writeHtmlLegend(VSILFILE *fileOut);
+    bool writeScreenOverlayLegend(VSILFILE *fileOut,std::string cScheme);
+	bool writeScreenOverlayDateTimeLegend(VSILFILE *fileOut);
+	bool writeScreenOverlayDateTimeLegendWxModelRun(VSILFILE *fileOut);
 
-	bool writeVectors(FILE *fileOut);
-	bool writeTurbulence(FILE *fileOut);
+	bool writeVectors(VSILFILE *fileOut);
+	bool writeTurbulence(VSILFILE *fileOut);
 	#ifdef FRICTION_VELOCITY
 	bool writeUstar(FILE *fileOut);
 	#endif

--- a/src/ninja/LineStyle.h
+++ b/src/ninja/LineStyle.h
@@ -47,7 +47,7 @@ public:
 	bool setHexColorRGBA();
 
 	bool printLineStyle();
-	bool writeLineStyle(FILE *fileOut);
+	bool writeLineStyle(VSILFILE *fileOut);
     std::string  asOGRLineStyle();
 
 private:

--- a/src/ninja/Style.h
+++ b/src/ninja/Style.h
@@ -40,7 +40,7 @@ public:
 	~Style();
 
 	bool printStyle();
-	bool writeStyle(FILE *fileOut);
+	bool writeStyle(VSILFILE *fileOut);
     std::string asOGRStyleString();
 
 private:


### PR DESCRIPTION
On macos, apple clang does not like the signature mismatch between FILE and VSILFILE on a few of the methods.

```
LineStyle.cpp
             :140:17: error: out-of-line definition of 'writeLineStyle' does not match any declaration in 'LineStyle'
     779     bool LineStyle::writeLineStyle(VSILFILE *fileOut)
```

This PR resolves it.