### PR TITLE
GUI redesign add ninjaCom progress bar methods, for issue #654

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -772,7 +772,7 @@ void MainWindow::solveButtonClicked()
     }
     writeToConsole(QString::number( numNinjas ) + " runs initialized. Starting solver...");
 
-    int maxProgress = numNinjas*100;
+    maxProgress = numNinjas*100;
     progressDialog = new QProgressDialog("Solving...", "Cancel", 0, maxProgress, ui->centralwidget);
     progressDialog->setWindowModality(Qt::WindowModal);
     progressDialog->setMinimumDuration(0);
@@ -801,140 +801,9 @@ void MainWindow::solveButtonClicked()
 
     writeToConsole( "Initializing runs..." );
 
+    connect(futureWatcher, &QFutureWatcher<int>::finished, this, &MainWindow::finishedSolve);
 
-    connect(futureWatcher, &QFutureWatcher<void>::finished, [=]() {
-        try {
-
-            int result = futureWatcher->future().result();  // gets return of the QtConcurrent::run() function, unless an error was thrown in which case it throws. But the thrown error comes out truncated, it loses the details of the error message
-
-            if( result == 1 ) // simulation properly finished
-            {
-                progressDialog->setValue(maxProgress);
-                progressDialog->setLabelText("Simulations finished");
-                progressDialog->setCancelButtonText("Close");
-
-                qDebug() << "Finished with simulations";
-                writeToConsole("Finished with simulations", Qt::darkGreen);
-            }
-            ////else if( futureWatcher->isCanceled() ) // this doesn't get triggered as reliably as the QProgressDialog cancel button
-            //else if( result == NINJA_E_CANCELLED ) // this is probably the proper way to do this, but checking progressDialog->wasCanceled() seems way safer
-            else if( progressDialog->wasCanceled() ) // simulation was cancelled
-            {
-                progressDialog->setValue(maxProgress);
-                progressDialog->setLabelText("Simulation cancelled");
-                progressDialog->setCancelButtonText("Close");
-                //progressDialog->close();
-
-                qDebug() << "Simulation cancelled by user";
-                //writeToConsole( "Simulation cancelled by user", Qt::orange);  // orange isn't a predefined QColor
-                //writeToConsole( "Simulation cancelled by user", Qt::QColor::fromRgb(255, 165, 0) );  // orange
-                writeToConsole( "Simulation cancelled by user", Qt::yellow);
-            }
-            else // simulation ended in some known error
-            {
-                progressDialog->setValue(maxProgress);
-                progressDialog->setLabelText("Simulation ended in error\nerror: "+QString::number(result));
-                progressDialog->setCancelButtonText("Close");
-
-                qWarning() << "Solver error:" << result;
-                writeToConsole("Solver error: "+QString::number(result), Qt::red);
-            }
-
-        } catch (const std::exception &e) {
-
-            // message got truncated, use the QtConcurrent::run() messaging
-            // ooh, with the thread safe method, things are now updating appropriately
-            //progressDialog->setValue(maxProgress);
-            //progressDialog->setLabelText("Simulation ended in error\n"+QString(e.what()));
-            //progressDialog->setCancelButtonText("Close");
-
-            //qWarning() << "Solver error:" << e.what();
-            //writeToConsole("Solver error: "+QString(e.what()), Qt::red);
-
-        } catch (...) {
-
-            // message got truncated, use the QtConcurrent::run() messaging
-            //progressDialog->setValue(maxProgress);
-            //progressDialog->setLabelText("Simulation ended with unknown error");
-            //progressDialog->setCancelButtonText("Close");
-
-            //qWarning() << "unknown solver error";
-            //writeToConsole("unknown solver error", Qt::red);
-        }
-
-        disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
-
-        int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-        if(err != NINJA_SUCCESS)
-        {
-            printf("NinjaDestroyRuns: err = %d\n", err);
-        }
-
-        // clear the progress values for the next set of runs
-        runProgress.clear();
-
-        futureWatcher->deleteLater();
-    });
-
-    QFuture<int> future = QtConcurrent::run([=]() {
-        try {
-
-            //// calling prepareArmy here is causing all kinds of troubles. Local variables aren't properly being passed on,
-            //// or aren't properly copied ([=] type thing), or aren't properly in scope. The other values are .h variables,
-            //// so they would at least be in the proper scope. But the out of scope variables leads to all kinds
-            //// of "QObject::connect: Cannot connect" and "err = 2" type messages. It is still somehow continuing to run though.
-            ////
-            //// seems the only way to put prepareArmy into a QFutureWatcher function, if it would even work,
-            //// would be to have two separate QFutureWatcher functions
-            ////prepareArmy(ninjaArmy, ui->numberOfProcessorsSpinBox->value(), initializationMethod);
-
-            return NinjaStartRuns(ninjaArmy, ui->numberOfProcessorsSpinBox->value(), papszOptions);
-
-        } catch (cancelledByUser& e) {  // I forgot that the cancelSolve() works by doing a throw, I'm surprised that this throw is propagating out of the solver though
-
-            qWarning() << "Solver error:" << e.what();
-
-            // no message with this error, and it is a known error,
-            // so probably better to update the message in the finished() function, than in QtConcurrent::run()
-            //QMetaObject::invokeMethod(this, [this, maxProgress]() {
-            //    progressDialog->setLabelText("Simulation cancelled by user");
-            //    progressDialog->setCancelButtonText("Close");
-            //    progressDialog->setValue(maxProgress);
-            //    writeToConsole( "Simulation cancelled by user", Qt::yellow);
-            //}, Qt::QueuedConnection);
-
-            ////throw; // will propagate to the future. We purposefully want to skip passing it on for this case, use the QFutureWatcher->future()->result() value instead. However, the return/result value was 0, not the NINJA_E_CANCELLED value of 7. Hrm.
-            return NINJA_E_CANCELLED;  // turns out NinjaStartRuns() simply didn't return a value because cancelSolve() runs by triggering a throw before a return value can be given. So just have to return the appropriate value here.
-
-        } catch (const std::exception &e) { // Store error message somewhere (thread-safe)
-
-            qWarning() << "Solver error:" << e.what();
-
-            QString errorMsg = QString::fromStdString(e.what()); // copy out of 'e' before creating the invokeMethod lambda function
-            QMetaObject::invokeMethod(this, [this, maxProgress, errorMsg]() {
-                progressDialog->setLabelText("Simulation ended in error\n"+errorMsg);
-                progressDialog->setCancelButtonText("Close");
-                progressDialog->setValue(maxProgress);
-                writeToConsole("Solver error: "+errorMsg, Qt::red);
-            }, Qt::QueuedConnection);
-
-            throw; // will propagate to the future
-
-        } catch (...) {
-
-            qWarning() << "unknown solver error";
-
-            QMetaObject::invokeMethod(this, [this, maxProgress]() {
-                progressDialog->setLabelText("Simulation ended with unknown error");
-                progressDialog->setCancelButtonText("Close");
-                progressDialog->setValue(maxProgress);
-                writeToConsole("unknown solver error", Qt::red);
-            }, Qt::QueuedConnection);
-
-            throw; // will propagate to the future
-
-        }
-    });
+    QFuture<int> future = QtConcurrent::run(&MainWindow::startSolve, this, ui->numberOfProcessorsSpinBox->value());
     futureWatcher->setFuture(future);
 
     // vector<string> outputFiles;
