### PR TITLE
Separate Domain Average API functions

### DIFF
--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -485,11 +485,11 @@ void MainWindow::solveButtonClicked()
         {
             if(ui->diurnalCheckBox->isChecked() || ui->stabilityCheckBox->isChecked())
             {
-                ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);
+                ninjaErr = NinjaMakeDomainAverageArmyThermalParameterization(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);
             }
             else
             {
-                ninjaErr = NinjaMakeDomainAverageArmy2(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), papszOptions);
+                ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), papszOptions);
             }
             //ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, -1, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeDomainAverageArmy() single messaging error, instead of the double messaging makeDomainAverageArmy() error.
             //ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, 0, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeDomainAverageArmy() single messaging error, instead of the double messaging makeDomainAverageArmy() error.

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -1258,7 +1258,7 @@ void ninjaArmy::setAtmFlags()
  *  C-API makeArmy function calls
  *-----------------------------------------------------------------------------*/
 
-int ninjaArmy::NinjaMakeDomainAverageArmy( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char * airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** papszOptions )
+int ninjaArmy::NinjaMakeDomainAverageArmyThermalParameterization( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char * airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** papszOptions )
 {
     try
     {
@@ -1352,7 +1352,7 @@ int ninjaArmy::NinjaMakeDomainAverageArmy( int numNinjas, bool momentumFlag, con
 }
 
 
-int ninjaArmy::NinjaMakeDomainAverageArmy2( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** papszOptions )
+int ninjaArmy::NinjaMakeDomainAverageArmy( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** papszOptions )
 {
     try
     {

--- a/src/ninja/ninjaArmy.h
+++ b/src/ninja/ninjaArmy.h
@@ -170,8 +170,8 @@ public:
     /*-----------------------------------------------------------------------------
      *  C-API makeArmy function calls
      *-----------------------------------------------------------------------------*/
-    int NinjaMakeDomainAverageArmy( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char * airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** papszOptions=NULL );
-    int NinjaMakeDomainAverageArmy2( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** papszOptions=NULL );
+    int NinjaMakeDomainAverageArmyThermalParameterization( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char * airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** papszOptions=NULL );
+    int NinjaMakeDomainAverageArmy( int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** papszOptions=NULL );
     int NinjaMakePointArmy( int * yearList, int * monthList, int * dayList, int * hourList, int * minuteList, int timeListSize, char * timeZone, const char ** stationFileNames, int numStationFiles, char * elevationFile, bool matchPointsFlag, bool momentumFlag, char ** papzOptions=NULL );
     int NinjaMakeWeatherModelArmy( const char * forecastFilename, const char * timeZone, const char** inputTimeList, int size, bool momentumFlag, char ** papzOptions=NULL );
 

--- a/src/ninja/windninja.cpp
+++ b/src/ninja/windninja.cpp
@@ -82,7 +82,7 @@ WINDNINJADLL_EXPORT NinjaArmyH* NinjaInitializeArmy()
 }
 
 /**
- * \brief Generate a new suite of domain average windninja runs.
+ * \brief Generate a new suite of domain average windninja runs using thermal parameterization.
  *
  * Use this method to create a finite, known number of runs for windninja.
  * There are other creation methods that automatically allocate the correct
@@ -114,7 +114,7 @@ WINDNINJADLL_EXPORT NinjaArmyH* NinjaInitializeArmy()
  *
  * \return NINJA_SUCCESS on success, non-zero otherwise.
  */
-WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
+WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmyThermalParameterization
     ( NinjaArmyH * army, int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList,
       const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char * airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** options )
 {
@@ -123,7 +123,7 @@ WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
         return NINJA_E_NULL_PTR;
     }
 
-    return reinterpret_cast<ninjaArmy*>( army )->NinjaMakeDomainAverageArmy(numNinjas, momentumFlag, speedList, speedUnits, directionList, yearList, monthList, dayList, hourList, minuteList, timeZone, airTempList, airTempUnits, cloudCoverList, cloudCoverUnits, options);
+    return reinterpret_cast<ninjaArmy*>( army )->NinjaMakeDomainAverageArmyThermalParameterization(numNinjas, momentumFlag, speedList, speedUnits, directionList, yearList, monthList, dayList, hourList, minuteList, timeZone, airTempList, airTempUnits, cloudCoverList, cloudCoverUnits, options);
 }
 
 /**
@@ -145,21 +145,10 @@ WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
  * \param speedList List of wind speeds to simulate.
  * \param speedUnits String indicating wind speed units ("mph", "mps", "kph", "knots").
  * \param directionList List of wind directions to simulate in degrees.
- * \param yearList List of years to simulate (only needed if diurnal or stability is going to be used), can be NULL.
- * \param monthList List of months to simulate (only needed if diurnal or stability is going to be used), can be NULL.
- * \param dayList List of days to simulate (only needed if diurnal or stability is going to be used), can be NULL.
- * \param hourList List of hours to simulate (only needed if diurnal or stability is going to be used), can be NULL.
- * \param minuteList List of minutes to simulate (only needed if diurnal or stability is going to be used), can be NULL.
- * \param timeZone A string representing a valid timezone.
- * \param airTempList List of air temperatures (only needed if diurnal or stability is going to be used), can be NULL.
- * \param airTempUnits String indicating air temperature units ("F", "C", or "K"), can be NULL.
- * \param cloudCoverList List of cloud covers (only needed if diurnal or stability is going to be used), can be NULL.
- * \param cloudCoverUnits String indicating cloud cover units ("fraction" or "percent"), can be NULL.
- * \param options Key, value option pairs from the options listed above, can be NULL.
  *
  * \return NINJA_SUCCESS on success, non-zero otherwise.
  */
-WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy2
+WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
     ( NinjaArmyH * army, int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** options )
 {
     if(!army)
@@ -167,7 +156,7 @@ WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy2
         return NINJA_E_NULL_PTR;
     }
 
-    return reinterpret_cast<ninjaArmy*>( army )->NinjaMakeDomainAverageArmy2(numNinjas, momentumFlag, speedList, speedUnits, directionList, options);
+    return reinterpret_cast<ninjaArmy*>( army )->NinjaMakeDomainAverageArmy(numNinjas, momentumFlag, speedList, speedUnits, directionList, options);
 }
 
 /**

--- a/src/ninja/windninja.h
+++ b/src/ninja/windninja.h
@@ -73,11 +73,11 @@ typedef int  NinjaErr;
      *-----------------------------------------------------------------------------*/
     WINDNINJADLL_EXPORT NinjaArmyH* NinjaInitializeArmy();
 
-    WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
+    WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmyThermalParameterization
         ( NinjaArmyH * ninjaArmy, int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList,
           const int * yearList, const int * monthList, const int * dayList, const int * hourList, const int * minuteList, const char * timeZone, const double * airTempList, const char* airTempUnits, const double * cloudCoverList, const char * cloudCoverUnits, char ** options);
 
-    WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy2
+    WINDNINJADLL_EXPORT NinjaErr NinjaMakeDomainAverageArmy
         ( NinjaArmyH * ninjaArmy, int numNinjas, bool momentumFlag, const double * speedList, const char * speedUnits, const double * directionList, char ** options);
 
     //TODO: add helper function to generate arrays of years, months, days, hours, and minutes from a station file


### PR DESCRIPTION
This separates the `makeDomainAverageArmy` function into two functions: one with thermal parameterization and one without. 

Fixes #736