### PR TITLE
merge kEpsilonToRngKEpsilon

### DIFF
--- a/data/ninjafoam/2.2.0/0/epsilon
+++ b/data/ninjafoam/2.2.0/0/epsilon
@@ -25,7 +25,7 @@ $boundaryField$
     minZ
     {
         type            epsilonWallFunction;
-        Cmu             0.09;
+        Cmu             0.085;
         kappa           0.41;
         E               9.8;
         value           uniform 1;

--- a/data/ninjafoam/2.2.0/0/epsilon
+++ b/data/ninjafoam/2.2.0/0/epsilon
@@ -25,7 +25,8 @@ $boundaryField$
     minZ
     {
         type            epsilonWallFunction;
-        Cmu             0.085;
+        Cmu             0.09;  // original, this is for regular k epsilon model
+        //Cmu             0.085;  // for RNG k epsilon model
         kappa           0.41;
         E               9.8;
         value           uniform 1;

--- a/data/ninjafoam/2.2.0/0/nut
+++ b/data/ninjafoam/2.2.0/0/nut
@@ -45,9 +45,10 @@ boundaryField
     {
         type            nutkAtmRoughWallFunction;
         z0              uniform $z0$;
-        Cmu             0.085;
-        kappa           0.41;
-        E               9.8;
+        Cmu             0.09;  // original, this is for regular k epsilon model
+        //Cmu             0.085;  // for RNG k epsilon model
+        //kappa           0.41;   // uncomment this out for RNG k epsilon model, leave commented for k epsilon model
+        //E               9.8;    // uncomment this out for RNG k epsilon model, leave commented for k epsilon model
         value           uniform 0.1;    
     }
     maxZ

--- a/data/ninjafoam/2.2.0/0/nut
+++ b/data/ninjafoam/2.2.0/0/nut
@@ -45,6 +45,9 @@ boundaryField
     {
         type            nutkAtmRoughWallFunction;
         z0              uniform $z0$;
+        Cmu             0.085;
+        kappa           0.41;
+        E               9.8;
         value           uniform 0.1;    
     }
     maxZ

--- a/data/ninjafoam/2.2.0/constant/RASProperties
+++ b/data/ninjafoam/2.2.0/constant/RASProperties
@@ -14,8 +14,8 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-//RASModel            kEpsilon;
-RASModel            RNGkEpsilon;
+RASModel            kEpsilon;
+//RASModel            RNGkEpsilon;
 
 turbulence          on;
 

--- a/data/ninjafoam/2.2.0/constant/RASProperties
+++ b/data/ninjafoam/2.2.0/constant/RASProperties
@@ -14,7 +14,8 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-RASModel            kEpsilon;
+//RASModel            kEpsilon;
+RASModel            RNGkEpsilon;
 
 turbulence          on;
 
@@ -27,5 +28,16 @@ kEpsilonCoeffs
     C2               1.92;
     alphak           1.0;
     alphaEps         0.76923;
+}
+
+RNGkEpsilonCoeffs
+{
+    Cmu         0.085;
+    C1          0.92;
+    C2          1.68;
+    sigmak      0.7179;
+    sigmaEps    0.7179;
+    eta0        4.38;
+    beta        0.012;
 }
 // ************************************************************************* //

--- a/data/ninjafoam/8/0/epsilon
+++ b/data/ninjafoam/8/0/epsilon
@@ -25,7 +25,7 @@ $boundaryField$
     minZ
     {
         type            epsilonWallFunction;
-        Cmu             0.09;
+        Cmu             0.085;
         kappa           0.41;
         E               9.8;
         value           uniform 1;

--- a/data/ninjafoam/8/0/nut
+++ b/data/ninjafoam/8/0/nut
@@ -45,6 +45,9 @@ boundaryField
     {
         type            nutkAtmRoughWallFunction;
         z0              uniform $z0$;
+        Cmu             0.085;
+        kappa           0.41;
+        E               9.8;
         value           uniform 0.1;    
     }
     maxZ

--- a/data/ninjafoam/8/constant/momentumTransport
+++ b/data/ninjafoam/8/constant/momentumTransport
@@ -34,7 +34,7 @@ RAS
 	    alphak           1.0;
 	    alphaEps         0.76923;
 	}
-	
+
 	RNGkEpsilonCoeffs
     {
          Cmu         0.085;

--- a/data/ninjafoam/8/constant/momentumTransport
+++ b/data/ninjafoam/8/constant/momentumTransport
@@ -19,7 +19,8 @@ simulationType RAS;
 
 RAS
 {
-    model           kEpsilon;
+    //model           kEpsilon;
+    model           RNGkEpsilon;
 
     turbulence      on;
 
@@ -33,6 +34,17 @@ RAS
 	    alphak           1.0;
 	    alphaEps         0.76923;
 	}
+	
+	RNGkEpsilonCoeffs
+    {
+         Cmu         0.085;
+         C1          0.92;
+         C2          1.68;
+         sigmak      0.7179;
+         sigmaEps    0.7179;
+         eta0        4.38;
+         beta        0.012;
+    }
 
 }
 

--- a/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -198,8 +198,8 @@ void logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs()
     //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);  // seemed to work
     //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));  // seemed to work
     ////scalar kappa = rasModel.kappa().value();  // Foam::incompressible::RASModel’ has no member named ‘kappa’
-    //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
-    scalar Cmu = 0.085;  // for RNG k epsilon models
+    scalar Cmu = 0.09;  // original, this is for regular k epsilon models
+    //scalar Cmu = 0.085;  // for RNG k epsilon models
 
     scalar ustar = UfreeStream_*0.41/log((inputWindHeight_Veg_)/z0_);
 

--- a/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -192,12 +192,12 @@ void logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs()
     // Caluculate Input Wind Height
     scalarField Kp(patch().Cf().size(), scalar(0));
 
-    //const RASModel& rasModel = db().lookupObject<RASModel>("RASProperties");
+    ////const RASModel& rasModel = db().lookupObject<RASModel>("RASProperties");  // RASModel does not name a type
     //const incompressible::RASModel& rasModel = db().lookupObject<incompressible::RASModel>("RASProperties");
 
-    //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);
-    //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));
-    //scalar kappa = rasModel.kappa().value();
+    //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);  // seemed to work
+    //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));  // seemed to work
+    ////scalar kappa = rasModel.kappa().value();  // Foam::incompressible::RASModel’ has no member named ‘kappa’
     //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
     scalar Cmu = 0.085;  // for RNG k epsilon models
 

--- a/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/2.2.0/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -198,7 +198,8 @@ void logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs()
     //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);
     //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));
     //scalar kappa = rasModel.kappa().value();
-    scalar Cmu = 0.09;
+    //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
+    scalar Cmu = 0.085;  // for RNG k epsilon models
 
     scalar ustar = UfreeStream_*0.41/log((inputWindHeight_Veg_)/z0_);
 

--- a/src/ninjafoam/8/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/8/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -287,12 +287,12 @@ void Foam::logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs
     // Caluculate Input Wind Height
     scalarField Kp(patch().Cf().size(), scalar(0));
 
-    //const RASModel& rasModel = db().lookupObject<RASModel>("RASProperties");
-    //const incompressible::RASModel& rasModel = db().lookupObject<incompressible::RASModel>("RASProperties");
+    //const momentumTransportModel& turbModel = db().lookupObject<momentumTransportModel>( IOobject::groupName(momentumTransportModel::typeName,internalField().group()) );  // seemed to work
+    //const momentumTransportModel& turbModel = db().lookupObject<momentumTransportModel>("momentumTransport");  // seemed to work
 
-    //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);
-    //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));
-    //scalar kappa = rasModel.kappa().value();
+    //const scalar Cmu = turbModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);  // seemed to work
+    //scalar Cmu = readScalar(turbModel.coeffDict().lookup("Cmu"));  // seemed to work
+    ////scalar kappa = turbModel.kappa().value();  // Foam::incompressible::RASModel’ has no member named ‘kappa’
     //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
     scalar Cmu = 0.085;  // for RNG k epsilon models
 

--- a/src/ninjafoam/8/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/8/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -293,7 +293,8 @@ void Foam::logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs
     //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);
     //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));
     //scalar kappa = rasModel.kappa().value();
-    scalar Cmu = 0.09;
+    //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
+    scalar Cmu = 0.085;  // for RNG k epsilon models
 
     scalar ustar = UfreeStream_*0.41/log((inputWindHeight_Veg_)/z0_);
 


### PR DESCRIPTION

merging this branch will leave WindNinja running the various OpenFOAM versions doing the following:
- OpenFOAM 2.2.0 -- standard kEpsilon  (for windows build)
- OpenFOAM 8       -- RNG-kEpsilon
- OpenFOAM 9       -- standard kEpsilon  (will still need further commits to upgrade to RNG-kEpsilon)

Note that the wiki build instructions, for building WindNinja on Ubuntu 20.04, Ubuntu 22.04, and Windows, should still be good as is. But, for a user with pre-existing OpenFOAM BCs, they will need to rebuild the OpenFOAM BCs with a fresh copy of the files from the /windninja/src/ninjafoam/8/ folder, or their WindNinja will run RNG-kEpsilon files with standard kEpsilon BC functions.