@@ -1387,5 +1256,147 @@ OutputMeshResolution MainWindow::getMeshResolution(
     return result;
 }
 
+int MainWindow::startSolve(int numProcessors)
+{
+    try {
+
+        char **papszOptions = nullptr; // found that I could pass this in as an argument after all, but makes more sense to just define it here
+        
+        //// calling prepareArmy here is causing all kinds of troubles. Local variables aren't properly being passed on,
+        //// or aren't properly copied ([=] type thing), or aren't properly in scope. The other values are .h variables,
+        //// so they would at least be in the proper scope. But the out of scope variables leads to all kinds
+        //// of "QObject::connect: Cannot connect" and "err = 2" type messages. It is still somehow continuing to run though.
+        ////
+        //// seems the only way to put prepareArmy into a QFutureWatcher function, if it would even work,
+        //// would be to have two separate QFutureWatcher functions, needs to be separated out from NinjaStartRuns()
+        ////prepareArmy(ninjaArmy, ui->numberOfProcessorsSpinBox->value(), initializationMethod);
+
+        return NinjaStartRuns(ninjaArmy, ui->numberOfProcessorsSpinBox->value(), papszOptions); // huh? I guess because "this" was used, it still has access to numNinjas this way
+        //return NinjaStartRuns(ninjaArmy, numProcessors, papszOptions);
+
+    } catch (cancelledByUser& e) {  // I forgot that the cancelSolve() works by doing a throw, I'm surprised that this throw is propagating out of the solver though
+
+        qWarning() << "Solver error:" << e.what();
+
+        // no message with this error, and it is a known error,
+        // so probably better to update the message in the finished() function, than in QtConcurrent::run()
+        //QMetaObject::invokeMethod(this, [this]() {
+        //    progressDialog->setLabelText("Simulation cancelled by user");
+        //    progressDialog->setCancelButtonText("Close");
+        //    progressDialog->setValue(this->maxProgress);
+        //    writeToConsole( "Simulation cancelled by user", Qt::yellow);
+        //}, Qt::QueuedConnection);
+
+        ////throw; // will propagate to the future. We purposefully want to skip passing it on for this case, use the QFutureWatcher->future()->result() value instead. However, the return/result value was 0, not the NINJA_E_CANCELLED value of 7. Hrm.
+        return NINJA_E_CANCELLED;  // turns out NinjaStartRuns() simply didn't return a value because cancelSolve() runs by triggering a throw before a return value can be given. So just have to return the appropriate value here.
+
+    } catch (const std::exception &e) { // Store error message somewhere (thread-safe)
+
+        qWarning() << "Solver error:" << e.what();
+
+        QString errorMsg = QString::fromStdString(e.what()); // copy out of 'e' before creating the thread safe invokeMethod lambda function
+        QMetaObject::invokeMethod(this, [this, errorMsg]() {
+            progressDialog->setLabelText("Simulation ended in error\n"+errorMsg);
+            progressDialog->setCancelButtonText("Close");
+            progressDialog->setValue(this->maxProgress);
+            writeToConsole("Solver error: "+errorMsg, Qt::red);
+        }, Qt::QueuedConnection);
+
+        throw; // will propagate to the future
+
+    } catch (...) {
+
+        qWarning() << "unknown solver error";
+
+        QMetaObject::invokeMethod(this, [this]() {
+            progressDialog->setLabelText("Simulation ended with unknown error");
+            progressDialog->setCancelButtonText("Close");
+            progressDialog->setValue(this->maxProgress);
+            writeToConsole("unknown solver error", Qt::red);
+        }, Qt::QueuedConnection);
+
+        throw; // will propagate to the future
+
+    }
+}
+
+void MainWindow::finishedSolve()
+{
+    try {
+
+        // get the return value of the QtConcurrent::run() function
+        // Note that if an error was thrown during QtConcurrent::run(), this throws instead
+        // but the thrown error comes out truncated, it loses the details of the original error message
+        int result = futureWatcher->future().result();
+
+        if( result == 1 ) // simulation properly finished
+        {
+            progressDialog->setValue(maxProgress);
+            progressDialog->setLabelText("Simulations finished");
+            progressDialog->setCancelButtonText("Close");
+
+            qDebug() << "Finished with simulations";
+            writeToConsole("Finished with simulations", Qt::darkGreen);
+        }
+        ////else if( futureWatcher->isCanceled() ) // this doesn't get triggered as reliably as the QProgressDialog cancel button
+        //else if( result == NINJA_E_CANCELLED ) // this is probably the proper way to do this, but checking progressDialog->wasCanceled() seems way safer
+        else if( progressDialog->wasCanceled() ) // simulation was cancelled
+        {
+            progressDialog->setValue(maxProgress);
+            progressDialog->setLabelText("Simulation cancelled");
+            progressDialog->setCancelButtonText("Close");
+            //progressDialog->close();
+
+            qDebug() << "Simulation cancelled by user";
+            //writeToConsole( "Simulation cancelled by user", Qt::orange);  // orange isn't a predefined QColor
+            //writeToConsole( "Simulation cancelled by user", Qt::QColor::fromRgb(255, 165, 0) );  // orange
+            writeToConsole( "Simulation cancelled by user", Qt::yellow);
+        }
+        else // simulation ended in some known error
+        {
+            progressDialog->setValue(maxProgress);
+            progressDialog->setLabelText("Simulation ended in error\nerror: "+QString::number(result));
+            progressDialog->setCancelButtonText("Close");
+
+            qWarning() << "Solver error:" << result;
+            writeToConsole("Solver error: "+QString::number(result), Qt::red);
+        }
+
+    } catch (const std::exception &e) {
+
+        // message got truncated, use the QtConcurrent::run() messaging
+        // ooh, with the thread safe method, things are now updating appropriately
+        //progressDialog->setValue(maxProgress);
+        //progressDialog->setLabelText("Simulation ended in error\n"+QString(e.what()));
+        //progressDialog->setCancelButtonText("Close");
+
+        //qWarning() << "Solver error:" << e.what();
+        //writeToConsole("Solver error: "+QString(e.what()), Qt::red);
+
+    } catch (...) {
+
+        // message got truncated, use the QtConcurrent::run() messaging
+        //progressDialog->setValue(maxProgress);
+        //progressDialog->setLabelText("Simulation ended with unknown error");
+        //progressDialog->setCancelButtonText("Close");
+
+        //qWarning() << "unknown solver error";
+        //writeToConsole("unknown solver error", Qt::red);
+    }
+
+    disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+
+    char **papszOptions = nullptr;
+    int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaDestroyRuns: err = %d\n", err);
+    }
+
+    // clear the progress values for the next set of runs
+    runProgress.clear();
+
+    futureWatcher->deleteLater();
+}
 
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -809,19 +809,9 @@ void MainWindow::solveButtonClicked()
 
             if( result == 1 ) // simulation properly finished
             {
-                disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
                 progressDialog->setValue(maxProgress);
                 progressDialog->setLabelText("Simulations finished");
                 progressDialog->setCancelButtonText("Close");
-
-                int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-                if(err != NINJA_SUCCESS)
-                {
-                    printf("NinjaDestroyRuns: err = %d\n", err);
-                }
-
-                // clear the progress values for the next set of runs
-                runProgress.clear();
 
                 qDebug() << "Finished with simulations";
                 writeToConsole("Finished with simulations", Qt::darkGreen);
@@ -830,20 +820,10 @@ void MainWindow::solveButtonClicked()
             //else if( result == NINJA_E_CANCELLED ) // this is probably the proper way to do this, but checking progressDialog->wasCanceled() seems way safer
             else if( progressDialog->wasCanceled() ) // simulation was cancelled
             {
-                int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-                if(err != NINJA_SUCCESS)
-                {
-                    printf("NinjaDestroyRuns: err = %d\n", err);
-                }
-
-                disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
                 progressDialog->setValue(maxProgress);
                 progressDialog->setLabelText("Simulation cancelled");
                 progressDialog->setCancelButtonText("Close");
                 //progressDialog->close();
-
-                // clear the progress values for the next set of runs
-                runProgress.clear();
 
                 qDebug() << "Simulation cancelled by user";
                 //writeToConsole( "Simulation cancelled by user", Qt::orange);  // orange isn't a predefined QColor
@@ -852,19 +832,9 @@ void MainWindow::solveButtonClicked()
             }
             else // simulation ended in some known error
             {
-                disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
                 progressDialog->setValue(maxProgress);
                 progressDialog->setLabelText("Simulation ended in error\nerror: "+QString::number(result));
                 progressDialog->setCancelButtonText("Close");
-
-                int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-                if(err != NINJA_SUCCESS)
-                {
-                    printf("NinjaDestroyRuns: err = %d\n", err);
-                }
-
-                // clear the progress values for the next set of runs
-                runProgress.clear();
 
                 qWarning() << "Solver error:" << result;
                 writeToConsole("Solver error: "+QString::number(result), Qt::red);
@@ -872,49 +842,36 @@ void MainWindow::solveButtonClicked()
 
         } catch (const std::exception &e) {
 
-            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
             // message got truncated, use the QtConcurrent::run() messaging
             // ooh, with the thread safe method, things are now updating appropriately
             //progressDialog->setValue(maxProgress);
             //progressDialog->setLabelText("Simulation ended in error\n"+QString(e.what()));
             //progressDialog->setCancelButtonText("Close");
 
-            int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-            if(err != NINJA_SUCCESS)
-            {
-                printf("NinjaDestroyRuns: err = %d\n", err);
-            }
-
-            // clear the progress values for the next set of runs
-            runProgress.clear();
-
-            // message got truncated, use the QtConcurrent::run() messaging
-            // ooh, with the thread safe method, things are now updating appropriately
             //qWarning() << "Solver error:" << e.what();
             //writeToConsole("Solver error: "+QString(e.what()), Qt::red);
 
         } catch (...) {
 
-            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
             // message got truncated, use the QtConcurrent::run() messaging
             //progressDialog->setValue(maxProgress);
             //progressDialog->setLabelText("Simulation ended with unknown error");
             //progressDialog->setCancelButtonText("Close");
 
-            int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
-            if(err != NINJA_SUCCESS)
-            {
-                printf("NinjaDestroyRuns: err = %d\n", err);
-            }
-
-            // clear the progress values for the next set of runs
-            runProgress.clear();
-
-            // message got truncated, use the QtConcurrent::run() messaging
             //qWarning() << "unknown solver error";
             //writeToConsole("unknown solver error", Qt::red);
-
         }
+
+        disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+
+        int err = NinjaDestroyArmy(ninjaArmy, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+            printf("NinjaDestroyRuns: err = %d\n", err);
+        }
+
+        // clear the progress values for the next set of runs
+        runProgress.clear();
 
         futureWatcher->deleteLater();
     });

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -815,11 +815,11 @@ void MainWindow::solveButtonClicked()
     {
         if( err == NINJA_E_CANCELLED )
         {
-//            progressDialog->cancel();  // sometimes delays it enough to cause it to seem to truly cancel, but it really doesn't, heck this signal was already emitted up to this point anyways
-            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));  // moving this to after the ninjaArmy destructor does its final extra flush-like emit, seems to neither hurt nor help. chatgpt seems to think we shouldn't even be doing disconnect() in the first place.  // have to have this uncommented out somewhere in here, or the code seg faults
-            progressDialog->setAutoClose(true);  // leaving this here or not in this spot, or in cancelSolve(), doesn't seem to be having much effect
+////            progressDialog->cancel();  // sometimes delays it enough to cause it to seem to truly cancel, but it really doesn't, heck this signal was already emitted up to this point anyways
+//            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));  // moving this to after the ninjaArmy destructor does its final extra flush-like emit, seems to neither hurt nor help. chatgpt seems to think we shouldn't even be doing disconnect() in the first place.  // have to have this uncommented out somewhere in here, or the code seg faults
+//            progressDialog->setAutoClose(true);  // leaving this here or not in this spot, or in cancelSolve(), doesn't seem to be having much effect
 
