### PR TITLE
merge kEpsilonToRngKEpsilon-foam9

### DIFF
--- a/data/ninjafoam/9/0/epsilon
+++ b/data/ninjafoam/9/0/epsilon
@@ -25,7 +25,7 @@ $boundaryField$
     minZ
     {
         type            epsilonWallFunction;
-        Cmu             0.09;
+        Cmu             0.085;
         kappa           0.41;
         E               9.8;
         value           uniform 1;

--- a/data/ninjafoam/9/0/nut
+++ b/data/ninjafoam/9/0/nut
@@ -45,6 +45,9 @@ boundaryField
     {
         type            nutkAtmRoughWallFunction;
         z0              uniform $z0$;
+        Cmu             0.085;
+        kappa           0.41;
+        E               9.8;
         value           uniform 0.1;    
     }
     maxZ

--- a/data/ninjafoam/9/constant/momentumTransport
+++ b/data/ninjafoam/9/constant/momentumTransport
@@ -19,7 +19,8 @@ simulationType RAS;
 
 RAS
 {
-    model           kEpsilon;
+    //model           kEpsilon;
+    model           RNGkEpsilon;
 
     turbulence      on;
 
@@ -33,6 +34,17 @@ RAS
 	    alphak           1.0;
 	    alphaEps         0.76923;
 	}
+
+    RNGkEpsilonCoeffs
+    {
+         Cmu         0.085;
+         C1          0.92;
+         C2          1.68;
+         sigmak      0.7179;
+         sigmaEps    0.7179;
+         eta0        4.38;
+         beta        0.012;
+    }
 
 }
 

--- a/src/ninjafoam/9/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
+++ b/src/ninjafoam/9/inletBC/logProfileTurbulentKineticEnergyInlet/logProfileTurbulentKineticEnergyInletFvPatchScalarField.C
@@ -293,7 +293,8 @@ void Foam::logProfileTurbulentKineticEnergyInletFvPatchScalarField::updateCoeffs
     //const scalar Cmu = rasModel.coeffDict().lookupOrDefault<scalar>("Cmu", 0.09);
     //scalar Cmu = readScalar(rasModel.coeffDict().lookup("Cmu"));
     //scalar kappa = rasModel.kappa().value();
-    scalar Cmu = 0.09;
+    //scalar Cmu = 0.09;  // original, this is for regular k epsilon models
+    scalar Cmu = 0.085;  // for RNG k epsilon models
 
     scalar ustar = UfreeStream_*0.41/log((inputWindHeight_Veg_)/z0_);
 


### PR DESCRIPTION
Turned out to not be that complicated, just needed to apply the foam 8 changes to foam 9, and it ran fine.

There's still cleanup that I would love to do, as described in past OpenFOAM issues related to this issue #710, but we should be good to go ahead with this for now. Do those other things at some later OpenFOAM cleanup stage or something.

People will need to follow the instructions from the wiki to rebuild their foam 9 BCs [here](https://github.com/firelab/windninja/wiki/Building-WindNinja-on-Linux-22.04).