-            runProgress.clear();  // trying to move this to after the destructor, when it is no longer needed, doesn't seem to hurt or help. But shouldn't this be after the disconnect, since signals still seem to be getting emitted till at least after the disconnect()? Hrm.
+//            runProgress.clear();  // trying to move this to after the destructor, when it is no longer needed, doesn't seem to hurt or help. But shouldn't this be after the disconnect, since signals still seem to be getting emitted till at least after the disconnect()? Hrm.
 
             // calls delete on the solve class instance inner parts, normally done outside of canceled(),
             // but because doing a return here to try to skip the final message, need to do it now
@@ -829,11 +829,11 @@ void MainWindow::solveButtonClicked()
                 printf("NinjaDestroyRuns: err = %d\n", err);
             }
 
-//            runProgress.clear();
-//
-////            progressDialog->cancel();
-//            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
-//            progressDialog->setAutoClose(true);
+            runProgress.clear();
+
+//            progressDialog->cancel();
+            disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+            progressDialog->setAutoClose(true);
 
             // why is there another message and info from the threads that occurs after this one most if not at least half the time? Somehow the threads are still finishing up, or the ninjaArmy destructor is behaving as a late extra final flush-like emit and overwrites this result with a new one that is actually an old one immediately after. So annoying.
             writeToConsole( "Simulation cancelled by user" );
@@ -848,7 +848,7 @@ void MainWindow::solveButtonClicked()
 
     // moving this to after the ninjaArmy destructor does its final flush-like emit, seems to neither hurt nor help.
     // chatgpt seems to think we shouldn't even be doing disconnect() in the first place, but have to have this uncommented out somewhere in here, or the code seg faults
-    disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+//    disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
 
     // why does this sometimes not become the final message and info? Somehow the threads are still finishing up, or the ninjaArmy destructor is behaving as a late extra final flush-like emit and overwrites this result with a new one that is actually an old one immediately after. So annoying.
     int maxProgress = numNinjas*100;
@@ -856,7 +856,7 @@ void MainWindow::solveButtonClicked()
     progressDialog->setLabelText("Simulations finished");
     progressDialog->setCancelButtonText("Close");  // is this really wise? "close" now runs "cancelSolve" again! So maybe the disconnect SHOULD occur before this step. Hrm.
     // clear the progress values for the next set of runs
-    runProgress.clear();  // is this wise to do before the ninjaArmy destructor, if it has that final extra flush-like emit still using this information?
+//    runProgress.clear();  // is this wise to do before the ninjaArmy destructor, if it has that final extra flush-like emit still using this information?
 
     err = NinjaDestroyArmy(ninjaArmy, papszOptions);
     if(err != NINJA_SUCCESS)
@@ -865,8 +865,8 @@ void MainWindow::solveButtonClicked()
     }
     writeToConsole("Finished with simulations", Qt::darkGreen);
 
-//    disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
-//    runProgress.clear();
+    disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+    runProgress.clear();
 
     // vector<string> outputFiles;
     // QDir outDir(ui->outputDirectoryLineEdit->text());

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1086,10 +1086,10 @@ void MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, &MainWindow::writeToConsole );  // more exact way of doing it
         connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( writeToConsole(QString, QColor) ) );  // other way of doing it
 
-        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, &MainWindow::updateProgress );
+        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::updateProgress) );
         connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgress( QString ) ) );
 
-        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendProgress, this, &MainWindow::updateProgress );
+        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendProgress, this, static_cast<void (MainWindow::*)(int,int)>(&MainWindow::updateProgress) );
         connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgress( int, int ) ) );
 
 //        // old code style method (see this in the old qt4 gui code)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -320,12 +320,12 @@ void MainWindow::writeToConsole(QString message, QColor color)
     lineNumber++;
 }
 
-void MainWindow::updateProgress(const QString message)
+void MainWindow::updateProgressMessage(const QString message)
 {
     progressDialog->setLabelText(message);
 }
 
-void MainWindow::updateProgress(int run, int progress)
+void MainWindow::updateProgressValue(int run, int progress)
 {
     // update the stored progress value for the current run
     if( runProgress[run] > progress )
@@ -1086,21 +1086,21 @@ void MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, &MainWindow::writeToConsole );  // more exact way of doing it
         connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( writeToConsole(QString, QColor) ) );  // other way of doing it
 
-        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::updateProgress) );
-        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgress( QString ) ) );
+        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendMessage, this, &MainWindow::updateProgressMessage );
+        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgressMessage( QString ) ) );
 
-        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendProgress, this, static_cast<void (MainWindow::*)(int,int)>(&MainWindow::updateProgress) );
-        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgress( int, int ) ) );
+        //connect( static_cast<ninjaGUIComHandler*>(NinjaGetCommunication( ninjaArmy, i, papszOptions )), &ninjaGUIComHandler::sendProgress, this, &MainWindow::updateProgressValue );
+        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgressValue( int, int ) ) );
 
 //        // old code style method (see this in the old qt4 gui code)
 //        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( writeToConsole(QString, QColor) ), Qt::AutoConnection );
-//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgress( QString ) ), Qt::AutoConnection );
-//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgress( int, int ) ), Qt::AutoConnection );
+//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgressMessage( QString ) ), Qt::AutoConnection );
+//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgressValue( int, int ) ), Qt::AutoConnection );
 
 //        // new code style method, chatgpt seems to prefer this one, though the AutoConnection seems to have slightly better results, well maybe
 //        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( writeToConsole(QString, QColor) ), Qt::QueuedConnection );
-//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgress( QString ) ), Qt::QueuedConnection );
-//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgress( int, int ) ), Qt::QueuedConnection );
+//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendMessage(QString, QColor) ), this, SLOT( updateProgressMessage( QString ) ), Qt::QueuedConnection );
+//        connect( NinjaGetCommunication( ninjaArmy, i, papszOptions ), SIGNAL( sendProgress( int, int ) ), this, SLOT( updateProgressValue( int, int ) ), Qt::QueuedConnection );
 
         err = NinjaSetNumberCPUs(ninjaArmy, i, ui->numberOfProcessorsSpinBox->value(), papszOptions);
         if(err != NINJA_SUCCESS)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -777,7 +777,7 @@ void MainWindow::solveButtonClicked()
     progressDialog->setWindowModality(Qt::WindowModal);
     progressDialog->setMinimumDuration(0);
     progressDialog->setAutoClose(false);
-//    progressDialog->setAutoReset(false);
+    progressDialog->setAutoReset(false);
 
     progressDialog->setCancelButtonText("Cancel");
     connect( progressDialog, SIGNAL( canceled() ), this, SLOT( cancelSolve() ) );

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -121,6 +121,9 @@ private slots:
     void geospatialPDFFilesMeshResolutionGroupBoxToggled(bool checked);
     void refreshUI();
     void writeToConsole(QString message, QColor color = Qt::white);
+    void updateProgress(int run, int progress);
+    void updateProgress(const QString message);
+    void cancelSolve();
 
 private:
     Ui::MainWindow *ui;
@@ -133,6 +136,12 @@ private:
     DomainAverageInput *domainAverageInput;
     WeatherModelInput *weatherModelInput;
     PointInitializationInput *pointInitializationInput;
+
+    QProgressDialog *progressDialog;
+    int totalProgress;
+    std::vector<int> runProgress;
+    NinjaArmyH *ninjaArmy;
+
     QString currentDEMFilePath;
 
     void connectSignals();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -139,7 +139,7 @@ private:
     PointInitializationInput *pointInitializationInput;
 
     QProgressDialog *progressDialog;
-    QFutureWatcher<void> *futureWatcher;
+    QFutureWatcher<int> *futureWatcher;
     int totalProgress;
     std::vector<int> runProgress;
     NinjaArmyH *ninjaArmy;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -138,11 +138,17 @@ private:
     WeatherModelInput *weatherModelInput;
     PointInitializationInput *pointInitializationInput;
 
+    NinjaArmyH *ninjaArmy;
+
+    std::vector<int> runProgress;
+    int totalProgress;
+    int maxProgress;
+
     QProgressDialog *progressDialog;
     QFutureWatcher<int> *futureWatcher;
-    int totalProgress;
-    std::vector<int> runProgress;
-    NinjaArmyH *ninjaArmy;
+
+    int startSolve(int numProcessors);
+    void finishedSolve();
 
     QString currentDEMFilePath;
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -122,8 +122,8 @@ private slots:
     void geospatialPDFFilesMeshResolutionGroupBoxToggled(bool checked);
     void refreshUI();
     void writeToConsole(QString message, QColor color = Qt::white);
-    void updateProgress(int run, int progress);
-    void updateProgress(const QString message);
+    void updateProgressValue(int run, int progress);
+    void updateProgressMessage(const QString message);
     void cancelSolve();
 
 private:

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -42,6 +42,7 @@
 //#include "ninjaCom.h"
 #include "windninja.h"
 #include <QWebChannel>
+#include <QFuture>
 #include <QFutureWatcher>
 #include <QtConcurrent/QtConcurrentRun>
 #include <QProgressDialog>
@@ -138,6 +139,7 @@ private:
     PointInitializationInput *pointInitializationInput;
 
     QProgressDialog *progressDialog;
+    QFutureWatcher<void> *futureWatcher;
     int totalProgress;
     std::vector<int> runProgress;
     NinjaArmyH *ninjaArmy;

--- a/src/gui/surfaceinput.h
+++ b/src/gui/surfaceinput.h
@@ -41,7 +41,6 @@
 #include <QStandardPaths>
 #include <QFileDialog>
 #include <QDebug>
-#include <QProgressDialog>
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QProgressDialog>

--- a/src/ninja/ninja.cpp
+++ b/src/ninja/ninja.cpp
@@ -261,7 +261,9 @@ bool ninja::simulate_wind()
 	checkCancel();
 
 	input.Com->ninjaCom(ninjaComClass::ninjaNone, "Reading elevation file...");
-	
+
+//throw std::runtime_error("I WANT CHOCOLATE!!! Yum.");
+
 	readInputFile();
 	set_position();
 

--- a/src/ninja/windninja.cpp
+++ b/src/ninja/windninja.cpp
@@ -519,9 +519,16 @@ WINDNINJADLL_EXPORT NinjaErr NinjaStartRuns
         {
             return reinterpret_cast<ninjaArmy*>( army )->startRuns( nprocessors );
         }
+        catch (exception& e)
+        {
+            std::cout << "Exception caught: " << e.what() << endl;
+            throw;
+        }
         catch( ... )
         {
-            return handleException();
+            std::cout << "Exception caught: Cannot determine exception type." << endl;
+//            return handleException();
+            throw;
         }
     }
     else


### PR DESCRIPTION
I finally worked out the QFutureWatcher version of the ninjaCom progress bar methods. There's still a LOT of weird quirkiness going on with all the ninjaCom methods, especially the progress bar ones, that might make editing the methods really tough in the future. But the final result is working, and even without that annoying final extra flush-like signal emit problem that I had when doing ninjaCom progress bar stuff without the QFutureWatcher methods.

Don't forget to uncomment out the throw "I WANT CHOCOLATE!! yum." statement in ninja.cpp, when testing error cases. Also note the changes to the windninja.cpp "NinjaStartRuns" function, to get the error messages passed on through the C-API.