### PR TITLE
An attempt to extend ninjaCom methods, became cleanup and unification of messaging methods

### DIFF
--- a/src/fetch_dem/fetch_dem.cpp
+++ b/src/fetch_dem/fetch_dem.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     int bHasBbox = FALSE;
     int bHasPoint = FALSE;
 
-    int nSrtmError;
+    int nDemError;
     lengthUnits::eLengthUnits units;
     GDALResampleAlg rAlg;
     GDALDataset *poDS;
@@ -464,8 +464,7 @@ int main(int argc, char *argv[])
             }
             #endif //HAVE_GMTED
         }
-        nSrtmError = fetch->FetchBoundingBox(adfBbox, dfCellSize, pszDstFile,
-                                             papszOptions);
+        nDemError = fetch->FetchBoundingBox(adfBbox, dfCellSize, pszDstFile, papszOptions);
     }
     else
     {
@@ -479,24 +478,48 @@ int main(int argc, char *argv[])
             }
             #endif //HAVE_GMTED
         }
-        nSrtmError = fetch->FetchPoint(adfPoint, adfBuff, units, dfCellSize,
-                                       pszDstFile, papszOptions);
+        nDemError = fetch->FetchPoint(adfPoint, adfBuff, units, dfCellSize, pszDstFile, papszOptions);
     }
 
-    if(nSrtmError < 0)
+    if(nDemError < 0)
     {
-        if(nSrtmError == SURF_FETCH_E_IO_ERR)
-            fprintf(stderr, "Failed to open a dataset\n");
-        else if(nSrtmError == SURF_FETCH_E_BOUNDS_ERR)
-            fprintf(stderr, "Request fell out of bounds of srtm data\n");
-        else if(nSrtmError == SURF_FETCH_E_WARPER_ERR)
-            fprintf(stderr, "Failed to warp data\n");
+        fprintf(stderr, "Failed to download elevation data.\n");
+        if(nDemError == SURF_FETCH_E_IO_ERR)
+        {
+            fprintf(stderr, "SURF_FETCH_E_IO_ERR, Failure opening a dataset.\n");
+        }
+        else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
+        {
+            fprintf(stderr, "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.\n");
+        }
+        else if(nDemError == SURF_FETCH_E_WARPER_ERR)
+        {
+            fprintf(stderr, "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.\n");
+        }
+        else if(nDemError == SURF_FETCH_E_BAD_INPUT)
+        {
+            fprintf(stderr, "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.\n");
+        }
+        else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
+        {
+            fprintf(stderr, "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.\n");
+        }
+        //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
+        //{
+        //    fprintf(stderr, "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.\n");
+        //}
+        else if(nDemError == SURF_FETCH_E_TIMEOUT)
+        {
+            fprintf(stderr, "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.\n");
+        }
         else
-            fprintf(stderr, "Unknown error occurred\n");
-        return nSrtmError;
+        {
+            fprintf(stderr, "Unknown error occurred during fetch.\n");
+        }
+        return nDemError;
     }
 
-    if(nSrtmError > 0 && bFillNoData)
+    if(nDemError > 0 && bFillNoData)
     {
         poDS = (GDALDataset*)GDALOpen(pszDstFile, GA_Update);
         if(poDS == NULL)
@@ -504,9 +527,9 @@ int main(int argc, char *argv[])
             fprintf(stderr, "Failed to open new dataset\n");
             return 1;
         }
-        nSrtmError = GDALFillBandNoData(poDS, 1, 100);
+        nDemError = GDALFillBandNoData(poDS, 1, 100);
         GDALClose((GDALDatasetH)poDS);
-        if(nSrtmError > 0)
+        if(nDemError > 0)
         {
             fprintf(stderr, "Failed to fill no data\n");
             return 1;

--- a/src/fetch_dem/fetch_dem.cpp
+++ b/src/fetch_dem/fetch_dem.cpp
@@ -486,31 +486,31 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to download elevation data.\n");
         if(nDemError == SURF_FETCH_E_IO_ERR)
         {
-            fprintf(stderr, "SURF_FETCH_E_IO_ERR, Failure opening a dataset.\n");
+            fprintf(stderr, "Failure opening a dataset.\n");
         }
         else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
         {
-            fprintf(stderr, "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.\n");
+            fprintf(stderr, "Fetch was outside the bounds of the dataset.\n");
         }
         else if(nDemError == SURF_FETCH_E_WARPER_ERR)
         {
-            fprintf(stderr, "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.\n");
+            fprintf(stderr, "Failure during warp, failed to warp data.\n");
         }
         else if(nDemError == SURF_FETCH_E_BAD_INPUT)
         {
-            fprintf(stderr, "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.\n");
+            fprintf(stderr, "Bad input to fetching functions.\n");
         }
         else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
         {
-            fprintf(stderr, "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.\n");
+            fprintf(stderr, "Hit a size limit during fetch.\n");
         }
         //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
         //{
-        //    fprintf(stderr, "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.\n");
+        //    fprintf(stderr, "Found NO_DATA in downloaded fetch data.\n");
         //}
         else if(nDemError == SURF_FETCH_E_TIMEOUT)
         {
-            fprintf(stderr, "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.\n");
+            fprintf(stderr, "Download failure, likely download timeout failure.\n");
         }
         else
         {

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -271,6 +271,7 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
 
     // the latestTime fetch just uses the first time from the list
     // the time-series fetch throws an error as expected, but the message seems to drop what is going on to cause the error
+    // looks like we don't have a proper start time > stop time check yet, so it just fails with the generic error
     /*QVector<int> year   = {start.date().year(),   start.date().year()-1};
     QVector<int> month  = {start.date().month(),  start.date().month()};
     QVector<int> day    = {start.date().day(),    start.date().day()};
@@ -365,7 +366,7 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
 
     if(ui->weatherStationDataTimeComboBox->currentIndex() == 1) // TODO: Add proper error handling for a bad time duration (someone downloads too much data)
     {
-        //outYear[0] = outYear[1]-2;  // doing more than a year worth of time SHOULD be what triggers it, this is NOT a check on the times themselves  // hrm, it returns an error code of 8, but no ninjaCom seems to be sent so it leaves it hanging without a proper message. runs fine for a latestTime simulation.
+        //outYear[0] = outYear[1]-2;  // doing more than a year worth of time SHOULD be what triggers it, this is NOT a check on the times themselves  // hrm, it returns an error code of 8, but no ninjaCom seems to be sent so it leaves it hanging without a proper message. runs fine for a latestTime simulation. // updated ninja code and the error message is WAY better now, has a proper error message.
         //outYear[1] = outYear[0]+2;  // not sure if it can even handle when the endYear goes past the current year  // same result as the above test.
         ninjaErr = NinjaCheckTimeDuration(ninjaTools, outYear.data(), outMonth.data(), outDay.data(), outHour.data(), outMinute.data(), 2, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
@@ -470,7 +471,7 @@ int PointInitializationInput::fetchStationFromBbox(NinjaToolsH* ninjaTools,
     //year[0] = year[1]+1;  // throws an error as expected, though the message seems to drop what is going on to cause the error
     //hour[0] = hour[1]+1;  // need to carefully set the date to the same date for both times for this test to properly work. apparently this test SHOULD break, but something must be up in how it is handled within the ninja code because it ends up just downloading a single dateTime, of the earliest of the two sets of times. Seems to work better when not close to the hour.
     //hour[0] = hour[1]+2;  // throws an error as expected. need to carefully set the date to the same date for both times for this test to properly work.
-    //elevationFile = "fudge";  // throws error as expected, after a message of "ERROR 4: fudge: No such file or directory", BUT, the message seems to drop what is going on to cause the error
+    //elevationFile = "fudge";  // after adding in the check to the raw ninja code, for if the file exists BEFORE opening, it now properly throws the error "demFile 'fudge' does not exist."
     //buffer = -1;  // runs fine, no error messages, just downloads the data within the area of the dem
     //units = "fudge";  // runs fine, no error messages, just downloads the data within the area of the dem
     //osTimeZone = "fudge";  // runs fine, no error messages, seems to just download the data assuming the timezone of the dem

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -739,7 +739,7 @@ void PointInitializationInput::pointInitializationTreeViewItemSelectionChanged(c
             OGRFeature* poFeature = poLayer->GetFeature(1);         // Skip header, row 1 is first time in series
             if(poFeature == NULL)
             {
-                emit writeToConsoleSignal("No Stations Found in file!");
+                emit writeToConsoleSignal("No station data found in file!");
                 state.isStationFileSelectionValid = false;
                 return;
             }

--- a/src/ninja/cli.cpp
+++ b/src/ninja/cli.cpp
@@ -672,17 +672,48 @@ int windNinjaCLI(int argc, char* argv[])
                 }
 
                 double srtmRes = fetch->GetXRes();
-                int nSrtmError = fetch->FetchBoundingBox(bbox, srtmRes,
-                                                     new_elev.c_str(), NULL);
+                int nDemError = fetch->FetchBoundingBox(bbox, srtmRes, new_elev.c_str(), NULL);
                 delete fetch;
-                                                     
-                if(nSrtmError < 0)
+
+                if(nDemError < 0)
                 {
-                    cerr << "Failed to download elevation data\n";
+                    std::cerr << "Failed to download elevation data." << std::endl;
+                    if(nDemError == SURF_FETCH_E_IO_ERR)
+                    {
+                        std::cerr << "SURF_FETCH_E_IO_ERR, Failure opening a dataset." << std::endl;
+                    }
+                    else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
+                    {
+                        std::cerr << "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset." << std::endl;
+                    }
+                    else if(nDemError == SURF_FETCH_E_WARPER_ERR)
+                    {
+                        std::cerr << "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data." << std::endl;
+                    }
+                    else if(nDemError == SURF_FETCH_E_BAD_INPUT)
+                    {
+                        std::cerr << "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions." << std::endl;
+                    }
+                    else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
+                    {
+                        std::cerr << "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch." << std::endl;
+                    }
+                    //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
+                    //{
+                    //    std::cerr << "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data." << std::endl;
+                    //}
+                    else if(nDemError == SURF_FETCH_E_TIMEOUT)
+                    {
+                        std::cerr << "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure." << std::endl;
+                    }
+                    else
+                    {
+                        std::cerr << "Unknown error occurred during fetch." << std::endl;
+                    }
                     VSIUnlink(new_elev.c_str());
                     exit(1);
                 }
-                
+
                 if( vm["elevation_source"].as<std::string>() != "lcp") {
                     //fill in no data values
                     GDALDataset *poDS;
@@ -724,7 +755,7 @@ int windNinjaCLI(int argc, char* argv[])
             std::cout << "Downloading elevation file..." << std::endl;
             std::string new_elev = vm["fetch_elevation"].as<std::string>();
 
-            int nSrtmError;
+            int nDemError;
             conflicting_options(vm, "elevation_file", "fetch_elevation");
             option_dependency(vm, "fetch_elevation", "elevation_source");
             std::string source = vm["elevation_source"].as<std::string>();
@@ -769,16 +800,7 @@ int windNinjaCLI(int argc, char* argv[])
                     elevRes = fetch->GetXRes() * 111325;  // convert from lat/lon to m
                 }
                 #endif //HAVE_GMTED
-                nSrtmError = fetch->FetchBoundingBox(bbox, elevRes,
-                                                     new_elev.c_str(), NULL);
-                                                     
-                if(nSrtmError < 0)
-                {
-                    cerr << "Failed to download elevation data.\n";
-                    VSIUnlink(new_elev.c_str());
-                    exit(1);
-                }
-
+                nDemError = fetch->FetchBoundingBox(bbox, elevRes, new_elev.c_str(), NULL);
             }
             else
             {
@@ -827,14 +849,45 @@ int windNinjaCLI(int argc, char* argv[])
                     elevRes = fetch->GetXRes() * 111325;  // convert from lat/lon to m
                 }
                 #endif //HAVE_GMTED
-                nSrtmError = fetch->FetchPoint(center, buffer, buffer_units,
-                                               elevRes, new_elev.c_str(), NULL);
+                nDemError = fetch->FetchPoint(center, buffer, buffer_units, elevRes, new_elev.c_str(), NULL);
             }
             delete fetch;
 
-            if(nSrtmError < 0)
+            if(nDemError < 0)
             {
-                cerr << "Failed to download elevation data\n";
+                std::cerr << "Failed to download elevation data." << std::endl;
+                if(nDemError == SURF_FETCH_E_IO_ERR)
+                {
+                    std::cerr << "SURF_FETCH_E_IO_ERR, Failure opening a dataset." << std::endl;
+                }
+                else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
+                {
+                    std::cerr << "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset." << std::endl;
+                }
+                else if(nDemError == SURF_FETCH_E_WARPER_ERR)
+                {
+                    std::cerr << "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data." << std::endl;
+                }
+                else if(nDemError == SURF_FETCH_E_BAD_INPUT)
+                {
+                    std::cerr << "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions." << std::endl;
+                }
+                else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
+                {
+                    std::cerr << "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch." << std::endl;
+                }
+                //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
+                //{
+                //    std::cerr << "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data." << std::endl;
+                //}
+                else if(nDemError == SURF_FETCH_E_TIMEOUT)
+                {
+                    std::cerr << "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure." << std::endl;
+                }
+                else
+                {
+                    std::cerr << "Unknown error occurred during fetch." << std::endl;
+                }
                 VSIUnlink(new_elev.c_str());
                 exit(1);
             }

--- a/src/ninja/cli.cpp
+++ b/src/ninja/cli.cpp
@@ -680,31 +680,31 @@ int windNinjaCLI(int argc, char* argv[])
                     std::cerr << "Failed to download elevation data." << std::endl;
                     if(nDemError == SURF_FETCH_E_IO_ERR)
                     {
-                        std::cerr << "SURF_FETCH_E_IO_ERR, Failure opening a dataset." << std::endl;
+                        std::cerr << "Failure opening a dataset." << std::endl;
                     }
                     else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
                     {
-                        std::cerr << "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset." << std::endl;
+                        std::cerr << "Fetch was outside the bounds of the dataset." << std::endl;
                     }
                     else if(nDemError == SURF_FETCH_E_WARPER_ERR)
                     {
-                        std::cerr << "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data." << std::endl;
+                        std::cerr << "Failure during warp, failed to warp data." << std::endl;
                     }
                     else if(nDemError == SURF_FETCH_E_BAD_INPUT)
                     {
-                        std::cerr << "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions." << std::endl;
+                        std::cerr << "Bad input to fetching functions." << std::endl;
                     }
                     else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
                     {
-                        std::cerr << "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch." << std::endl;
+                        std::cerr << "Hit a size limit during fetch." << std::endl;
                     }
                     //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
                     //{
-                    //    std::cerr << "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data." << std::endl;
+                    //    std::cerr << "Found NO_DATA in downloaded fetch data." << std::endl;
                     //}
                     else if(nDemError == SURF_FETCH_E_TIMEOUT)
                     {
-                        std::cerr << "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure." << std::endl;
+                        std::cerr << "Download failure, likely download timeout failure." << std::endl;
                     }
                     else
                     {
@@ -858,31 +858,31 @@ int windNinjaCLI(int argc, char* argv[])
                 std::cerr << "Failed to download elevation data." << std::endl;
                 if(nDemError == SURF_FETCH_E_IO_ERR)
                 {
-                    std::cerr << "SURF_FETCH_E_IO_ERR, Failure opening a dataset." << std::endl;
+                    std::cerr << "Failure opening a dataset." << std::endl;
                 }
                 else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
                 {
-                    std::cerr << "SURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset." << std::endl;
+                    std::cerr << "Fetch was outside the bounds of the dataset." << std::endl;
                 }
                 else if(nDemError == SURF_FETCH_E_WARPER_ERR)
                 {
-                    std::cerr << "SURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data." << std::endl;
+                    std::cerr << "Failure during warp, failed to warp data." << std::endl;
                 }
                 else if(nDemError == SURF_FETCH_E_BAD_INPUT)
                 {
-                    std::cerr << "SURF_FETCH_E_BAD_INPUT, Bad input to fetching functions." << std::endl;
+                    std::cerr << "Bad input to fetching functions." << std::endl;
                 }
                 else if(nDemError == SURF_FETCH_E_SIZE_LIMIT)
                 {
-                    std::cerr << "SURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch." << std::endl;
+                    std::cerr << "Hit a size limit during fetch." << std::endl;
                 }
                 //else if(nDemError == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
                 //{
-                //    std::cerr << "SURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data." << std::endl;
+                //    std::cerr << "Found NO_DATA in downloaded fetch data." << std::endl;
                 //}
                 else if(nDemError == SURF_FETCH_E_TIMEOUT)
                 {
-                    std::cerr << "SURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure." << std::endl;
+                    std::cerr << "Download failure, likely download timeout failure." << std::endl;
                 }
                 else
                 {

--- a/src/ninja/gcp_wx_init.cpp
+++ b/src/ninja/gcp_wx_init.cpp
@@ -180,7 +180,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
     GDALDatasetH hDS = GDALOpen(demFile.c_str(), GA_ReadOnly);
     double demBounds[4];
     if (!GDALGetBounds((GDALDataset *)hDS, demBounds)) {
-        throw badForecastFile("Could not download weather forecast, invalid projection for the DEM");
+        throw badForecastFile("Failed to get bounds of the DEM for weather forecast download. Failed to download weather forecast.");
     }
 
     double adfNESW[4];
@@ -229,13 +229,13 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
 
         VSILFILE *fpRemote = VSIFOpenL(("/vsicurl/" + idxUrl).c_str(), "r");
         if (!fpRemote) {
-            CPLError(CE_Warning, CPLE_AppDefined, "GCP, Failed to open remote idx file: %s", idxUrl.c_str());
+            CPLError(CE_Warning, CPLE_AppDefined, "Failed to open remote idx file: %s", idxUrl.c_str());
             continue;
         }
 
         VSILFILE *fpLocal = VSIFOpenL(localIdxPath.c_str(), "w");
         if (!fpLocal) {
-            CPLError(CE_Warning, CPLE_AppDefined, "GCP, Failed to create local idx file: %s", localIdxPath.c_str());
+            CPLError(CE_Warning, CPLE_AppDefined, "Failed to create local idx file: %s", localIdxPath.c_str());
             VSIFCloseL(fpRemote);
             continue;
         }
@@ -274,7 +274,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
                          CPLSPrintf( "Downloading file 1 out of %d...\n This may take a few minutes...", validTimes.size() ),
                          NULL ) )
         {
-            CPLError( CE_Failure, CPLE_UserInterrupt, "Cancelled by user." );
+            CPLError(CE_Failure, CPLE_UserInterrupt, "Cancelled by user.");
             nrc = GCP_ERR;
             return "";
         }
@@ -310,7 +310,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
 
         CPLJoinableThread* handle = CPLCreateJoinableThread(ThreadFunc, params);
         if (!handle) {
-            CPLError(CE_Failure, CPLE_AppDefined, "GCP, Failed to create thread");
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to create thread.");
             delete params;
             break;
         }
@@ -327,7 +327,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
                              CPLSPrintf( "Downloading file %d out of %d...\n This may take a few minutes...", i+1, threadHandles.size() ),
                              NULL ) )
             {
-                CPLError( CE_Failure, CPLE_UserInterrupt, "Cancelled by user." );
+                CPLError(CE_Failure, CPLE_UserInterrupt, "Cancelled by user.");
                 nrc = GCP_ERR;
                 return "";
             }
@@ -380,7 +380,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
         VSILFILE* fpSrc = VSIFOpenL(filePath.c_str(), "rb");
         if (!fpSrc) {
             ostringstream os;
-            os << "GCP, Failed to open source file for zipping: " << filePath << "\n";
+            os << "Failed to open source file for zipping: " << filePath << "\n";
             throw badForecastFile( os.str() );
         }
 
@@ -392,7 +392,7 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
         if (VSIFReadL(buffer.data(), 1, fileSize, fpSrc) != fileSize) {
             VSIFCloseL(fpSrc);
             ostringstream os;
-            os << "GCP, Failed to read complete file for zipping: " << filePath << "\n";
+            os << "Failed to read complete file for zipping: " << filePath << "\n";
             throw badForecastFile( os.str() );
         }
         VSIFCloseL(fpSrc);
@@ -400,14 +400,14 @@ std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
         VSILFILE* fpZip = VSIFOpenL(zipEntryPath.c_str(), "wb");
         if (!fpZip) {
             ostringstream os;
-            os << "GCP, Failed to create zip entry: " << zipEntryPath << "\n";
+            os << "Failed to create zip entry: " << zipEntryPath << "\n";
             throw badForecastFile( os.str() );
         }
 
         if (VSIFWriteL(buffer.data(), 1, fileSize, fpZip) != fileSize) {
             VSIFCloseL(fpZip);
             ostringstream os;
-            os << "GCP, Failed to write data to zip entry: " << zipEntryPath << "\n";
+            os << "Failed to write data to zip entry: " << zipEntryPath << "\n";
             throw badForecastFile( os.str() );
         }
         VSIFCloseL(fpZip);
@@ -448,7 +448,7 @@ int GCPWxModel::fetchData( boost::posix_time::ptime dt, std::string outPath, std
     GDALDatasetH hSrcDS = GDALOpen(srcFile.c_str(), GA_ReadOnly);
     if (!hSrcDS)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "GCP, Failed to open input dataset for %s", srcFile.c_str());
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open input dataset for %s", srcFile.c_str());
         GDALTranslateOptionsFree(transOptions);
         return GCP_ERR;
     }
@@ -459,7 +459,7 @@ int GCPWxModel::fetchData( boost::posix_time::ptime dt, std::string outPath, std
 
     if (!hOutDS)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "GCP, GDALTranslate failed for %s", outFile.c_str());
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALTranslate failed for %s", outFile.c_str());
         return GCP_ERR;
     }
     GDALClose(hOutDS);
@@ -492,7 +492,7 @@ std::string GCPWxModel::findBands(std::string idxFilePath, std::vector<std::stri
     std::ifstream idxFile(idxFilePath.c_str());
     if (!idxFile.is_open())
     {
-        CPLError(CE_Warning, CPLE_AppDefined, "GCP, Failed to open cached .idx file: %s", idxFilePath.c_str());
+        CPLError(CE_Warning, CPLE_AppDefined, "Failed to open cached .idx file: %s", idxFilePath.c_str());
         return "";
     }
 
@@ -518,7 +518,7 @@ std::string GCPWxModel::findBands(std::string idxFilePath, std::vector<std::stri
                     }
                     else
                     {
-                        CPLError(CE_Warning, CPLE_AppDefined, "GCP, Could not parse band number in line: %s", line.c_str());
+                        CPLError(CE_Warning, CPLE_AppDefined, "Could not parse band number in line: %s", line.c_str());
                     }
                 }
             }
@@ -656,8 +656,7 @@ void GCPWxModel::setSurfaceGrids(WindNinjaInputs& input,
     const char *pszForecastFile = vsiPath.c_str();
     if( !pszForecastFile )
     {
-        throw badForecastFile( "Could not find forecast associated with " \
-                          "requested time step" );
+        throw badForecastFile("Could not find forecast associated with requested time step");
     }
 
     hSrcDS = GDALOpenShared(pszForecastFile, GA_ReadOnly);

--- a/src/ninja/gcp_wx_init.cpp
+++ b/src/ninja/gcp_wx_init.cpp
@@ -691,7 +691,7 @@ void GCPWxModel::setSurfaceGrids(WindNinjaInputs& input,
         // direct calculation of FROM wx TO dem, already has the appropriate sign
         if(!GDALCalculateCoordinateTransformationAngle( (GDALDataset*)hSrcDS, coordinateTransformationAngle, pszDstWkt ))  // this is FROM wx TO dem
         {
-            printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
         }
     }
 
@@ -758,7 +758,7 @@ void GCPWxModel::setSurfaceGrids(WindNinjaInputs& input,
         }
 
         if (!bHaveCloud) {
-            CPLError(CE_Warning, CPLE_AppDefined, "No cloud data found. Setting cloud grid to 0.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "No cloud data found. Setting cloud grid to 0.");
             cloudGrid.set_headerData(uGrid);
             cloudGrid = 0.0;
         }

--- a/src/ninja/gdal_fetch.cpp
+++ b/src/ninja/gdal_fetch.cpp
@@ -109,7 +109,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
     hSrcDS = GDALOpen(GetPath().c_str(), GA_ReadOnly);
     if(hSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "GDALFetch::FetchBoundingBox(), Could not open path for reading, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open path '%s' for reading, download failed.", GetPath().c_str());
         return SURF_FETCH_E_IO_ERR;
     }
     hDriver = GDALGetDriverByName("GTiff");
@@ -178,10 +178,9 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     hDstDS = GDALCreate(hDriver, filename, nPixels, nLines, 
                         GDALGetRasterCount(hSrcDS), GDT_Float32, NULL);
-
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final gdal_fetch file for writing, Failed to create output file, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create final output file for writing, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -268,7 +267,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     if(nNoDataCount > 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "GDALFetch::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+        CPLError(CE_Failure, CPLE_AppDefined, "Final downloaded elevation file contains '%d' noDataValues", nNoDataCount);
     }
     return nNoDataCount;
 }

--- a/src/ninja/gdal_fetch.cpp
+++ b/src/ninja/gdal_fetch.cpp
@@ -109,6 +109,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
     hSrcDS = GDALOpen(GetPath().c_str(), GA_ReadOnly);
     if(hSrcDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALFetch::FetchBoundingBox(), Could not open path for reading, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
     hDriver = GDALGetDriverByName("GTiff");
@@ -143,6 +144,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         return SURF_FETCH_E_WARPER_ERR;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
@@ -165,6 +167,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     if(nPixels <= 0 || nLines <= 0)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid nPixels and/or nLines for warp. Could not warp image, download failed.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -178,6 +181,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final gdal_fetch file for writing, Failed to create output file, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -262,6 +266,10 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
     CPLSetConfigOption("GTIFF_DIRECT_IO", "NO");
     CPLSetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", NULL);
 
+    if(nNoDataCount > 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALFetch::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+    }
     return nNoDataCount;
 }
 

--- a/src/ninja/gdal_fetch.cpp
+++ b/src/ninja/gdal_fetch.cpp
@@ -89,6 +89,8 @@ int GDALFetch::Initialize()
  * \param resolution output resolution in meters
  * \param filename file to write data into
  * \param options key/value options, unused
+ *
+ * \return number of no data values on success, < 0 on error
  */
 SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
                                          const char *filename,
@@ -141,7 +143,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
 
@@ -163,7 +165,7 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     if(nPixels <= 0 || nLines <= 0)
     {
-        return SURF_FETCH_E_WARPER_ERR; /*assumption*/
+        return SURF_FETCH_E_WARPER_ERR;
     }
 
     adfDstGeoTransform[0] = dfMinX;
@@ -220,14 +222,12 @@ SURF_FETCH_E GDALFetch::FetchBoundingBox(double *bbox, double resolution,
 
     if( eErr != CE_None )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp image, " \
-                                               "download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         CPLFree((void*)pszDstWKT);
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
-
 
     GDALRasterBandH hSrcBand;
     GDALRasterBandH hDstBand;

--- a/src/ninja/gdal_util.cpp
+++ b/src/ninja/gdal_util.cpp
@@ -43,7 +43,7 @@ double GDALGetMax( GDALDataset *poDS )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get max value of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get max value of the GDAL dataset.");
         //return false;  // not really a good return value here for this particular function, probably not safe to throw yet either
     }
 
@@ -64,7 +64,7 @@ double GDALGetMin( GDALDataset *poDS )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get min value of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get min value of the GDAL dataset.");
         //return false;  // not really a good return value here for this particular function, probably not safe to throw yet either
     }
 
@@ -87,7 +87,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get lat lon center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get lat lon center of the GDAL dataset.");
         return false;
     }
 
@@ -100,7 +100,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     const char *pszPrj = GDALGetProjectionRef(hDS);
     if(pszPrj == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get lat lon center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to get lat lon center of the GDAL dataset.");
         return false;
     }
 
@@ -109,7 +109,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     hTargetSRS = OSRNewSpatialReference(NULL);
     if(hSrcSRS == NULL || hTargetSRS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Could not get lat lon center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Failed to get lat lon center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -127,7 +127,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     hCT = OCTNewCoordinateTransformation(hSrcSRS, hTargetSRS);
     if(hCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get lat lon center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to get lat lon center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -139,7 +139,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     double adfGeoTransform[6];
     if(GDALGetGeoTransform(hDS, adfGeoTransform) != CE_None)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Could not get lat lon center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Failed to get lat lon center of the GDAL dataset.");
         OCTDestroyCoordinateTransformation(hCT);
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
@@ -178,7 +178,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get center of the GDAL dataset.");
         return false;
     }
 
@@ -194,7 +194,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     double adfGeoTransform[6];
     if(GDALGetGeoTransform(hDS, adfGeoTransform) != CE_None)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Could not get center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Failed to get center of the GDAL dataset.");
         return false;
     }
 
@@ -214,7 +214,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     const char *pszSrcWkt = GDALGetProjectionRef(hDS);
     if(pszSrcWkt == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to get center of the GDAL dataset.");
         return false;
     }
 
@@ -224,7 +224,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     hTargetSRS = OSRNewSpatialReference(NULL);
     if(hSrcSRS == NULL || hTargetSRS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Could not get center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Failed to get center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -233,7 +233,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     OSRImportFromWkt( hTargetSRS, (char**)&pszDstWkt );
     if(hTargetSRS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to import spatial reference from pszDstWkt '%s', Cannot not get center of the GDAL dataset.", pszDstWkt);
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to import spatial reference from pszDstWkt '%s', Failed to get center of the GDAL dataset.", pszDstWkt);
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -250,7 +250,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     hCT = OCTNewCoordinateTransformation(hSrcSRS, hTargetSRS);
     if(hCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get center of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to get center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -277,7 +277,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get lat lon bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get lat lon bounds of the GDAL dataset.");
         return false;
     }
 
@@ -296,7 +296,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 
     if(poDS->GetProjectionRef() == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get lat lon bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to get lat lon bounds of the GDAL dataset.");
 	    return false;
     }
 	pszPrj = (char*)poDS->GetProjectionRef();
@@ -312,7 +312,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get lat lon bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to get lat lon bounds of the GDAL dataset.");
         return false;
     }
 
@@ -323,7 +323,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 
     if(!poCT->Transform(1, &eLon, &nLat))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get lat lon bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to get lat lon bounds of the GDAL dataset.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -333,7 +333,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 
     if(!poCT->Transform(1, &wLon, &sLat))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get lat lon bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to get lat lon bounds of the GDAL dataset.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -360,7 +360,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get bounds of the GDAL dataset.");
         return false;
     }
 
@@ -390,7 +390,7 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
     char* pszSrcWkt;
     if(poDS->GetProjectionRef() == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to get bounds of the GDAL dataset.");
         return false;
     }
     pszSrcWkt = (char*)poDS->GetProjectionRef();
@@ -411,19 +411,19 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to get bounds of the GDAL dataset.");
         return false;
     }
 
     if(!poCT->Transform(1, &east, &north))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to get bounds of the GDAL dataset.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
     if(!poCT->Transform(1, &west, &south))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get bounds of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to get bounds of the GDAL dataset.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -448,7 +448,7 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot calculate angleFromNorth of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
@@ -461,7 +461,7 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
 
     if(!GDALGetCenter(poDS, &x1, &y1))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Could not calculate angleFromNorth of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Failed to calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
@@ -470,7 +470,7 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
     //add 1/4 size of the DEM extent in y direction
     if(!GDALGetBounds(poDS, boundsLonLat))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Could not calculate angleFromNorth of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Failed to calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
@@ -482,13 +482,13 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
     //project the two lat/lon points to projected DEM coordinates
     if(!GDALPointFromLatLon(x1, y1, poDS, "WGS84"))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate angleFromNorth of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Failed to calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
     if(!GDALPointFromLatLon(x2, y2, poDS, "WGS84"))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate angleFromNorth of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Failed to calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
@@ -548,7 +548,7 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
 {
     if(poSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot calculate coordinateTransformationAngle of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
@@ -563,7 +563,7 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
     //get the center of the poSrcDS, in the projection of the poSrcDS
     if(!GDALGetCenter(poSrcDS, &x1, &y1, NULL))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Failed to calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
@@ -572,7 +572,7 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
     //add 1/4 size of the poSrcDS extent in y direction, in the projection of the poSrcDS
     if(!GDALGetBounds(poSrcDS, bounds, NULL))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Failed to calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
@@ -584,13 +584,13 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
     //project the two points FROM the projection of the poSrcDS TO the pszDstWkt projection
     if(!GDALTransformPoint(x1, y1, poSrcDS, pszDstWkt))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Failed to calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
     if(!GDALTransformPoint(x2, y2, poSrcDS, pszDstWkt))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Failed to calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
@@ -646,7 +646,7 @@ bool GDALTestSRS( GDALDataset *poDS )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot test SRS of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Test SRS fails for the GDAL dataset.");
         return false;
     }
 
@@ -691,7 +691,7 @@ bool GDALHasNoData( GDALDataset *poDS, int band )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot check if GDAL dataset has NO_DATA values.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to check if GDAL dataset has NO_DATA values.");
         return false;
     }
 
@@ -705,7 +705,7 @@ bool GDALHasNoData( GDALDataset *poDS, int band )
     GDALRasterBand *poBand = poDS->GetRasterBand( band );
     if(poBand == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get raster band from GDAL dataset, Could not check if GDAL dataset has NO_DATA values.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get raster band from GDAL dataset, Failed to check if GDAL dataset has NO_DATA values.");
         return false;
     }
 
@@ -737,7 +737,7 @@ bool GDAL2AsciiGrid( GDALDataset *poDS, int band, AsciiGrid<double> &grid )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot convert from GDAL dataset to ascii grid dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to convert from GDAL dataset to ascii grid dataset.");
         return false;
     }
 
@@ -837,14 +837,14 @@ bool GDALTransformPoint( double &dfX, double &dfY, GDALDataset *poSrcDS, const c
 {
     if(poSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to transform point.");
         return false;
     }
 
     char* pszSrcWkt;
     if(poSrcDS->GetProjectionRef() == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to transform point.");
         return false;
     }
     pszSrcWkt = (char*)poSrcDS->GetProjectionRef();
@@ -865,13 +865,13 @@ bool GDALTransformPoint( double &dfX, double &dfY, GDALDataset *poSrcDS, const c
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to transform point.");
         return false;
     }
 
     if(!poCT->Transform(1, &dfX, &dfY))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to transform point.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -884,7 +884,7 @@ bool GDALPointFromLatLon(double &x, double &y, GDALDataset *poSrcDS, const char 
 {
     if(poSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point from lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to transform point from lat lon.");
         return false;
     }
 
@@ -895,7 +895,7 @@ bool GDALPointFromLatLon(double &x, double &y, GDALDataset *poSrcDS, const char 
 
     if(poSrcDS->GetProjectionRef() == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point from lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to transform point from lat lon.");
         return false;
     }
 	pszPrj = (char*)poSrcDS->GetProjectionRef();
@@ -913,13 +913,13 @@ bool GDALPointFromLatLon(double &x, double &y, GDALDataset *poSrcDS, const char 
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point from lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to transform point from lat lon.");
         return false;
     }
 
     if(!poCT->Transform(1, &x, &y))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point from lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to transform point from lat lon.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -932,7 +932,7 @@ bool GDALPointToLatLon(double &x, double &y, GDALDataset *poSrcDS, const char *d
 {
     if(poSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to transform point to lat lon.");
         return false;
     }
 
@@ -943,7 +943,7 @@ bool GDALPointToLatLon(double &x, double &y, GDALDataset *poSrcDS, const char *d
 
     if(poSrcDS->GetProjectionRef() == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Failed to transform point to lat lon.");
         return false;
     }
 	pszPrj = (char*)poSrcDS->GetProjectionRef();
@@ -961,13 +961,13 @@ bool GDALPointToLatLon(double &x, double &y, GDALDataset *poSrcDS, const char *d
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to transform point to lat lon.");
         return false;
     }
 
     if(!poCT->Transform(1, &x, &y))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to transform point to lat lon.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -980,7 +980,7 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS, const char *datu
 {
     if(hDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid OGR dataset handle, Cannot transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid OGR dataset handle, Failed to transform point to lat lon.");
         return false;
     }
 
@@ -998,7 +998,7 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS, const char *datu
     poSrcSRS = poLayer->GetSpatialRef();
     if(poSrcSRS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from OGR dataset, Cannot transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from OGR dataset, Failed to transform point to lat lon.");
         return false;
     }
     oSourceSRS = *poSrcSRS;
@@ -1014,13 +1014,13 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS, const char *datu
     poCT = OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to transform point to lat lon.");
         return false;
     }
 
     if(!poCT->Transform(1, &x, &y))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point to lat lon.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to transform point to lat lon.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
@@ -1040,7 +1040,7 @@ int GDALGetUtmZone( GDALDataset *poDS )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get UTM zone of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get UTM zone of the GDAL dataset.");
         return 0;
     }
 
@@ -1048,7 +1048,7 @@ int GDALGetUtmZone( GDALDataset *poDS )
     double latitude = 0;
     if(!GDALGetCenter(poDS, &longitude, &latitude))
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not get center of the GDAL dataset, Could not get UTM zone of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get center of the GDAL dataset, Failed to get UTM zone of the GDAL dataset.");
         return 0;
     }
 
@@ -1132,7 +1132,7 @@ int GDALFillBandNoData(GDALDataset *poDS, int nBand, int nSearchPixels)
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot fill NO_DATA values of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to fill NO_DATA values of the GDAL dataset.");
         return -1;
     }
 
@@ -1171,7 +1171,7 @@ int GDALGetCorners( GDALDataset *poDS, double corners[8] )
 {
     if(poDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get corners of the GDAL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to get corners of the GDAL dataset.");
         return -1;
     }
 
@@ -1441,7 +1441,7 @@ bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDs
 {
     if(hSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to UTM.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to warp GDAL dataset to UTM.");
         return false;
     }
 
@@ -1482,7 +1482,7 @@ bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDs
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "GDALSuggestedWarpOutput failed, Could not warp GDAL dataset to UTM.");
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALSuggestedWarpOutput failed, Failed to warp GDAL dataset to UTM.");
         return false;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
@@ -1491,7 +1491,7 @@ bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDs
                         GDALGetRasterCount(hSrcDS), GDT_Float32, NULL);
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create GDAL dataset, Could not warp GDAL dataset to UTM.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create GDAL dataset, Failed to warp GDAL dataset to UTM.");
         return false;
     }
 
@@ -1599,7 +1599,7 @@ GDALDataset* gdalWarpToUtm(const char* filename, GDALDataset* pSrcDS)
 {
     if(pSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to UTM.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to warp GDAL dataset to UTM.");
         return NULL;
     }
 
@@ -1660,7 +1660,7 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
 {
     if(hSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to WKT.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Failed to warp GDAL dataset to WKT.");
         return false;
     }
 

--- a/src/ninja/gdal_util.cpp
+++ b/src/ninja/gdal_util.cpp
@@ -41,6 +41,12 @@
  */
 double GDALGetMax( GDALDataset *poDS )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get max value of the GDAL dataset.");
+        //return false;  // not really a good return value here for this particular function, probably not safe to throw yet either
+    }
+
     GDALRasterBand *poBand = poDS->GetRasterBand( 1 );
     double adfMinMax[2];
 
@@ -56,6 +62,12 @@ double GDALGetMax( GDALDataset *poDS )
  */
 double GDALGetMin( GDALDataset *poDS )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get min value of the GDAL dataset.");
+        //return false;  // not really a good return value here for this particular function, probably not safe to throw yet either
+    }
+
     GDALRasterBand *poBand = poDS->GetRasterBand( 1 );
     double adfMinMax[2];
 
@@ -73,6 +85,12 @@ double GDALGetMin( GDALDataset *poDS )
  */
 bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get lat lon center of the GDAL dataset.");
+        return false;
+    }
+
     GDALDatasetH hDS = (GDALDatasetH)poDS;
     assert(hDS);
     assert(longitude);
@@ -80,14 +98,18 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     bool rc = true;
 
     const char *pszPrj = GDALGetProjectionRef(hDS);
-    if(pszPrj == NULL) {
+    if(pszPrj == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get lat lon center of the GDAL dataset.");
         return false;
     }
 
     OGRSpatialReferenceH hSrcSRS, hTargetSRS;
     hSrcSRS = OSRNewSpatialReference(pszPrj);
     hTargetSRS = OSRNewSpatialReference(NULL);
-    if(hSrcSRS == NULL || hTargetSRS == NULL) {
+    if(hSrcSRS == NULL || hTargetSRS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Could not get lat lon center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -103,7 +125,9 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
 
     OGRCoordinateTransformationH hCT;
     hCT = OCTNewCoordinateTransformation(hSrcSRS, hTargetSRS);
-    if(hCT == NULL) {
+    if(hCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get lat lon center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -113,7 +137,9 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
     int nY = GDALGetRasterYSize(hDS);
 
     double adfGeoTransform[6];
-    if(GDALGetGeoTransform(hDS, adfGeoTransform) != CE_None) {
+    if(GDALGetGeoTransform(hDS, adfGeoTransform) != CE_None)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Could not get lat lon center of the GDAL dataset.");
         OCTDestroyCoordinateTransformation(hCT);
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
@@ -150,6 +176,12 @@ bool GDALGetCenter( GDALDataset *poDS, double *longitude, double *latitude )
  */
 bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *pszDstWkt )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get center of the GDAL dataset.");
+        return false;
+    }
+
     GDALDatasetH hDS = (GDALDatasetH)poDS;
     assert(hDS);
     assert(dfX);
@@ -162,6 +194,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     double adfGeoTransform[6];
     if(GDALGetGeoTransform(hDS, adfGeoTransform) != CE_None)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get GeoTransform of the GDAL dataset, Could not get center of the GDAL dataset.");
         return false;
     }
 
@@ -181,6 +214,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     const char *pszSrcWkt = GDALGetProjectionRef(hDS);
     if(pszSrcWkt == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get center of the GDAL dataset.");
         return false;
     }
 
@@ -190,6 +224,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     hTargetSRS = OSRNewSpatialReference(NULL);
     if(hSrcSRS == NULL || hTargetSRS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRSpatialReference from GDAL dataset, Could not get center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -198,6 +233,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     OSRImportFromWkt( hTargetSRS, (char**)&pszDstWkt );
     if(hTargetSRS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to import spatial reference from pszDstWkt '%s', Cannot not get center of the GDAL dataset.", pszDstWkt);
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -214,6 +250,7 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
     hCT = OCTNewCoordinateTransformation(hSrcSRS, hTargetSRS);
     if(hCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get center of the GDAL dataset.");
         OSRDestroySpatialReference(hSrcSRS);
         OSRDestroySpatialReference(hTargetSRS);
         return false;
@@ -238,6 +275,12 @@ bool GDALGetCenter( GDALDataset *poDS, double *dfX, double *dfY, const char *psz
  */
 bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get lat lon bounds of the GDAL dataset.");
+        return false;
+    }
+
     char* pszPrj;
     double adfGeoTransform[6];
     int xSize, ySize;
@@ -246,17 +289,16 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
     OGRSpatialReference oSourceSRS, oTargetSRS;
     OGRCoordinateTransformation *poCT;
 
-    if( poDS == NULL )
-	return false;
-
     xSize = poDS->GetRasterXSize ();
     ySize = poDS->GetRasterYSize();
 
     poDS->GetGeoTransform( adfGeoTransform );
 
-    if( poDS->GetProjectionRef() == NULL )
-	return false;
-    else
+    if(poDS->GetProjectionRef() == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get lat lon bounds of the GDAL dataset.");
+	    return false;
+    }
 	pszPrj = (char*)poDS->GetProjectionRef();
 
     oSourceSRS.importFromWkt( &pszPrj );
@@ -268,25 +310,32 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
 #endif /* GDAL_COMPUTE_VERSION */
 
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-    if( poCT == NULL )
-	return false;
+    if(poCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get lat lon bounds of the GDAL dataset.");
+        return false;
+    }
 
     nLat = adfGeoTransform[3] + adfGeoTransform[4] * 0 + adfGeoTransform[5] * 0;
     eLon = adfGeoTransform[0] + adfGeoTransform[1] * xSize + adfGeoTransform[2] * 0;
     sLat = adfGeoTransform[3] + adfGeoTransform[4] * 0 + adfGeoTransform[5] * ySize;
     wLon = adfGeoTransform[0] + adfGeoTransform[1] * 0 + adfGeoTransform[2] * 0;
 
-    if( !poCT->Transform( 1, &eLon, &nLat ) ) {
-	OGRCoordinateTransformation::DestroyCT( poCT );
-	return false;
+    if(!poCT->Transform(1, &eLon, &nLat))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get lat lon bounds of the GDAL dataset.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
+        return false;
     }
 
     boundsLonLat[0] = nLat;
     boundsLonLat[1] = eLon;
 
-    if( !poCT->Transform( 1, &wLon, &sLat ) ) {
-	OGRCoordinateTransformation::DestroyCT( poCT );
-	return false;
+    if(!poCT->Transform(1, &wLon, &sLat))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get lat lon bounds of the GDAL dataset.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
+        return false;
     }
 
     boundsLonLat[2] = sLat;
@@ -309,8 +358,9 @@ bool GDALGetBounds( GDALDataset *poDS, double *boundsLonLat )
  */
 bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
 {
-    if( poDS == NULL )
+    if(poDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get bounds of the GDAL dataset.");
         return false;
     }
 
@@ -338,8 +388,9 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
     // pszDstWkt != NULL, attempt to reproject the bounds to the output spatial reference
 
     char* pszSrcWkt;
-    if( poDS->GetProjectionRef() == NULL )
+    if(poDS->GetProjectionRef() == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot get bounds of the GDAL dataset.");
         return false;
     }
     pszSrcWkt = (char*)poDS->GetProjectionRef();
@@ -358,19 +409,22 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
 
     OGRCoordinateTransformation *poCT;
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-    if( poCT == NULL )
+    if(poCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not get bounds of the GDAL dataset.");
         return false;
     }
 
-    if( !poCT->Transform( 1, &east, &north ) )
+    if(!poCT->Transform(1, &east, &north))
     {
-        OGRCoordinateTransformation::DestroyCT( poCT );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get bounds of the GDAL dataset.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
-    if( !poCT->Transform( 1, &west, &south ) )
+    if(!poCT->Transform(1, &west, &south))
     {
-        OGRCoordinateTransformation::DestroyCT( poCT );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not get bounds of the GDAL dataset.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
 
@@ -392,44 +446,54 @@ bool GDALGetBounds( GDALDataset *poDS, double *bounds, const char *pszDstWkt )
  */
 bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot calculate angleFromNorth of the GDAL dataset.");
+        return false;
+    }
+
     double x1, y1; //center point of DEM in lat/lon
     double x2, y2; //point due north of center point in lat/lon
     double boundsLonLat[4]; //bounds of the DS in lat/lon
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "GDALCalculateAngleFromNorth()");
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "pszSrcWkt = \"%s\"", GDALGetProjectionRef( poDS ) );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "GDALCalculateAngleFromNorth()");
+    CPLDebug("COORD_TRANSFORM_ANGLES", "pszSrcWkt = \"%s\"", GDALGetProjectionRef(poDS));
 
-    if(!GDALGetCenter( poDS, &x1, &y1 ))
+    if(!GDALGetCenter(poDS, &x1, &y1))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Could not calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
     x2 = x1;
 
     //add 1/4 size of the DEM extent in y direction
-    if(!GDALGetBounds( poDS, boundsLonLat ))
+    if(!GDALGetBounds(poDS, boundsLonLat))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Could not calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
     y2 = y1 + 0.25*(boundsLonLat[0] - boundsLonLat[2]);
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1 );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2 );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2);
 
     //project the two lat/lon points to projected DEM coordinates
     if(!GDALPointFromLatLon(x1, y1, poDS, "WGS84"))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
     if(!GDALPointFromLatLon(x2, y2, poDS, "WGS84"))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate angleFromNorth of the GDAL dataset.");
         return false;
     }
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1 );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2 );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2);
 
     //compute angle of the line formed between projected (x1,y1) to (x2,y2) (projected true north)
     //and projected (x1,y1) to (x1,y2) (y coordinate gridline of the projected CRS).
@@ -447,7 +511,7 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
     ay = y2 - y1;
     bx = x2 - x1;
     by = y2 - y1;
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "a = (%lf,%lf), b = (%lf,%lf)", ax, ay, bx, by );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "a = (%lf,%lf), b = (%lf,%lf)", ax, ay, bx, by);
 
     adotb = ax*bx + ay*by;
     mag_a = sqrt(ax*ax + ay*ay);
@@ -464,10 +528,10 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
         angleFromNorth = -1*angleFromNorth;
     }
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "angleFromNorth in radians = %lf", angleFromNorth );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "angleFromNorth in radians = %lf", angleFromNorth);
     //convert the result from radians to degrees
     angleFromNorth *= 180.0 / PI;
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "angleFromNorth in degrees = %lf", angleFromNorth );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "angleFromNorth in degrees = %lf", angleFromNorth);
 
     return true;
 }
@@ -482,46 +546,56 @@ bool GDALCalculateAngleFromNorth( GDALDataset *poDS, double &angleFromNorth )
  */
 bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &coordinateTransformAngle, const char *pszDstWkt )
 {
+    if(poSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot calculate coordinateTransformationAngle of the GDAL dataset.");
+        return false;
+    }
+
     double x1, y1; //center point of the poSrcDS, in the projection of the poSrcDS, to be transformed to the pszDstWkt projection
     double x2, y2; //point straight out in the direction of the y coordinate grid line from the center point of the poSrcDS, in the projection of the poSrcDS, to be transformed to the pszDstWkt projection
     double bounds[4]; //bounds of the poSrcDS, used to calculate y2
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "GDALCalculateCoordinateTransformationAngle()");
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "pszSrcWkt = \"%s\"", GDALGetProjectionRef( poSrcDS ) );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "pszDstWkt = \"%s\"", pszDstWkt );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "GDALCalculateCoordinateTransformationAngle()");
+    CPLDebug("COORD_TRANSFORM_ANGLES", "pszSrcWkt = \"%s\"", GDALGetProjectionRef(poSrcDS));
+    CPLDebug("COORD_TRANSFORM_ANGLES", "pszDstWkt = \"%s\"", pszDstWkt);
 
     //get the center of the poSrcDS, in the projection of the poSrcDS
-    if(!GDALGetCenter( poSrcDS, &x1, &y1, NULL ))
+    if(!GDALGetCenter(poSrcDS, &x1, &y1, NULL))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get center of GDAL dataset, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
     x2 = x1;
 
     //add 1/4 size of the poSrcDS extent in y direction, in the projection of the poSrcDS
-    if(!GDALGetBounds( poSrcDS, bounds, NULL ))
+    if(!GDALGetBounds(poSrcDS, bounds, NULL))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to get bounds of GDAL dataset, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
     y2 = y1 + 0.25*(bounds[0] - bounds[2]);
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1 );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2 );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2);
 
     //project the two points FROM the projection of the poSrcDS TO the pszDstWkt projection
     if(!GDALTransformPoint(x1, y1, poSrcDS, pszDstWkt))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
     if(!GDALTransformPoint(x2, y2, poSrcDS, pszDstWkt))
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point from lat lon, Could not calculate coordinateTransformationAngle of the GDAL dataset.");
         return false;
     }
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1 );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2 );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x1, y1 = %lf, %lf", x1, y1);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "x2, y2 = %lf, %lf", x2, y2);
 
     //compute angle of the line formed between projected (x1,y1) to (x2,y2) (y coordinate gridline of poSrcDS, in the pszDstWkt projection coordinates)
     //and projected (x1,y1) to (x1,y2) (y coordinate gridline of the pszDstWkt projection coordinate system, in the pszDstWkt projection coordinates).
@@ -539,7 +613,7 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
     ay = y2 - y1;
     bx = x2 - x1;
     by = y2 - y1;
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "a = (%lf,%lf), b = (%lf,%lf)", ax, ay, bx, by );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "a = (%lf,%lf), b = (%lf,%lf)", ax, ay, bx, by);
 
     adotb = ax*bx + ay*by;
     mag_a = sqrt(ax*ax + ay*ay);
@@ -556,10 +630,10 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
         coordinateTransformAngle = -1*coordinateTransformAngle;
     }
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "coordinateTransformAngle in radians = %lf", coordinateTransformAngle );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "coordinateTransformAngle in radians = %lf", coordinateTransformAngle);
     //convert the result from radians to degrees
     coordinateTransformAngle *= 180.0 / PI;
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "coordinateTransformAngle in degrees = %lf", coordinateTransformAngle );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "coordinateTransformAngle in degrees = %lf", coordinateTransformAngle);
 
     return true;
 }
@@ -570,17 +644,22 @@ bool GDALCalculateCoordinateTransformationAngle( GDALDataset *poSrcDS, double &c
  */
 bool GDALTestSRS( GDALDataset *poDS )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot test SRS of the GDAL dataset.");
+        return false;
+    }
+
     char* pszPrj;
     OGRSpatialReference oSourceSRS, oTargetSRS;
     OGRCoordinateTransformation *poCT;
 
-    if( poDS == NULL )
-	return false;
-
-    if( poDS->GetProjectionRef() == NULL )
-	return false;
-    else
-	pszPrj = (char*) poDS->GetProjectionRef();
+    if(poDS->GetProjectionRef() == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Test SRS fails for the GDAL dataset.");
+        return false;
+    }
+    pszPrj = (char*) poDS->GetProjectionRef();
 
     oSourceSRS.importFromWkt( &pszPrj );
     oTargetSRS.SetWellKnownGeogCS( "WGS84" );
@@ -591,10 +670,14 @@ bool GDALTestSRS( GDALDataset *poDS )
 #endif /* GDAL_COMPUTE_VERSION */
 
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
+    if(poCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Test SRS fails for the GDAL dataset.");
+	    return false;
+    }
 
-    if( poCT == NULL )
-	return false;
     OGRCoordinateTransformation::DestroyCT( poCT );
+
     return true;
 }
 
@@ -606,6 +689,12 @@ bool GDALTestSRS( GDALDataset *poDS )
  */
 bool GDALHasNoData( GDALDataset *poDS, int band )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot check if GDAL dataset has NO_DATA values.");
+        return false;
+    }
+
     bool hasNDV = false;
     //check if poDS is NULL #lm
     int ncols = poDS->GetRasterXSize();
@@ -614,8 +703,11 @@ bool GDALHasNoData( GDALDataset *poDS, int band )
     double nDV;
 
     GDALRasterBand *poBand = poDS->GetRasterBand( band );
-    if( poBand == NULL )
-	return false;
+    if(poBand == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get raster band from GDAL dataset, Could not check if GDAL dataset has NO_DATA values.");
+        return false;
+    }
 
     int pbSuccess = 0;
     nDV = poBand->GetNoDataValue( &pbSuccess );
@@ -643,9 +735,12 @@ done:
 
 bool GDAL2AsciiGrid( GDALDataset *poDS, int band, AsciiGrid<double> &grid )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot convert from GDAL dataset to ascii grid dataset.");
+        return false;
+    }
 
-    if( poDS == NULL )
-	return false;
     //get some info from the ds
 
     int nXSize = poDS->GetRasterXSize();
@@ -662,7 +757,7 @@ bool GDAL2AsciiGrid( GDALDataset *poDS, int band, AsciiGrid<double> &grid )
     //check for non-square cells
     /*
     if( abs( adfGeoTransform[1] ) - abs( adfGeoTransform[5] ) > 0.0001 )
-	CPLDebug( "GDAL2AsciiGrid", "Non-uniform cells" );
+	CPLDebug("GDAL2AsciiGrid", "Non-uniform cells");
     */
 
     GDALRasterBand *poBand;
@@ -740,14 +835,16 @@ bool GDAL2AsciiGrid( GDALDataset *poDS, int band, AsciiGrid<double> &grid )
  */
 bool GDALTransformPoint( double &dfX, double &dfY, GDALDataset *poSrcDS, const char *pszDstWkt )
 {
-    if( poSrcDS == NULL )
+    if(poSrcDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point.");
         return false;
     }
 
     char* pszSrcWkt;
-    if( poSrcDS->GetProjectionRef() == NULL )
+    if(poSrcDS->GetProjectionRef() == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point.");
         return false;
     }
     pszSrcWkt = (char*)poSrcDS->GetProjectionRef();
@@ -766,14 +863,16 @@ bool GDALTransformPoint( double &dfX, double &dfY, GDALDataset *poSrcDS, const c
 
     OGRCoordinateTransformation *poCT;
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-    if( poCT == NULL )
+    if(poCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point.");
         return false;
     }
 
-    if( !poCT->Transform( 1, &dfX, &dfY ) )
+    if(!poCT->Transform(1, &dfX, &dfY))
     {
-        OGRCoordinateTransformation::DestroyCT( poCT );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
 
@@ -781,20 +880,24 @@ bool GDALTransformPoint( double &dfX, double &dfY, GDALDataset *poSrcDS, const c
     return true;
 }
 
-bool GDALPointFromLatLon( double &x, double &y, GDALDataset *poSrcDS,
-			  const char *datum )
+bool GDALPointFromLatLon(double &x, double &y, GDALDataset *poSrcDS, const char *datum)
 {
+    if(poSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point from lat lon.");
+        return false;
+    }
+
     char* pszPrj;
 
     OGRSpatialReference oSourceSRS, oTargetSRS;
     OGRCoordinateTransformation *poCT;
 
-    if( poSrcDS == NULL )
-	return false;
-
-    if( poSrcDS->GetProjectionRef() == NULL )
-	return false;
-    else
+    if(poSrcDS->GetProjectionRef() == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point from lat lon.");
+        return false;
+    }
 	pszPrj = (char*)poSrcDS->GetProjectionRef();
 
     oSourceSRS.SetWellKnownGeogCS( datum );
@@ -808,32 +911,41 @@ bool GDALPointFromLatLon( double &x, double &y, GDALDataset *poSrcDS,
 #endif /* GDAL_COMPUTE_VERSION */
 
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-    if( poCT == NULL )
-	return false;
+    if(poCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point from lat lon.");
+        return false;
+    }
 
-    if( !poCT->Transform( 1, &x, &y ) ) {
-	OGRCoordinateTransformation::DestroyCT( poCT );
-	return false;
+    if(!poCT->Transform(1, &x, &y))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point from lat lon.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
+        return false;
     }
 
     OGRCoordinateTransformation::DestroyCT( poCT );
     return true;
 }
 
-bool GDALPointToLatLon( double &x, double &y, GDALDataset *poSrcDS,
-				const char *datum )
+bool GDALPointToLatLon(double &x, double &y, GDALDataset *poSrcDS, const char *datum)
 {
+    if(poSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot transform point to lat lon.");
+        return false;
+    }
+
     char* pszPrj = NULL;
 
     OGRSpatialReference oSourceSRS, oTargetSRS;
     OGRCoordinateTransformation *poCT;
 
-    if( poSrcDS == NULL )
-	return false;
-
-    if( poSrcDS->GetProjectionRef() == NULL )
-	return false;
-    else
+    if(poSrcDS->GetProjectionRef() == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from GDAL dataset, Cannot transform point to lat lon.");
+        return false;
+    }
 	pszPrj = (char*)poSrcDS->GetProjectionRef();
 
     oSourceSRS.importFromWkt( &pszPrj );
@@ -847,29 +959,36 @@ bool GDALPointToLatLon( double &x, double &y, GDALDataset *poSrcDS,
 #endif /* GDAL_COMPUTE_VERSION */
 
     poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-
-    if( poCT == NULL )
-	return false;
-
-    if( !poCT->Transform( 1, &x, &y ) ) {
-	OGRCoordinateTransformation::DestroyCT( poCT );
-	return false;
+    if(poCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point to lat lon.");
+        return false;
     }
+
+    if(!poCT->Transform(1, &x, &y))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point to lat lon.");
+        OGRCoordinateTransformation::DestroyCT(poCT);
+        return false;
+    }
+
     OGRCoordinateTransformation::DestroyCT( poCT );
     return true;
 }
 
-bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS,
-                      const char *datum) {
+bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS, const char *datum)
+{
+    if(hDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid OGR dataset handle, Cannot transform point to lat lon.");
+        return false;
+    }
+
     char *pszPrj = NULL;
 
     const OGRSpatialReference *poSrcSRS;
     OGRSpatialReference oSourceSRS, oTargetSRS;
     OGRCoordinateTransformation *poCT;
-
-    if (hDS == NULL) {
-        return false;
-    }
 
     OGRLayer *poLayer;
 
@@ -877,7 +996,9 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS,
     poLayer->ResetReading();
 
     poSrcSRS = poLayer->GetSpatialRef();
-    if (poSrcSRS == NULL) {
+    if(poSrcSRS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get projection from OGR dataset, Cannot transform point to lat lon.");
         return false;
     }
     oSourceSRS = *poSrcSRS;
@@ -889,16 +1010,21 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS,
         oTargetSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     #endif /* GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,0,0) */
     #endif /* GDAL_COMPUTE_VERSION */
-    poCT = OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
 
-    if (poCT == NULL) {
+    poCT = OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
+    if(poCT == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Could not transform point to lat lon.");
         return false;
     }
 
-    if (!poCT->Transform(1, &x, &y)) {
+    if(!poCT->Transform(1, &x, &y))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Could not transform point to lat lon.");
         OGRCoordinateTransformation::DestroyCT(poCT);
         return false;
     }
+
     OGRCoordinateTransformation::DestroyCT(poCT);
     return true;
 }
@@ -912,12 +1038,19 @@ bool OGRPointToLatLon(double &x, double &y, OGRDataSourceH hDS,
  */
 int GDALGetUtmZone( GDALDataset *poDS )
 {
-    if( poDS == NULL )
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get UTM zone of the GDAL dataset.");
         return 0;
+    }
 
     double longitude = 0;
     double latitude = 0;
-    if( !GDALGetCenter( poDS, &longitude, &latitude ) ) return 0;
+    if(!GDALGetCenter(poDS, &longitude, &latitude))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get center of the GDAL dataset, Could not get UTM zone of the GDAL dataset.");
+        return 0;
+    }
 
     return GetUTMZoneInEPSG( longitude, latitude );
 }
@@ -999,9 +1132,10 @@ int GDALFillBandNoData(GDALDataset *poDS, int nBand, int nSearchPixels)
 {
     if(poDS == NULL)
     {
-        fprintf(stderr, "Invalid GDAL Dataset Handle, cannot fill no data\n");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot fill NO_DATA values of the GDAL dataset.");
         return -1;
     }
+
     int nPixels, nLines;
     nPixels = poDS->GetRasterXSize();
     nLines = poDS->GetRasterYSize();
@@ -1035,6 +1169,12 @@ int GDALFillBandNoData(GDALDataset *poDS, int nBand, int nSearchPixels)
 
 int GDALGetCorners( GDALDataset *poDS, double corners[8] )
 {
+    if(poDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot get corners of the GDAL dataset.");
+        return -1;
+    }
+
     //corners is northeast x, northeast y, southeast x, southeast y,
     //southwest x, southwest y, northwest x, northwest y
     double adfGeoTransform[6];
@@ -1083,7 +1223,7 @@ int GDALGetCorners( GDALDataset *poDS, double corners[8] )
 
 std::string FetchTimeZone( double dfX, double dfY, const char *pszWkt )
 {
-    CPLDebug( "WINDNINJA", "Fetching timezone for  %lf,%lf", dfX, dfY );
+    CPLDebug("WINDNINJA", "Fetching timezone for  %lf,%lf", dfX, dfY);
     if( pszWkt != NULL )
     {
         OGRSpatialReference oSourceSRS, oTargetSRS;
@@ -1100,16 +1240,14 @@ std::string FetchTimeZone( double dfX, double dfY, const char *pszWkt )
 #endif /* GDAL_COMPUTE_VERSION */
 
         poCT = OGRCreateCoordinateTransformation( &oSourceSRS, &oTargetSRS );
-        if( poCT == NULL )
+        if(poCT == NULL)
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "OGR coordinate transformation failed" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate OGRCoordinateTransformation, Failed to fetch timezone.");
             return std::string();
         }
-        if( !poCT->Transform( 1, &dfX, &dfY ) )
+        if(!poCT->Transform(1, &dfX, &dfY))
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "OGR coordinate transformation failed" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to transform point, Failed to fetch timezone.");
             return std::string();
         }
         OGRCoordinateTransformation::DestroyCT( poCT );
@@ -1125,10 +1263,9 @@ std::string FetchTimeZone( double dfX, double dfY, const char *pszWkt )
     oTzFile = "/vsizip/" + oTzFile + "/world/tz_world.shp";
 
     hDS = OGROpen( oTzFile.c_str(), 0, NULL );
-    if( hDS == NULL )
+    if(hDS == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to open datasource: %s", oTzFile.c_str() );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open datasource: %s, Failed to fetch timezone.", oTzFile.c_str());
         return std::string();
     }
     hLayer = OGR_DS_GetLayer( hDS, 0 );
@@ -1156,9 +1293,8 @@ std::string FetchTimeZone( double dfX, double dfY, const char *pszWkt )
     std::string oTimeZone;
     if( hFeature == NULL )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to find timezone.");
         oTimeZone = std::string();
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to find timezone" );
     }
     else
     {
@@ -1188,24 +1324,25 @@ std::string FetchTimeZone( double dfX, double dfY, const char *pszWkt )
 int NinjaOGRContain(const char *pszWkt, const char *pszFile,
                     const char *pszLayer)
 {
-    int bContains = FALSE;
-    if( pszWkt == NULL || pszFile == NULL )
+    if(pszWkt == NULL || pszFile == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NinjaOGRContain(), One or both inputs 'pszWkt' and 'pszFile' are NULL.");
         return FALSE;
     }
-    CPLDebug( "WINDNINJA", "Checking for containment of %s in %s:%s",
-              pszWkt, pszFile, pszLayer ? pszLayer : "" );
+
+    CPLDebug("WINDNINJA", "Checking for containment of %s in %s:%s", pszWkt, pszFile, pszLayer ? pszLayer : "");
+    int bContains = FALSE;
     OGRGeometryH hTestGeometry = NULL;
     int err = OGR_G_CreateFromWkt( (char**)&pszWkt, NULL, &hTestGeometry );
     if( hTestGeometry == NULL || err != CE_None )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NinjaOGRContain(), Failed to create geometry from input pszWkt '%s'.", pszWkt);
         return FALSE;
     }
     OGRDataSourceH hDS = OGROpen( pszFile, 0, NULL );
     if( hDS == NULL )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to open datasource: %s", pszFile );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open datasource: %s.", pszFile);
         OGR_G_DestroyGeometry( hTestGeometry );
         bContains = FALSE;
         return bContains;
@@ -1243,7 +1380,8 @@ int NinjaOGRContain(const char *pszWkt, const char *pszFile,
 
 // PCM - more GDAL utility functions. To distinguish them from the GDAL libs we us a 'gdal' prefix
 
-bool gdalHasGeographicSRS (const char* filename) {
+bool gdalHasGeographicSRS(const char* filename)
+{
     bool isGeographic = false;
     GDALDatasetH hDS = (GDALDatasetH) GDALOpen(filename, GA_ReadOnly);
     CPLAssert(hDS);
@@ -1258,8 +1396,8 @@ bool gdalHasGeographicSRS (const char* filename) {
 }
 
 // return UTM zone 1-60 or -1 if illegal input
-int gdalGetUtmZone (double lat, double lon) {
-
+int gdalGetUtmZone(double lat, double lon)
+{
     // handle special cases (Svalbard/Norway)
     if (lat > 55 && lat < 64 && lon > 2 && lon < 6) {
         return 32;
@@ -1283,6 +1421,7 @@ int gdalGetUtmZone (double lat, double lon) {
         return ((int)(lon / 6.0) % 60) + 1;
     }
 
+    CPLError(CE_Failure, CPLE_AppDefined, "Failed to get UTM zone.");
     return -1;
 }
 
@@ -1298,8 +1437,14 @@ int gdalGetUtmZone (double lat, double lon) {
  * @return true on success, false on failure
  *
  */
-bool GDALWarpToUtm (const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDstDS)
+bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDstDS)
 {
+    if(hSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to UTM.");
+        return false;
+    }
+
     /* parse options */
     GDALResampleAlg eAlg = GRA_NearestNeighbour;
 
@@ -1337,17 +1482,16 @@ bool GDALWarpToUtm (const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hD
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "GDALSuggestedWarpOutput failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALSuggestedWarpOutput failed, Could not warp GDAL dataset to UTM.");
         return false;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
 
     hDstDS = GDALCreate(hDriver, filename, nPixels, nLines, 
                         GDALGetRasterCount(hSrcDS), GDT_Float32, NULL);
-
     if(hDstDS == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Failed to create gdal dataset." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create GDAL dataset, Could not warp GDAL dataset to UTM.");
         return false;
     }
 
@@ -1408,7 +1552,7 @@ bool GDALWarpToUtm (const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hD
 
     if( eErr != CE_None )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp downloaded DEM." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to warp GDAL dataset to UTM.");
         CPLFree((void*)pszDstWKT);
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
@@ -1437,7 +1581,7 @@ bool GDALWarpToUtm (const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hD
     }
     if(nNoDataCount > 0)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Failed to fill all no data values." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to fill all NO_DATA values of warped GDAL dataset.");
         return false;
     }
 
@@ -1451,7 +1595,14 @@ bool GDALWarpToUtm (const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hD
 
 // turn provided data set into a GeoTiff with UTM projection
 // returning NULL indicates error
-GDALDataset* gdalWarpToUtm (const char* filename, GDALDataset* pSrcDS) {
+GDALDataset* gdalWarpToUtm(const char* filename, GDALDataset* pSrcDS)
+{
+    if(pSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to UTM.");
+        return NULL;
+    }
+
     GDALDataset* pDstDS = NULL;
     double lat, lon;
     if (pSrcDS != NULL && GDALGetCenter( pSrcDS, &lon, &lat)) {
@@ -1507,21 +1658,27 @@ GDALDataset* gdalWarpToUtm (const char* filename, GDALDataset* pSrcDS) {
  */
 bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDALDatasetH& hDstDS, const char *pszDstWkt )
 {
+    if(hSrcDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid GDAL dataset handle, Cannot warp GDAL dataset to WKT.");
+        return false;
+    }
+
     //if(hDstDS != NULL)  // this didn't work as a good checking method
     //{
-    //    CPLError( CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input hDstDS is NOT NULL, it was input pre-filled!" );
+    //    CPLError(CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input hDstDS is NOT NULL, it was input pre-filled!");
     //    return false;
     //}
 
     int nBandCount = GDALGetRasterCount( hSrcDS );
     if( band <= 0 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input band is <= 0." );
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input band is <= 0.");
         return false;
     }
     if( band > nBandCount )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input band %i is > nBands of the dataset.", band );
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALWarpToWKT_GDALAutoCreateWarpedVRT() input band %i is > nBands of the dataset.", band);
         return false;
     }
 
@@ -1565,14 +1722,12 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
         psWarpOptions->papszWarpOptions = CSLSetNameValue( psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str() );
     }
 
-
     hDstDS = GDALAutoCreateWarpedVRT( hSrcDS, pszSrcWkt, pszDstWkt,
                                       GRA_NearestNeighbour, 1.0,
                                       psWarpOptions );
-
     if(hDstDS == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Warp operation failed!" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to warp GDAL dataset to WKT.");
         return false;
     }
 
@@ -1580,5 +1735,4 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
 
     return true;
 }
-
 

--- a/src/ninja/genericSurfInitialization.cpp
+++ b/src/ninja/genericSurfInitialization.cpp
@@ -136,6 +136,14 @@ int genericSurfInitialization::getEndHour()
 */
 void genericSurfInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -157,7 +165,6 @@ void genericSurfInitialization::checkForValidData()
     }
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -177,10 +184,9 @@ void genericSurfInitialization::checkForValidData()
 
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() )
             throw badForecastFile("Forecast file doesn't have projection information.");
 
@@ -365,27 +371,20 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw();
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw()
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( poDS == NULL ) {
-        CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else
-        GDALClose((GDALDatasetH) poDS );
+    GDALClose((GDALDatasetH) poDS);
 
     // open ds one by one and warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
@@ -407,16 +406,12 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
-            //throw
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
         }
 
         /*
@@ -460,7 +455,7 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -469,6 +464,10 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,
                                                         1.0, psWarpOptions );
+        if(wrpDS == NULL)
+        {
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+        }
 
         if( varList[i] == "Temperature_height_above_ground" ) {
             GDAL2AsciiGrid( wrpDS, bandNum, airGrid );

--- a/src/ninja/genericSurfInitialization.cpp
+++ b/src/ninja/genericSurfInitialization.cpp
@@ -371,18 +371,18 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
     if( poDS == NULL ) {
-        throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS);
 
@@ -406,12 +406,12 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
         if( srcWkt.empty() ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
         /*

--- a/src/ninja/landfireclient.cpp
+++ b/src/ninja/landfireclient.cpp
@@ -57,7 +57,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     (void)resolution;
     if( NULL == filename )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "LandfireClient::FetchBoundingBox(), Input filename is NULL.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input, The input filename is NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
 
@@ -146,7 +146,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     CPLFree( (void*)pszProduct );
     CPLDebug("LCP_CLIENT", "Request URL: %s", pszUrl);
     m_poResult = CPLHTTPFetch( pszUrl, NULL );
-    CHECK_HTTP_RESULT( "Failed to get download URL" );
+    CHECK_HTTP_RESULT("Failed to get download URL.");
 
     if( strstr((const char*)m_poResult->pabyData, "\"success\":\"false\"") )
     {
@@ -194,7 +194,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     do
     {
         m_poResult = CPLHTTPFetch( pszUrl, NULL );
-        CHECK_HTTP_RESULT( "Failed to get job status" );
+        CHECK_HTTP_RESULT("Failed to get job status.");
         papszTokens = CSLTokenizeString2( (const char*)m_poResult->pabyData, ",:",
                                           CSLT_HONOURSTRINGS | CSLT_PRESERVEESCAPES |
                                           CSLT_STRIPENDSPACES | CSLT_STRIPLEADSPACES );
@@ -235,14 +235,14 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
         CPLHTTPDestroyResult( m_poResult );
         return SURF_FETCH_E_TIMEOUT;
     }
-    CHECK_HTTP_RESULT( "Failed to get job status" ); 
+    CHECK_HTTP_RESULT("Failed to get job status.");
 
     /*-----------------------------------------------------------------------------
      *  Download the landfire model
      *-----------------------------------------------------------------------------*/
     pszUrl = downloadUrl.c_str();
     m_poResult = CPLHTTPFetch( pszUrl, NULL );
-    CHECK_HTTP_RESULT( "Failed to get job status" );
+    CHECK_HTTP_RESULT("Failed to get job status.");
 
     nSize = m_poResult->nDataLen;
     VSILFILE *fout;
@@ -252,7 +252,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     fout = VSIFOpenL( pszTmpZip, "w+" );
     if( NULL == fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open lcp file for writing, Failed to create output file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create final output file for writing, download failed.");
         CPLHTTPDestroyResult( m_poResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -331,7 +331,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(nNoDataCount > 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "LandfireClient::FetchBoundingBox() after downloading, found '%d' noDataValues", nNoDataCount);
+        CPLError(CE_Failure, CPLE_AppDefined, "Final downloaded elevation file contains '%d' noDataValues", nNoDataCount);
     }
     return nNoDataCount;
 }

--- a/src/ninja/landfireclient.cpp
+++ b/src/ninja/landfireclient.cpp
@@ -57,6 +57,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     (void)resolution;
     if( NULL == filename )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "LandfireClient::FetchBoundingBox(), Input filename is NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
 
@@ -109,7 +110,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
         }
         else
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "Failed to locate product.");
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to locate product. Requested DEM is outside of the Landfire client bounds.");
             return SURF_FETCH_E_BOUNDS_ERR;
         }
     }
@@ -251,7 +252,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     fout = VSIFOpenL( pszTmpZip, "w+" );
     if( NULL == fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create output file");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open lcp file for writing, Failed to create output file.");
         CPLHTTPDestroyResult( m_poResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -328,6 +329,10 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
         VSIUnlink( pszTmpZip );
     }
 
+    if(nNoDataCount > 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "LandfireClient::FetchBoundingBox() after downloading, found '%d' noDataValues", nNoDataCount);
+    }
     return nNoDataCount;
 }
 

--- a/src/ninja/landfireclient.cpp
+++ b/src/ninja/landfireclient.cpp
@@ -60,15 +60,11 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
         return SURF_FETCH_E_BAD_INPUT;
     }
 
-    /*
-    ** We have an arbitrary limit on request size, 0.001 degrees
-    */
+    // We have an arbitrary limit on request size, 0.001 degrees, 111 meters (roughly 364 feet)
     if( fabs( bbox[0] - bbox[2] ) < 0.001 || fabs( bbox[1] - bbox[3] ) < 0.001 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Bounding box too small, must be greater than " \
-                  "0.001 x 0.001 degrees." );
-        return SURF_FETCH_E_BAD_INPUT;
+        CPLError(CE_Failure, CPLE_AppDefined, "Bounding box too small, must be greater than 0.001 x 0.001 degrees.");
+        return SURF_FETCH_E_BOUNDS_ERR;
     }
 
     /*-----------------------------------------------------------------------------
@@ -93,8 +89,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
                                bbox[1], bbox[0], bbox[3], bbox[0],
                                bbox[3], bbox[2], bbox[1], bbox[2],
                                bbox[1], bbox[0] );
-        CPLDebug( "LCP_CLIENT", "Testing if %s contains %s", osDataPath.c_str(),
-                  pszGeom );
+        CPLDebug("LCP_CLIENT", "Testing if %s contains %s", osDataPath.c_str(), pszGeom);
         //using same code for all geographic areas, but could update by region as updates
         //become available. See codes at https://lfps.usgs.gov/products
         if( NinjaOGRContain( pszGeom, osDataPath.c_str(), "conus" ) )
@@ -114,12 +109,11 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
         }
         else
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Failed to locate product." );
-            return SURF_FETCH_E_BAD_INPUT;
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to locate product.");
+            return SURF_FETCH_E_BOUNDS_ERR;
         }
     }
-    CPLDebug( "LCP_CLIENT", "Using product: %s", pszProduct );
+    CPLDebug("LCP_CLIENT", "Using product: %s", pszProduct);
     const char *pszUrl;
 
     const char *pszTemp = CSLFetchNameValue( options, "OVERRIDE_BEST_UTM" );
@@ -138,9 +132,9 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     */
     if( nEpsgCode < 1 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Invalid EPSG code." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid EPSG code.");
         CPLFree( (void*)pszProduct );
-        return SURF_FETCH_E_BAD_INPUT;
+        return SURF_FETCH_E_BOUNDS_ERR;
     }
 
     /*-----------------------------------------------------------------------------
@@ -149,44 +143,41 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     pszUrl = CPLSPrintf( LF_REQUEST_TEMPLATE, nEpsgCode, pszProduct, bbox[3], bbox[2], bbox[1],
                                               bbox[0] );
     CPLFree( (void*)pszProduct );
+    CPLDebug("LCP_CLIENT", "Request URL: %s", pszUrl);
     m_poResult = CPLHTTPFetch( pszUrl, NULL );
     CHECK_HTTP_RESULT( "Failed to get download URL" );
-    CPLDebug( "LCP_CLIENT", "Request URL: %s", pszUrl );
 
     if( strstr((const char*)m_poResult->pabyData, "\"success\":\"false\"") )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                 "Landfire server returned error: %s",
-                 (const char*)m_poResult->pabyData );
+        CPLError(CE_Failure, CPLE_AppDefined, "Landfire server returned error: %s", (const char*)m_poResult->pabyData);
         CPLHTTPDestroyResult(m_poResult);
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_TIMEOUT;
     }
 
      /*-----------------------------------------------------------------------------
      *  Parse the JSON result of the request
      *-----------------------------------------------------------------------------*/
-    CPLDebug( "LCP_CLIENT", "JSON Response: %s", m_poResult->pabyData );
+    CPLDebug("LCP_CLIENT", "JSON Response: %s", m_poResult->pabyData);
 
     char **papszTokens = NULL;
     papszTokens = CSLTokenizeString2( (const char*)m_poResult->pabyData, ",:",
                                       CSLT_HONOURSTRINGS | CSLT_PRESERVEESCAPES |
                                       CSLT_STRIPENDSPACES | CSLT_STRIPLEADSPACES );
     int nTokens = CSLCount( papszTokens );
-    CPLDebug( "LCP_CLIENT", "papszTokens[0]: %s", papszTokens[0]);
-    CPLDebug( "LCP_CLIENT", "papszTokens[1]: %s", papszTokens[1]);
-    CPLDebug( "LCP_CLIENT", "papszTokens[2]: %s", papszTokens[2]);
-    CPLDebug( "LCP_CLIENT", "papszTokens[3]: %s", papszTokens[3]);
+    CPLDebug("LCP_CLIENT", "papszTokens[0]: %s", papszTokens[0]);
+    CPLDebug("LCP_CLIENT", "papszTokens[1]: %s", papszTokens[1]);
+    CPLDebug("LCP_CLIENT", "papszTokens[2]: %s", papszTokens[2]);
+    CPLDebug("LCP_CLIENT", "papszTokens[3]: %s", papszTokens[3]);
 
     m_JobId = std::string(papszTokens[1]);
-    CPLDebug( "LCP_CLIENT", "m_JobId: %s", m_JobId.c_str());
+    CPLDebug("LCP_CLIENT", "m_JobId: %s", m_JobId.c_str());
 
     if( nTokens < 4)
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to generate valid URL for LCP download." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to generate valid URL for LCP download.");
         CPLHTTPDestroyResult( m_poResult );
         CSLDestroy( papszTokens );
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_TIMEOUT;
     }
 
     /*-----------------------------------------------------------------------------
@@ -196,9 +187,9 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     int nSize = 0;
     bool downloadReady = false;
     bool downloadFailed = false;
-    CPLDebug( "LCP_CLIENT", "m_JobId: %s", m_JobId.c_str());
+    CPLDebug("LCP_CLIENT", "m_JobId: %s", m_JobId.c_str());
     pszUrl = CPLStrdup(CPLSPrintf( LF_GET_STATUS_TEMPLATE, m_JobId.c_str() ));
-    CPLDebug( "LCP_CLIENT", "Status url: %s", pszUrl );
+    CPLDebug("LCP_CLIENT", "Status url: %s", pszUrl);
     do
     {
         m_poResult = CPLHTTPFetch( pszUrl, NULL );
@@ -208,7 +199,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
                                           CSLT_STRIPENDSPACES | CSLT_STRIPLEADSPACES );
         int nTokens = CSLCount( papszTokens );
 
-        CPLDebug( "LCP_CLIENT", "papszTokens[3]: %s", papszTokens[3]);
+        CPLDebug("LCP_CLIENT", "papszTokens[3]: %s", papszTokens[3]);
 
         if(EQUAL( papszTokens[5], "Succeeded" )) {
           downloadReady = true;
@@ -217,8 +208,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
           downloadFailed = true;
         }
 
-        CPLDebug( "LCP_CLIENT", "Attempting to fetch LCP, try %d of %d, jobStatus: %s", i,
-            nMaxTries, papszTokens[3] );
+        CPLDebug("LCP_CLIENT", "Attempting to fetch LCP, try %d of %d, jobStatus: %s", i, nMaxTries, papszTokens[3]);
 
         std::string strLCPTest = papszTokens[nTokens - 1];
         strLCPTest.pop_back(); // Removes the last character '}'
@@ -234,18 +224,13 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(downloadFailed)
     {
-        CPLError( CE_Warning, CPLE_AppDefined, "Failed to download lcp," \
-                                               "There was an extraction " \
-                                               "error on the server." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to download lcp, There was an extraction error on the server.");
         CPLHTTPDestroyResult( m_poResult );
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_TIMEOUT;
     }
     else if( !downloadReady )
     {
-        CPLError( CE_Warning, CPLE_AppDefined, "Failed to download lcp, timed " \
-                                               "out.  Try increasing " \
-                                               "LCP_MAX_DOWNLOAD_TRIES or "
-                                               "LCP_DOWNLOAD_WAIT" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to download lcp, timed out.\nTry increasing LCP_MAX_DOWNLOAD_TRIES or LCP_DOWNLOAD_WAIT");
         CPLHTTPDestroyResult( m_poResult );
         return SURF_FETCH_E_TIMEOUT;
     }
@@ -266,7 +251,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     fout = VSIFOpenL( pszTmpZip, "w+" );
     if( NULL == fout )
     {
-        CPLError( CE_Warning, CPLE_AppDefined, "Failed to create output file" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create output file");
         CPLHTTPDestroyResult( m_poResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -281,7 +266,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     char **papszFileList = NULL;
     std::string osPathInZip;
     const char *pszVSIZip = CPLSPrintf( "/vsizip/%s", pszTmpZip );
-    CPLDebug( "LCP_CLIENT", "Extracting .tif from %s", pszVSIZip );
+    CPLDebug("LCP_CLIENT", "Extracting .tif from %s", pszVSIZip);
     papszFileList = VSIReadDirRecursive( pszVSIZip );
     int bFound = FALSE;
     std::string osFullPath;
@@ -298,8 +283,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     CSLDestroy( papszFileList );
     if( !bFound )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to find .tif in archive" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to find .tif in archive");
         VSIUnlink( pszTmpZip );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -308,8 +292,7 @@ SURF_FETCH_E LandfireClient::FetchBoundingBox( double *bbox, double resolution,
     nError = ExtractFileFromZip( pszTmpZip, pszFileToFind, filename );
     if( nError )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to extract .tif from zip." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to extract .tif from zip.");
         VSIUnlink( pszTmpZip );
         return SURF_FETCH_E_IO_ERR;
     }

--- a/src/ninja/landfireclient.h
+++ b/src/ninja/landfireclient.h
@@ -76,9 +76,9 @@
 #define CHECK_HTTP_RESULT( error_msg )                      \
     if( m_poResult == NULL || m_poResult->nStatus != 0 )    \
     {                                                       \
-        CPLError( CE_Warning, CPLE_AppDefined, error_msg ); \
+        CPLError(CE_Warning, CPLE_AppDefined, error_msg);   \
         CPLHTTPDestroyResult( m_poResult );                 \
-        return SURF_FETCH_E_IO_ERR;                         \
+        return SURF_FETCH_E_TIMEOUT;                        \
     }
 
 /*-----------------------------------------------------------------------------

--- a/src/ninja/ncepGfsSurfInitialization.cpp
+++ b/src/ninja/ncepGfsSurfInitialization.cpp
@@ -438,18 +438,18 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
     if( poDS == NULL ) {
-        throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS);
 
@@ -475,7 +475,7 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         /*

--- a/src/ninja/ncepGfsSurfInitialization.cpp
+++ b/src/ninja/ncepGfsSurfInitialization.cpp
@@ -145,6 +145,14 @@ int ncepGfsSurfInitialization::getEndHour()
 */
 void ncepGfsSurfInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -166,7 +174,6 @@ void ncepGfsSurfInitialization::checkForValidData()
     }
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -186,10 +193,9 @@ void ncepGfsSurfInitialization::checkForValidData()
 
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         srcWkt = srcDS->GetProjectionRef();
-
         //see note
         //if( srcWkt.empty() )
         //    throw badForecastFile("Forecast file doesn't have projection information.");
@@ -432,27 +438,20 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "ncepGfsSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw();
+            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "ncepGfsSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw()
+            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( poDS == NULL ) {
-        CPLDebug( "ncepGfsSurfInitialization::setSurfaceGrids()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else
-        GDALClose((GDALDatasetH) poDS );
+    GDALClose((GDALDatasetH) poDS);
 
     // open ds one by one and warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
@@ -476,8 +475,7 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            CPLDebug( "ncepGfsSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepGfsSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         /*
@@ -541,7 +539,7 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -550,8 +548,7 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 GRA_NearestNeighbour, 1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
-            throw badForecastFile("Could not warp the forecast file, "
-                                  "possibly non-uniform grid.");
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
         }
 
         if( varList[i] == "Temperature_height_above_ground" ) {

--- a/src/ninja/ncepHrrrSurfInitialization.cpp
+++ b/src/ninja/ncepHrrrSurfInitialization.cpp
@@ -158,7 +158,8 @@ bool ncepHrrrSurfInitialization::identify( std::string fileName )
     GDALDataset *srcDS = (GDALDataset*)GDALOpenShared( fileName.c_str(), GA_ReadOnly );
 
     if( srcDS == NULL ) {
-        CPLDebug( "ncepHRRRSurfaceInitialization::identify()", "Bad forecast file" );
+        //CPLError(CE_Warning, CPLE_AppDefined, "ncepHRRRSurfaceInitialization::identify(), Bad forecast file.");
+        CPLDebug("HRRR", "ncepHRRRSurfaceInitialization::identify(), Bad forecast file.");
         return false;
 
     } else {
@@ -199,10 +200,8 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( srcDS == NULL ) {
-        CPLDebug( "ncepHRRRSurfaceInitialization::identify()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
 
     GDALRasterBand *poBand;
@@ -222,7 +221,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     {
         if(input.ninjaTime == timeList[i])
         {
-            cout<<"input.ninjaTime = "<<input.ninjaTime<<endl;
+            CPLDebug("HRRR", "input.ninjaTime = '%s'", input.ninjaTime.to_string().c_str());
             for(unsigned int j = 1; j <= srcDS->GetRasterCount(); j++)
             { 
                 poBand = srcDS->GetRasterBand( j );
@@ -241,7 +240,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                         } else if (bandName != "Temperature [K]") {
                             bandList.push_back( j);  // 2t
                         } else {
-                            cout << "skipping unsupported forecast temperature unit: " << bandName << endl;
+                            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "skipping unsupported forecast temperature unit: '%s'", bandName.c_str());
                         }
                     }
                 }
@@ -301,7 +300,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
     if(bandList.size() < 4) {
         GDALClose((GDALDatasetH) srcDS );
-        throw std::runtime_error("Not enough bands detected in HRRR forecast file.");
+        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Not enough bands detected in HRRR forecast file.");
     }
 
     std::string dstWkt;
@@ -314,6 +313,11 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     GDALWarpOptions* psWarpOptions;
 
     srcWkt = srcDS->GetProjectionRef();
+    if(srcWkt.empty())
+    {
+        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+    }
+
     psWarpOptions = GDALCreateWarpOptions();
 
     int nBandCount = bandList.size();
@@ -360,7 +364,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         // direct calculation of FROM wx TO dem, already has the appropriate sign
         if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
         {
-            printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
         }
     }
 
@@ -368,6 +372,11 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                                     dstWkt.c_str(),
                                                     GRA_NearestNeighbour,
                                                     1.0, psWarpOptions );
+    if(wrpDS == NULL)
+    {
+        throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+    }
+
     std::vector<std::string> varList = getVariableList();
 
     for( unsigned int i = 0; i < varList.size(); i++ ) {

--- a/src/ninja/ncepHrrrSurfInitialization.cpp
+++ b/src/ninja/ncepHrrrSurfInitialization.cpp
@@ -201,7 +201,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
     if( srcDS == NULL ) {
-        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
 
     GDALRasterBand *poBand;
@@ -300,7 +300,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
     if(bandList.size() < 4) {
         GDALClose((GDALDatasetH) srcDS );
-        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Not enough bands detected in HRRR forecast file.");
+        throw std::runtime_error("Not enough bands detected in HRRR forecast file.");
     }
 
     std::string dstWkt;
@@ -315,7 +315,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     srcWkt = srcDS->GetProjectionRef();
     if(srcWkt.empty())
     {
-        throw std::runtime_error("ncepHRRRSurfaceInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+        throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
     psWarpOptions = GDALCreateWarpOptions();

--- a/src/ninja/ncepNamAlaskaSurfInitialization.cpp
+++ b/src/ninja/ncepNamAlaskaSurfInitialization.cpp
@@ -129,6 +129,14 @@ int ncepNamAlaskaSurfInitialization::getEndHour()
 */
 void ncepNamAlaskaSurfInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -150,7 +158,6 @@ void ncepNamAlaskaSurfInitialization::checkForValidData()
     }
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -170,10 +177,9 @@ void ncepNamAlaskaSurfInitialization::checkForValidData()
 
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() )
             throw badForecastFile("Forecast file doesn't have projection information.");
 
@@ -407,27 +413,20 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "ncepNamAlaskaSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw();
+            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "ncepNamAlaskaSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw()
+            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( poDS == NULL ) {
-        CPLDebug( "ncepNamAlaskaSurfInitialization::setSurfaceGrids()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else
-        GDALClose((GDALDatasetH) poDS );
+    GDALClose((GDALDatasetH) poDS);
 
     // open ds one by one and warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
@@ -449,16 +448,12 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            CPLDebug( "ncepNamAlaskaSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() ) {
-            CPLDebug( "ncepNamAlaskaSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
-            //throw
+            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
         }
 
     /*
@@ -507,19 +502,18 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
 
         wrpDS = (GDALDataset*) GDALAutoCreateWarpedVRT( srcDS, srcWkt.c_str(), dstWkt.c_str(),
                 GRA_NearestNeighbour, 1.0, psWarpOptions );
-
         if(wrpDS == NULL)
         {
-            throw badForecastFile("Could not warp the forecast file, "
-                                  "possibly non-uniform grid.");
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
         }
+
     if( varList[i] == "Temperature_height_above_ground" ) {
             GDAL2AsciiGrid( wrpDS, bandNum, airGrid );
         if( std::isnan( dfNoData ) ) {

--- a/src/ninja/ncepNamAlaskaSurfInitialization.cpp
+++ b/src/ninja/ncepNamAlaskaSurfInitialization.cpp
@@ -413,18 +413,18 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
     if( poDS == NULL ) {
-        throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS);
 
@@ -448,12 +448,12 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
         if( srcWkt.empty() ) {
-            throw std::runtime_error("ncepNamAlaskaSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
     /*

--- a/src/ninja/ncepNamGrib2SurfInitialization.cpp
+++ b/src/ninja/ncepNamGrib2SurfInitialization.cpp
@@ -229,8 +229,16 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         srcDS = (GDALDataset*)GDALOpenShared(
         input.forecastFilename.c_str(), GA_ReadOnly );
     }
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("ncepNamGrib2SurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+    }
 
     srcWkt = srcDS->GetProjectionRef();
+    if(srcWkt.empty())
+    {
+        throw std::runtime_error("ncepNamGrib2SurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+    }
 
     GDALRasterBand *poBand = srcDS->GetRasterBand( 9 );
     int pbSuccess;
@@ -276,7 +284,7 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         // direct calculation of FROM wx TO dem, already has the appropriate sign
         if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
         {
-            printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
         }
     }
 
@@ -284,6 +292,10 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                                     dstWkt.c_str(),
                                                     GRA_NearestNeighbour,
                                                     1.0, psWarpOptions );
+    if(wrpDS == NULL)
+    {
+        throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+    }
 
     std::vector<std::string> varList = getVariableList();
 

--- a/src/ninja/ncepNamGrib2SurfInitialization.cpp
+++ b/src/ninja/ncepNamGrib2SurfInitialization.cpp
@@ -231,13 +231,13 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     }
     if(srcDS == NULL)
     {
-        throw std::runtime_error("ncepNamGrib2SurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
 
     srcWkt = srcDS->GetProjectionRef();
     if(srcWkt.empty())
     {
-        throw std::runtime_error("ncepNamGrib2SurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+        throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
     GDALRasterBand *poBand = srcDS->GetRasterBand( 9 );

--- a/src/ninja/ncepNamSurfInitialization.cpp
+++ b/src/ninja/ncepNamSurfInitialization.cpp
@@ -412,18 +412,18 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
     if( poDS == NULL ) {
-        throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS);
 
@@ -447,12 +447,12 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
         if( srcWkt.empty() ) {
-            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
         /*

--- a/src/ninja/ncepNamSurfInitialization.cpp
+++ b/src/ninja/ncepNamSurfInitialization.cpp
@@ -129,6 +129,14 @@ int ncepNamSurfInitialization::getEndHour()
 */
 void ncepNamSurfInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -150,7 +158,6 @@ void ncepNamSurfInitialization::checkForValidData()
     }
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -170,10 +177,9 @@ void ncepNamSurfInitialization::checkForValidData()
 
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() )
             throw badForecastFile("Forecast file doesn't have projection information.");
 
@@ -406,27 +412,20 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "ncepNamSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw();
+            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "ncepNamSurfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw()
+            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( poDS == NULL ) {
-        CPLDebug( "ncepNamSurfInitialization::setSurfaceGrids()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else
-        GDALClose((GDALDatasetH) poDS );
+    GDALClose((GDALDatasetH) poDS);
 
     // open ds one by one and warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
@@ -448,16 +447,12 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            CPLDebug( "ncepNamSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() ) {
-            CPLDebug( "ncepNamSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
-            //throw
+            throw std::runtime_error("ncepNamSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
         }
 
         /*
@@ -505,7 +500,7 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -520,8 +515,7 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                                         1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
-            throw badForecastFile("Could not warp the forecast file, "
-                                  "possibly non-uniform grid.");
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
         }
 
         if( varList[i] == "Temperature_height_above_ground" ) {

--- a/src/ninja/ncepNdfdInitialization.cpp
+++ b/src/ninja/ncepNdfdInitialization.cpp
@@ -155,6 +155,14 @@ int ncepNdfdInitialization::getEndHour()
 */
 void ncepNdfdInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -194,7 +202,6 @@ void ncepNdfdInitialization::checkForValidData()
 
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -214,10 +221,9 @@ void ncepNdfdInitialization::checkForValidData()
 
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() )
             throw badForecastFile("Forecast file doesn't have projection information.");
 
@@ -545,27 +551,20 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw();
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            //throw()
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose( (GDALDatasetH)poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
-
     if( poDS == NULL ) {
-        CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                "Bad forecast file" );
+        throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else
-        GDALClose( (GDALDatasetH)poDS );
+    GDALClose((GDALDatasetH) poDS);
 
     // open ds one by one and warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
@@ -587,16 +586,12 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
-
         if( srcWkt.empty() ) {
-            CPLDebug( "ncepNdfdInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
-            //throw
+            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
         }
 
     GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
@@ -639,7 +634,7 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -648,8 +643,7 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
                 GRA_NearestNeighbour, 1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
-            throw badForecastFile("Could not warp the forecast file, "
-                                  "possibly non-uniform grid.");
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
         }
 
         //if(varList[i] == "Maximum_temperature_height_above_ground_12_Hour_Maximum")

--- a/src/ninja/ncepNdfdInitialization.cpp
+++ b/src/ninja/ncepNdfdInitialization.cpp
@@ -551,18 +551,18 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose( (GDALDatasetH)poDS );
     }
 
     poDS = (GDALDataset*)GDALOpen( input.forecastFilename.c_str(), GA_ReadOnly );
     if( poDS == NULL ) {
-        throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS);
 
@@ -586,12 +586,12 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
 
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         if( srcDS == NULL ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         srcWkt = srcDS->GetProjectionRef();
         if( srcWkt.empty() ) {
-            throw std::runtime_error("ncepNdfdInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
     GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );

--- a/src/ninja/ncepRapSurfInitialization.cpp
+++ b/src/ninja/ncepRapSurfInitialization.cpp
@@ -393,18 +393,18 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
             //try to open original
             poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
             if( poDS == NULL ) {
-                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
+                throw std::runtime_error("Could not open input dem file.");
             }
             dstWkt = poDS->GetProjectionRef();
             if( dstWkt.empty() ) {
-                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+                throw std::runtime_error("Could not get projection reference from input dem file.");
             }
             GDALClose((GDALDatasetH) poDS );
         }
 
         poDS = (GDALDataset*)GDALOpenShared( wxModelFileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+            throw std::runtime_error("Could not open forecast file, bad forecast file.");
         }
         GDALClose((GDALDatasetH) poDS);
 
@@ -426,12 +426,12 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
 
             srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
             if( srcDS == NULL ) {
-                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+                throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
             }
 
             srcWkt = srcDS->GetProjectionRef();
             if( srcWkt.empty() ) {
-                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+                throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
             }
 
         /*

--- a/src/ninja/ncepRapSurfInitialization.cpp
+++ b/src/ninja/ncepRapSurfInitialization.cpp
@@ -130,6 +130,14 @@ int ncepRapSurfInitialization::getEndHour()
 */
 void ncepRapSurfInitialization::checkForValidData()
 {
+    GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
     //just make up a "dummy" timezone for use here
     boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
 
@@ -151,7 +159,6 @@ void ncepRapSurfInitialization::checkForValidData()
     }
 
     // open ds variable by variable
-    GDALDataset *srcDS;
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -172,10 +179,9 @@ void ncepRapSurfInitialization::checkForValidData()
 
             srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
             if( srcDS == NULL )
-                throw badForecastFile("Cannot open forecast file.");
+                throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
             srcWkt = srcDS->GetProjectionRef();
-
             if( srcWkt.empty() )
                 throw badForecastFile("Forecast file doesn't have projection information.");
 
@@ -387,27 +393,20 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
             //try to open original
             poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
             if( poDS == NULL ) {
-                CPLDebug( "ncepRAPSurfInitialization::setSurfaceGrids()",
-                        "Bad projection reference" );
-                //throw();
+                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not open input dem file.");
             }
             dstWkt = poDS->GetProjectionRef();
             if( dstWkt.empty() ) {
-                CPLDebug( "ncepRAPSurfInitialization::setSurfaceGrids()",
-                        "Bad projection reference" );
-                //throw()
+                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
             }
             GDALClose((GDALDatasetH) poDS );
         }
 
         poDS = (GDALDataset*)GDALOpenShared( wxModelFileName.c_str(), GA_ReadOnly );
-
         if( poDS == NULL ) {
-            CPLDebug( "ncepRAPSurfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
         }
-        else
-            GDALClose((GDALDatasetH) poDS );
+        GDALClose((GDALDatasetH) poDS);
 
         // open ds one by one and warp, then write to grid
         GDALDataset *srcDS, *wrpDS;
@@ -427,16 +426,12 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
 
             srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
             if( srcDS == NULL ) {
-                CPLDebug( "ncepRAPSurfInitialization::setSurfaceGrids()",
-                        "Bad forecast file" );
+                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
             }
 
             srcWkt = srcDS->GetProjectionRef();
-
             if( srcWkt.empty() ) {
-                CPLDebug( "ncepRAPSurfInitialization::setSurfaceGrids()",
-                        "Bad forecast file" );
-                //throw
+                throw std::runtime_error("ncepRAPSurfInitialization::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
             }
 
         /*
@@ -487,7 +482,7 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -498,8 +493,7 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
                                                         1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
-            throw badForecastFile("Could not warp the forecast file, "
-                                  "possibly non-uniform grid.");
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
         }
 
         if( varList[i] == "Temperature_height_above_ground" ) {

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -124,9 +124,41 @@ int ninjaTools::fetchDEMBBox(double *boundsBox, const char *fileName, double res
     if(result < 0)
     {
         //Com->ninjaCom(ninjaComClass::ninjaFailure, "Exception caught: %s", e.what());
-        Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), fetching failed!");
+
+        if(result == SURF_FETCH_E_IO_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_IO_ERR, Failure opening a dataset.");
+        }
+        else if(result == SURF_FETCH_E_BOUNDS_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.");
+        }
+        else if(result == SURF_FETCH_E_WARPER_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.");
+        }
+        else if(result == SURF_FETCH_E_BAD_INPUT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.");
+        }
+        else if(result == SURF_FETCH_E_SIZE_LIMIT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.");
+        }
+        //else if(result == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
+        //{
+        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.");
+        //}
+        else if(result == SURF_FETCH_E_TIMEOUT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.");
+        }
+        else
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nUnknown error occurred during fetch.");
+        }
         delete fetcher;
-        return NINJA_E_INVALID;
+        return result;
     }
     delete fetcher;
     return NINJA_SUCCESS;
@@ -178,9 +210,41 @@ int ninjaTools::fetchDEMPoint(double * adfPoint,double *adfBuff, const char* uni
     if(result < 0)
     {
         //Com->ninjaCom(ninjaComClass::ninjaFailure, "Exception caught: %s", e.what());
-        Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), fetching failed!");
+
+        if(result == SURF_FETCH_E_IO_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_IO_ERR, Failure opening a dataset.");
+        }
+        else if(result == SURF_FETCH_E_BOUNDS_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.");
+        }
+        else if(result == SURF_FETCH_E_WARPER_ERR)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.");
+        }
+        else if(result == SURF_FETCH_E_BAD_INPUT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.");
+        }
+        else if(result == SURF_FETCH_E_SIZE_LIMIT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.");
+        }
+        //else if(result == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
+        //{
+        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.");
+        //}
+        else if(result == SURF_FETCH_E_TIMEOUT)
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.");
+        }
+        else
+        {
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nUnknown error occurred during fetch.");
+        }
         delete fetcher;
-        return NINJA_E_INVALID;
+        return result;
     }
     delete fetcher;
     return NINJA_SUCCESS;

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -127,35 +127,35 @@ int ninjaTools::fetchDEMBBox(double *boundsBox, const char *fileName, double res
 
         if(result == SURF_FETCH_E_IO_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_IO_ERR, Failure opening a dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\Failure opening a dataset.");
         }
         else if(result == SURF_FETCH_E_BOUNDS_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset.");
         }
         else if(result == SURF_FETCH_E_WARPER_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFailure during warp, failed to warp data.");
         }
         else if(result == SURF_FETCH_E_BAD_INPUT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nBad input to fetching functions.");
         }
         else if(result == SURF_FETCH_E_SIZE_LIMIT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nHit a size limit during fetch.");
         }
         //else if(result == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
         //{
-        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.");
+        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFound NO_DATA in downloaded fetch data.");
         //}
         else if(result == SURF_FETCH_E_TIMEOUT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nSURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nDownload failure, likely download timeout failure.");
         }
         else
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMBBox(), Failed to download elevation data.\nUnknown error occurred during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.");
         }
         delete fetcher;
         return result;
@@ -213,35 +213,35 @@ int ninjaTools::fetchDEMPoint(double * adfPoint,double *adfBuff, const char* uni
 
         if(result == SURF_FETCH_E_IO_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_IO_ERR, Failure opening a dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFailure opening a dataset.");
         }
         else if(result == SURF_FETCH_E_BOUNDS_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_BOUNDS_ERR, Fetch was outside the bounds of the dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset.");
         }
         else if(result == SURF_FETCH_E_WARPER_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_WARPER_ERR, Failure during warp, failed to warp data.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFailure during warp, failed to warp data.");
         }
         else if(result == SURF_FETCH_E_BAD_INPUT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_BAD_INPUT, Bad input to fetching functions.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nBad input to fetching functions.");
         }
         else if(result == SURF_FETCH_E_SIZE_LIMIT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_SIZE_LIMIT, Hit some kind of size limit during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nHit a size limit during fetch.");
         }
         //else if(result == SURF_FETCH_E_NO_GDAL_DATA)  // not really used, instead we output the numNoDataValues
         //{
-        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_NO_GDAL_DATA, Found NO_DATA in downloaded fetch data.");
+        //    Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFound NO_DATA in downloaded fetch data.");
         //}
         else if(result == SURF_FETCH_E_TIMEOUT)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nSURF_FETCH_E_TIMEOUT, Download failure, likely download timeout failure.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nDownload failure, likely download timeout failure.");
         }
         else
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "in ninjaTools::fetchDEMPoint(), Failed to download elevation data.\nUnknown error occurred during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.");
         }
         delete fetcher;
         return result;

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -401,9 +401,8 @@ int ninjaTools::fetchStationFromBBox( const int* yearList, const int * monthList
         bool success = pointInitialization::fetchStationFromBbox(std::string(elevationFile), timeList, timeZone, fetchLatestFlag);
         if(!success)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "pointInitialization::fetchStationFromBbox() failed.\nCould not read station File: Possibly no stations exist for request.");
             pointInitialization::removeBadDirectory(stationPathName);
-            return NINJA_E_INVALID;
+            throw std::runtime_error("pointInitialization::fetchStationFromBbox() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
         }
         if(locationFileFlag)
         {
@@ -470,9 +469,8 @@ int ninjaTools::fetchStationByName( const int* yearList, const int * monthList, 
         bool success = pointInitialization::fetchStationByName(std::string(stationList), timeList, timeZone, fetchLatestFlag);
         if(!success)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "pointInitialization::fetchStationByName() failed.\nCould not read station File: Possibly no stations exist for request.");
             pointInitialization::removeBadDirectory(stationPathName);
-            return NINJA_E_INVALID;
+            throw std::runtime_error("pointInitialization::fetchStationByName() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
         }
         if(locationFileFlag)
         {
@@ -597,8 +595,7 @@ int ninjaTools::checkTimeDuration( int* yearList, int* monthList, int * dayList,
         int isValid = pointInitialization::checkFetchTimeDuration(timeList);
         if(isValid == -2)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "pointInitialization::checkFetchTimeDuration() failed.");
-            return NINJA_E_OTHER;
+            throw std::runtime_error("pointInitialization::checkFetchTimeDuration() failed. Time duration exceeds 1 year.");
         }
 
         return NINJA_SUCCESS;

--- a/src/ninja/nomads.c
+++ b/src/ninja/nomads.c
@@ -36,8 +36,7 @@ const char ** NomadsFindModel( const char *pszKey )
             if( EQUAL( pszKey, apszNomadsKeys[i][0] ) )
             {
                 ppszKey = apszNomadsKeys[i];
-                CPLDebug( "NOMADS", "Found model key: %s",
-                          ppszKey[NOMADS_NAME] );
+                CPLDebug("NOMADS", "Found model key: %s", ppszKey[NOMADS_NAME]);
                 return ppszKey;
             }
             i++;
@@ -59,6 +58,7 @@ static char * NomadsBuildArgList( const char *pszVars, const char *pszPrefix )
     char **papszArgs = CSLTokenizeString2( pszVars, ",", 0 );
     n = CSLCount(papszArgs);
     if (!n) {
+      CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildArgList(), Failed to tokenize input pszVars.");
       return NULL;
     }
     /* var_##=on& */
@@ -180,6 +180,7 @@ static int NomadsBuildForecastRunHours( const char **ppszKey,
             NomadsUtcAddHours( tmp, nStride );
             if( NomadsUtcCompare( tmp, end ) > 0 )
             {
+                CPLDebug("NOMADS", "NomadsBuildForecastRunHours(), found forecast hours '%d'.", k);
                 CSLDestroy( papszRunHours );
                 NomadsUtcFree( tmp );
                 CSLDestroy( papszHours );
@@ -212,6 +213,7 @@ static char ** NomadsBuildForecastFileList( const char *pszKey, int nFcstHour,
     ppszKey = NomadsFindModel( pszKey );
     if( !ppszKey )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildForecastFileList(), could not find input model key in nomads data.");
         return NULL;
     }
     pszVars = NomadsBuildArgList( ppszKey[NOMADS_VARIABLES], "var" );
@@ -220,8 +222,7 @@ static char ** NomadsBuildForecastFileList( const char *pszKey, int nFcstHour,
     {
         pszGribFile = CPLSPrintf( ppszKey[NOMADS_FILE_NAME_FRMT], nFcstHour,
                                   panRunHours[i] );
-        CPLDebug( "WINDNINJA", "NOMADS generated grib file name: %s",
-                  pszGribFile );
+        CPLDebug("WINDNINJA", "NOMADS generated grib file name: %s", pszGribFile);
         NomadsUtcStrfTime( fcst, ppszKey[NOMADS_DIR_DATE_FRMT] );
         /* Special case for urls with subdirectories */
         if(strstr(ppszKey[NOMADS_DIR_FRMT], "%02d") != NULL)
@@ -232,8 +233,7 @@ static char ** NomadsBuildForecastFileList( const char *pszKey, int nFcstHour,
         {
             pszGribDir = CPLSPrintf( ppszKey[NOMADS_DIR_FRMT], fcst->s );
         }
-        CPLDebug( "WINDNINJA", "NOMADS generated grib directory: %s",
-                  pszGribDir );
+        CPLDebug("WINDNINJA", "NOMADS generated grib directory: %s", pszGribDir);
 
         pszUrl =
             CPLSPrintf( "%s%s?%s&%s%s&file=%s&dir=/%s",
@@ -246,7 +246,7 @@ static char ** NomadsBuildForecastFileList( const char *pszKey, int nFcstHour,
                         NOMADS_SUBREGION, pszGribFile, pszGribDir );
         pszUrl = CPLSPrintf( pszUrl, padfBbox[0], padfBbox[1],
                              padfBbox[2], padfBbox[3] );
-        CPLDebug( "WINDNINJA", "NOMADS generated url: %s", pszUrl );
+        CPLDebug("WINDNINJA", "NOMADS generated url: %s", pszUrl);
         papszFileList = CSLAddString( papszFileList, pszUrl );
     }
     CPLFree( (void*)pszVars );
@@ -267,6 +267,7 @@ static char ** NomadsBuildOutputFileList( const char *pszKey, int nFcstHour,
     ppszKey = NomadsFindModel( pszKey );
     if( !ppszKey )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildOutputFileList(), could not find input model key in nomads data.");
         return NULL;
     }
 
@@ -282,8 +283,7 @@ static char ** NomadsBuildOutputFileList( const char *pszKey, int nFcstHour,
         {
             pszGribFile = CPLSPrintf( "/vsizip/%s", pszGribFile );
         }
-        CPLDebug( "WINDNINJA", "NOMADS generated grib file name: %s",
-                  pszGribFile );
+        CPLDebug("WINDNINJA", "NOMADS generated grib file name: %s", pszGribFile);
         papszFileList = CSLAddString( papszFileList, pszGribFile );
     }
     return papszFileList;
@@ -296,14 +296,20 @@ static int NomadsZipFiles( char **papszIn, char **papszOut )
     char *pabyBuffer;
     n = CSLCount( papszIn );
     if( n != CSLCount( papszOut ) )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsZipFiles(), input and output file lists do not match in size.");
         return NOMADS_ERR;
+    }
     for( i = 0; i < n; i++ )
     {
         //VSIRename( papszIn[i], papszOut[i] );
         fin = VSIFOpenL( papszIn[i], "rb" );
         fout = VSIFOpenL( papszOut[i], "wb" );
         if( !fin || !fout )
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "NomadsZipFiles(), could not open '%s' and '%s' files for processing.", papszIn[i], papszOut[i]);
             return NOMADS_ERR;
+        }
         rc = VSIFSeekL( fin, 0, SEEK_END );
         c = VSIFTellL( fin );
         rc = VSIFSeekL( fin, 0, SEEK_SET );
@@ -337,15 +343,13 @@ static int NomadsFetchVsi( const char *pszUrl, const char *pszFilename )
     fin = VSIFOpenL( pszVsiUrl, "rb" );
     if( !fin )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to download file." );
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchVsi(), Failed to open Url '%s'.", pszVsiUrl);
         return NOMADS_ERR;
     }
     fout = VSIFOpenL( pszFilename, "wb" );
     if( !fout )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to open file for writing." );
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchVsi(), Failed to open '%s' file for writing.", pszFilename);
         VSIFCloseL( fin );
         return NOMADS_ERR;
     }
@@ -379,16 +383,14 @@ static int NomadsFetchHttp( const char *pszUrl, const char *pszFilename )
         strstr( (char*)psResult->pabyData, "HTTP error code : 404" ) ||
         strstr( (char*)psResult->pabyData, "data file is not present" ) )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to download file.");
         CPLHTTPDestroyResult( psResult );
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to download file." );
         return NOMADS_ERR;
     }
     fout = VSIFOpenL( pszFilename, "wb" );
     if( !fout )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to open file for writing." );
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchHttp(), Failed to open '%s' file for writing.", pszFilename);
         CPLHTTPDestroyResult( psResult );
         return NOMADS_ERR;
     }
@@ -418,6 +420,7 @@ static double NomadsGetMinSize( const char **ppszModel )
     char **papszTokens = CSLTokenizeString2( ppszModel[NOMADS_GRID_RES], " ", 0 );
     if( papszTokens == NULL || CSLCount( papszTokens ) < 2 )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsGetMinSize(), Failed to tokenize input ppszModel.");
         CSLDestroy( papszTokens );
         assert( 0 );
         return 0;
@@ -556,8 +559,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
     ppszKey = NomadsFindModel( pszModelKey );
     if( ppszKey == NULL )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Could not find model key in nomads data" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in nomads data.");
         return NOMADS_ERR;
     }
 
@@ -591,8 +593,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
         nBufTries++;
     }
 
-    CPLDebug( "NOMADS", "Fetching data for bounding box: %lf, %lf, %lf, %lf",
-              adfBufBbox[0], adfBufBbox[1],adfBufBbox[2],adfBufBbox[3] );
+    CPLDebug("NOMADS", "Fetching data for bounding box: %lf, %lf, %lf, %lf", adfBufBbox[0], adfBufBbox[1],adfBufBbox[2],adfBufBbox[3]);
 
     NomadsUtcCreate( &ref );
     NomadsUtcCreate( &end );
@@ -655,8 +656,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
         nrc = NOMADS_OK;
         fcst = NomadsSetForecastTime( ppszKey, ref, nFcstTries );
         nFcstHour = fcst->ts->tm_hour;
-        CPLDebug( "WINDNINJA", "Generated forecast time in utc: %s",
-                  NomadsUtcStrfTime( fcst, "%Y%m%dT%HZ" ) );
+        CPLDebug("WINDNINJA", "Generated forecast time in utc: %s", NomadsUtcStrfTime(fcst, "%Y%m%dT%HZ"));
 
         if( EQUALN( pszModelKey, "rtma", 4 ) )
         {
@@ -675,8 +675,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
                                          nFilesToGet, fcst, adfBufBbox );
         if( papszDownloadUrls == NULL )
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Could not generate list of URLs to download, invalid data" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not generate list of URLs to download, invalid data.");
             nFcstTries++;
             NomadsUtcFree( fcst );
             fcst = NULL;
@@ -684,15 +683,14 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
             continue;
         }
         pszTmpDir = CPLStrdup( CPLGenerateTempFilename( NULL ) );
-        CPLDebug( "WINDNINJA", "Creating Temp directory: %s", pszTmpDir );
+        CPLDebug("WINDNINJA", "Creating Temp directory: %s", pszTmpDir);
         VSIMkdir( pszTmpDir, 0777 );
         papszOutputFiles =
             NomadsBuildOutputFileList( pszModelKey, nFcstHour, panRunHours,
                                        nFilesToGet, pszTmpDir, FALSE );
         if( papszOutputFiles == NULL )
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Could not generate list of URLs to download, invalid data" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not generate list of output files to download, invalid data.");
             nFcstTries++;
             CSLDestroy( papszDownloadUrls );
             NomadsUtcFree( fcst );
@@ -704,7 +702,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
         CPLAssert( CSLCount( papszDownloadUrls ) == nFilesToGet );
         CPLAssert( CSLCount( papszOutputFiles ) == nFilesToGet );
 
-        CPLDebug( "NOMADS", "Starting download..." );
+        CPLDebug("NOMADS", "Starting download...");
         if( pfnProgress )
         {
             pfnProgress( 0.0, "Starting download...", NULL );
@@ -718,9 +716,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
 #endif /* NOMADS_USE_VSI_READ */
         if( nrc != NOMADS_OK )
         {
-            CPLError( CE_Warning, CPLE_AppDefined,
-                      "Failed to download forecast, " \
-                      "stepping back one forecast run time step." );
+            CPLError(CE_Warning, CPLE_AppDefined, "Failed to download forecast, stepping back one forecast run time step.");
             nFcstTries++;
             CPLSleep( 1 );
             /*
@@ -740,8 +736,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
                                              CPLGetFilename( papszOutputFiles[i] ) ),
                                  NULL ) )
                 {
-                    CPLError( CE_Failure, CPLE_UserInterrupt,
-                              "Cancelled by user." );
+                    CPLError(CE_Failure, CPLE_UserInterrupt, "Cancelled by user.");
                     nrc = NOMADS_ERR;
                     nFcstTries = nMaxFcstRewind;
                     break;
@@ -765,10 +760,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
             {
                 if( pasData[t].nErr )
                 {
-                    CPLError( CE_Warning, CPLE_AppDefined,
-                              "Threaded download failed, attempting " \
-                              "serial download for %s",
-                              CPLGetFilename( pasData[t].pszFilename ) );
+                    CPLError(CE_Warning, CPLE_AppDefined, "Threaded download failed, attempting serial download for '%s'.", CPLGetFilename(pasData[t].pszFilename));
                     /* Try again, serially though */
                     if( CPLCheckForFile( (char *)pasData[t].pszFilename, NULL ) )
                     {
@@ -797,9 +789,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
 #endif /* NOMADS_ENABLE_ASYNC */
             if( nrc != NOMADS_OK )
             {
-                CPLError( CE_Warning, CPLE_AppDefined,
-                          "Failed to download forecast, " \
-                          "stepping back one forecast run time step." );
+                CPLError(CE_Warning, CPLE_AppDefined, "Failed to download forecast, stepping back one forecast run time step.");
                 nFcstTries++;
                 CPLSleep( 1 );
                 break;
@@ -848,8 +838,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
         CSLDestroy( papszFinalFiles );
         if( nrc != NOMADS_OK )
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Could not copy files into path, unknown i/o failure" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not copy files into path, unknown i/o failure.");
             CPLUnlinkTree( pszDstVsiPath );
         }
         CPLUnlinkTree( pszTmpDir );
@@ -882,6 +871,7 @@ char * NomadsFormName( const char *pszKey, char pszSpacer )
     int n;
     if( ppszKey == NULL )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFormName(), could not find input model key in nomads data.");
         return NULL;
     }
     /* Count the levels to check on 3D */
@@ -957,6 +947,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
     VALIDATE_POINTER1( hSrcDS, "GDALAutoCreateWarpedVRT", NULL );
 
     if(psOptionsIn == NULL) {
+        CPLDebug("NOMADS", "NomadsAutoCreateWarpedVRT(), input GDALWarpOptions is NULL, running regular GDALAutoCreateWarpedVRT()");
         return GDALAutoCreateWarpedVRT(hSrcDS, pszSrcWKT, pszDstWKT, eResampleAlg,
                     dfMaxError, psOptionsIn);
     }
@@ -981,10 +972,12 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
         psWO->nBandCount = GDALGetRasterCount(hSrcDS);
         psWO->panSrcBands = CPLMalloc(psWO->nBandCount * sizeof(int));
         if (psWO->panSrcBands == NULL) {
+            CPLDebug("NOMADS", "NomadsAutoCreateWarpedVRT(), input GDALWarpOptions->panSrcBands is NULL, returning without warping.");
             return NULL;
         }
         psWO->panDstBands = CPLMalloc(psWO->nBandCount * sizeof(int));
         if (psWO->panDstBands == NULL) {
+            CPLDebug("NOMADS", "NomadsAutoCreateWarpedVRT(), input GDALWarpOptions->panDstBands is NULL, returning without warping.");
             return NULL;
         }
         for( i = 0; i < GDALGetRasterCount( hSrcDS ); i++ ){
@@ -1041,6 +1034,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
 
     if( psWO->pTransformerArg == NULL )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Failed during GDALCreateGenImgProjTransformer(). Returning NULL dataset.");
         GDALDestroyWarpOptions( psWO );
         return NULL;
     }
@@ -1054,6 +1048,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
                                  adfDstGeoTransform, &nDstPixels, &nDstLines );
     if( eErr != CE_None )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Failed during GDALSuggestedWarpOutput(). Returning NULL dataset.");
         GDALDestroyTransformer( psWO->pTransformerArg );
         GDALDestroyWarpOptions( psWO );
         return NULL;
@@ -1086,6 +1081,12 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
     GDALDatasetH hDstDS
         = GDALCreateWarpedVRT( hSrcDS, nDstPixels, nDstLines,
                                adfDstGeoTransform, psWO );
+    if(hDstDS == NULL)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Could not warp the forecast file, possibly non-uniform grid. Returning NULL dataset.");
+        GDALDestroyWarpOptions(psWO);
+        return NULL;
+    }
 
     GDALDestroyWarpOptions( psWO );
 
@@ -1101,5 +1102,4 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
     return hDstDS;
 }
 #endif /* NOMADS_INTERNAL_VRT */
-
 

--- a/src/ninja/nomads.c
+++ b/src/ninja/nomads.c
@@ -58,7 +58,7 @@ static char * NomadsBuildArgList( const char *pszVars, const char *pszPrefix )
     char **papszArgs = CSLTokenizeString2( pszVars, ",", 0 );
     n = CSLCount(papszArgs);
     if (!n) {
-      CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildArgList(), Failed to tokenize input pszVars.");
+      CPLError(CE_Failure, CPLE_AppDefined, "Failed to tokenize input pszVars, failed to build NOMADS arg list.");
       return NULL;
     }
     /* var_##=on& */
@@ -180,7 +180,7 @@ static int NomadsBuildForecastRunHours( const char **ppszKey,
             NomadsUtcAddHours( tmp, nStride );
             if( NomadsUtcCompare( tmp, end ) > 0 )
             {
-                CPLDebug("NOMADS", "NomadsBuildForecastRunHours(), found forecast hours '%d'.", k);
+                CPLDebug("NOMADS", "found forecast hours '%d'.", k);
                 CSLDestroy( papszRunHours );
                 NomadsUtcFree( tmp );
                 CSLDestroy( papszHours );
@@ -213,7 +213,7 @@ static char ** NomadsBuildForecastFileList( const char *pszKey, int nFcstHour,
     ppszKey = NomadsFindModel( pszKey );
     if( !ppszKey )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildForecastFileList(), could not find input model key in nomads data.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in NOMADS data, failed to build NOMADS forecast file list.");
         return NULL;
     }
     pszVars = NomadsBuildArgList( ppszKey[NOMADS_VARIABLES], "var" );
@@ -267,7 +267,7 @@ static char ** NomadsBuildOutputFileList( const char *pszKey, int nFcstHour,
     ppszKey = NomadsFindModel( pszKey );
     if( !ppszKey )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsBuildOutputFileList(), could not find input model key in nomads data.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in NOMADS data, failed to build NOMADS output file list.");
         return NULL;
     }
 
@@ -307,7 +307,7 @@ static int NomadsZipFiles( char **papszIn, char **papszOut )
         fout = VSIFOpenL( papszOut[i], "wb" );
         if( !fin || !fout )
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "NomadsZipFiles(), could not open '%s' and '%s' files for processing.", papszIn[i], papszOut[i]);
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not open '%s' and '%s' files for processing.", papszIn[i], papszOut[i]);
             return NOMADS_ERR;
         }
         rc = VSIFSeekL( fin, 0, SEEK_END );
@@ -343,13 +343,13 @@ static int NomadsFetchVsi( const char *pszUrl, const char *pszFilename )
     fin = VSIFOpenL( pszVsiUrl, "rb" );
     if( !fin )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchVsi(), Failed to open Url '%s'.", pszVsiUrl);
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open Url '%s'.", pszVsiUrl);
         return NOMADS_ERR;
     }
     fout = VSIFOpenL( pszFilename, "wb" );
     if( !fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchVsi(), Failed to open '%s' file for writing.", pszFilename);
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open '%s' file for writing.", pszFilename);
         VSIFCloseL( fin );
         return NOMADS_ERR;
     }
@@ -390,7 +390,7 @@ static int NomadsFetchHttp( const char *pszUrl, const char *pszFilename )
     fout = VSIFOpenL( pszFilename, "wb" );
     if( !fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFetchHttp(), Failed to open '%s' file for writing.", pszFilename);
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open '%s' file for writing.", pszFilename);
         CPLHTTPDestroyResult( psResult );
         return NOMADS_ERR;
     }
@@ -420,7 +420,7 @@ static double NomadsGetMinSize( const char **ppszModel )
     char **papszTokens = CSLTokenizeString2( ppszModel[NOMADS_GRID_RES], " ", 0 );
     if( papszTokens == NULL || CSLCount( papszTokens ) < 2 )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsGetMinSize(), Failed to tokenize input ppszModel.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to tokenize input ppszModel.");
         CSLDestroy( papszTokens );
         assert( 0 );
         return 0;
@@ -559,7 +559,7 @@ int NomadsFetch( const char *pszModelKey, const char *pszRefTime,
     ppszKey = NomadsFindModel( pszModelKey );
     if( ppszKey == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in nomads data.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in NOMADS data.");
         return NOMADS_ERR;
     }
 
@@ -871,7 +871,7 @@ char * NomadsFormName( const char *pszKey, char pszSpacer )
     int n;
     if( ppszKey == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsFormName(), could not find input model key in nomads data.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find input model key in NOMADS data.");
         return NULL;
     }
     /* Count the levels to check on 3D */
@@ -1034,7 +1034,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
 
     if( psWO->pTransformerArg == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Failed during GDALCreateGenImgProjTransformer(). Returning NULL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALCreateGenImgProjTransformer() failed. Returning NULL dataset.");
         GDALDestroyWarpOptions( psWO );
         return NULL;
     }
@@ -1048,7 +1048,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
                                  adfDstGeoTransform, &nDstPixels, &nDstLines );
     if( eErr != CE_None )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Failed during GDALSuggestedWarpOutput(). Returning NULL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "GDALSuggestedWarpOutput() failed. Returning NULL dataset.");
         GDALDestroyTransformer( psWO->pTransformerArg );
         GDALDestroyWarpOptions( psWO );
         return NULL;
@@ -1083,7 +1083,7 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
                                adfDstGeoTransform, psWO );
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "NomadsAutoCreateWarpedVRT(), Could not warp the forecast file, possibly non-uniform grid. Returning NULL dataset.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp the forecast file, possibly non-uniform grid. Returning NULL dataset.");
         GDALDestroyWarpOptions(psWO);
         return NULL;
     }

--- a/src/ninja/nomads_wx_init.cpp
+++ b/src/ninja/nomads_wx_init.cpp
@@ -76,7 +76,7 @@ NomadsWxModel::NomadsWxModel( const char *pszModelKey )
     ppszModelData = NomadsFindModel( pszModelKey );
     if( ppszModelData == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not find model key in nomads data");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find model key in nomads data.");
         pszKey = NULL;
     }
     else
@@ -235,13 +235,13 @@ std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
     GDALDatasetH hDS = GDALOpen( demFile.c_str(), GA_ReadOnly );
     if(hDS == NULL)
     {
-        throw badForecastFile("Could not download weather forecast, could not open DEM to get bounds.");
+        throw badForecastFile("Cannot open DEM to get bounds. Failed to download weather forecast.");
     }
 
     double demBounds[4];
     if(!GDALGetBounds((GDALDataset*)hDS,demBounds))//Cast GDALDatasetH as a GdalDataset*
     {
-        throw badForecastFile("Could not download weather forecast, could not get bounds from the DEM.");
+        throw badForecastFile("Could not get bounds from the DEM. Failed to download weather forecast.");
     }
 
     double adfNESW[4], adfWENS[4];
@@ -281,7 +281,7 @@ std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
     oTimes = wxModelInitialization::getTimeList();
     if( oTimes.size() < 1 )
     {
-        throw badForecastFile("Could not getTimeList() on forecast from nomads server.");
+        throw badForecastFile("Could not get times from downloaded weather forecast file. Failed to download weather forecast.");
     }
     std::string filename;
     filename = bpt::to_iso_string(oTimes[0].utc_time());
@@ -356,7 +356,7 @@ NomadsWxModel::getTimeList( const char *pszVariable,
     }
     if( wxModelFileName == "" )
     {
-        throw badForecastFile("Invalid forecast file name");
+        throw badForecastFile("Invalid forecast file name.");
     }
 
     int i, j;
@@ -375,7 +375,7 @@ NomadsWxModel::getTimeList( const char *pszVariable,
     int nCount = CSLCount( papszFileList );
     if( !nCount )
     {
-        throw badForecastFile("Could not open forecast path");
+        throw badForecastFile("Could not open forecast path.");
     }
     qsort( (void*)papszFileList, nCount, sizeof( char * ), NomadsCompareStrings );
            //(int (*)(const void*, const void*))strcmp );
@@ -406,7 +406,7 @@ NomadsWxModel::getTimeList( const char *pszVariable,
 
             if(msg && strlen(msg) > 0)
             {
-                std::string eMsg = "Could not open forecast file with GDAL.\nLast GDAL error message = '"+std::string(msg)+"'";
+                std::string eMsg = "Could not open forecast file with GDAL.\n\nLast GDAL error message = '"+std::string(msg)+"'";
                 throw badForecastFile(eMsg.c_str());
             }
             else
@@ -577,7 +577,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
 
     hSrcDS = GDALOpenShared( pszForecastFile, GA_ReadOnly );
     if( hSrcDS == NULL ) {
-        throw std::runtime_error("NomadsWxModel::setSurfaceGrids(), Could not open forecast file with the requested time step.");
+        throw std::runtime_error("Could not open forecast file with the requested time step.");
     }
 
     CPLFree( (void*) pszForecastFile );
@@ -613,12 +613,12 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
     pszSrcWkt = GDALGetProjectionRef( hSrcDS );
     if(pszSrcWkt == nullptr)
     {
-        throw std::runtime_error("NomadsWxModel::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+        throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
     pszDstWkt = input.dem.prjString.c_str();
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "nomads, pre warp");
+    CPLDebug("COORD_TRANSFORM_ANGLES", "nomads, pre warp");
     //compute angle between N-S grid lines in the dataset and true north, going FROM true north TO the y coordinate grid line of the dataset
     double angleFromNorth = 0.0;
     if( CSLTestBoolean(CPLGetConfigOption("DISABLE_COORDINATE_TRANSFORMATION_ANGLE_CALCULATIONS", "FALSE")) == false )
@@ -656,7 +656,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
         throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
     }
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "nomads, post warp");
+    CPLDebug("COORD_TRANSFORM_ANGLES", "nomads, post warp");
     //compute angle between N-S grid lines in the dataset and true north, going FROM true north TO the y coordinate grid line of the dataset
     angleFromNorth = 0.0;
     if( CSLTestBoolean(CPLGetConfigOption("DISABLE_COORDINATE_TRANSFORMATION_ANGLE_CALCULATIONS", "FALSE")) == false )
@@ -697,7 +697,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
         pszElement = GDALGetMetadataItem( hBand, "GRIB_ELEMENT", NULL );
         if( !pszElement )
         {
-          throw badForecastFile( "Could not fetch proper band" );
+          throw badForecastFile( "Could not fetch proper band from forecast file." );
         }
         if( EQUAL( pszElement, "TMP" ) )
         {
@@ -923,8 +923,8 @@ noCloudOK:
             }
         }
 
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "pre coordTransformAngle calc" );
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue() );
+        CPLDebug("COORD_TRANSFORM_ANGLES", "pre coordTransformAngle calc");
+        CPLDebug("COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue());
         // use the coordinateTransformationAngle to correct each spd,dir, u,v dataset for the warp
         for(int i=0; i<dirTmpGrid.get_nRows(); i++)
         {
@@ -938,8 +938,8 @@ noCloudOK:
                 }
             }
         }
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "post coordTransformAngle calc" );
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue() );
+        CPLDebug("COORD_TRANSFORM_ANGLES", "post coordTransformAngle calc");
+        CPLDebug("COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue());
 
 // this whole little section is no longer needed, if we properly set the NO_DATA values, as above, with NO_DATA values properly set and detected,
 // the .get_meanValue() returns the right result every time now.
@@ -961,8 +961,8 @@ noCloudOK:
                 }
             }
         }
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "true post coordTransformAngle calc value (NO_DATA spd, u, v vals (0.0) and NO_DATA dir vals (270.0) now dropped)" );
-        CPLDebug( "COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue() );
+        CPLDebug("COORD_TRANSFORM_ANGLES", "true post coordTransformAngle calc value (NO_DATA spd, u, v vals (0.0) and NO_DATA dir vals (270.0) now dropped)");
+        CPLDebug("COORD_TRANSFORM_ANGLES", "dirGrid.get_meanValue() = %lf", dirTmpGrid.get_meanValue());
 
         // cleanup the intermediate grids
         speedTmpGrid.deallocate();
@@ -1081,13 +1081,13 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     }
     if( !pszForecastFile )
     {
-        throw badForecastFile("Could not find forecast associated with requested time step");
+        throw badForecastFile("Could not find forecast associated with requested time step.");
     }
 
     hDS = GDALOpenShared( pszForecastFile, GA_ReadOnly );
     if(hDS == NULL)
     {
-        throw std::runtime_error("NomadsWxModel::set3dGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
 
     // wouldn't this here kill the opened file?? Shouldn't it be done later after the file gets closed??
@@ -1116,7 +1116,7 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     pszSrcWkt = GDALGetProjectionRef( hDS );
     if(pszSrcWkt == nullptr)
     {
-        throw std::runtime_error("NomadsWxModel::set3dGrids(), Could not get projection from forecast file, bad forecast file.");
+        throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
     pszDstWkt = input.dem.prjString.c_str();

--- a/src/ninja/nomads_wx_init.cpp
+++ b/src/ninja/nomads_wx_init.cpp
@@ -391,10 +391,21 @@ NomadsWxModel::getTimeList( const char *pszVariable,
         hDS = GDALOpenShared( pszFullPath, GA_ReadOnly );
         if( !hDS )
         {
+            const char* msg = CPLGetLastErrorMsg();
+
             CSLDestroy( papszFileList );
             CPLFree( (void*)pszPath );
             CPLFree( (void*)pszFullPath );
-            throw badForecastFile( "Could not open forecast file with GDAL" );
+
+            if(msg && strlen(msg) > 0)
+            {
+                std::string eMsg = "Could not open forecast file with GDAL.\nLast GDAL error message = '"+std::string(msg)+"'";
+                throw badForecastFile(eMsg.c_str());
+            }
+            else
+            {
+                throw badForecastFile("Could not open forecast file with GDAL");
+            }
         }
         nBandCount = GDALGetRasterCount( hDS );
         for( j = 0; j < nBandCount; j++ ) {

--- a/src/ninja/nomads_wx_init.cpp
+++ b/src/ninja/nomads_wx_init.cpp
@@ -76,8 +76,7 @@ NomadsWxModel::NomadsWxModel( const char *pszModelKey )
     ppszModelData = NomadsFindModel( pszModelKey );
     if( ppszModelData == NULL )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Could not find model key in nomads data" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not find model key in nomads data");
         pszKey = NULL;
     }
     else
@@ -109,7 +108,7 @@ const char ** NomadsWxModel::FindModelKey( const char *pszFilename )
     CPLFree( (void*)pszVsiDir );
     if( !papszFileList )
     {
-        return FALSE;
+        return nullptr;
     }
     nCount = CSLCount( papszFileList );
     /* Must match one file name format */
@@ -227,18 +226,22 @@ std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
 {
     if( !ppszModelData )
     {
-        throw badForecastFile( "Model not found" );
+        throw badForecastFile("Model not found.");
     }
 
     //Check to make sure the DEM is good.
     //This check is very similar to wxModelInitialization::fetchForecast
-    //Line ~388-394
+    //Line ~388-398
     GDALDatasetH hDS = GDALOpen( demFile.c_str(), GA_ReadOnly );
+    if(hDS == NULL)
+    {
+        throw badForecastFile("Could not download weather forecast, could not open DEM to get bounds.");
+    }
+
     double demBounds[4];
     if(!GDALGetBounds((GDALDataset*)hDS,demBounds))//Cast GDALDatasetH as a GdalDataset*
     {
-        throw badForecastFile("Could not download weather forecast, invalid "
-                              "projection for the DEM");
+        throw badForecastFile("Could not download weather forecast, could not get bounds from the DEM.");
     }
 
     double adfNESW[4], adfWENS[4];
@@ -271,14 +274,14 @@ std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
     if( rc )
     {
         CPLFree( (void*)pszTmpFile );
-        throw badForecastFile( "Could not download from nomads server!" );
+        throw badForecastFile("Could not download from nomads server.");
     }
     wxModelFileName = pszTmpFile;
     std::vector<blt::local_date_time> oTimes;
     oTimes = wxModelInitialization::getTimeList();
     if( oTimes.size() < 1 )
     {
-        throw badForecastFile( "Could not open forecast from nomads server" );
+        throw badForecastFile("Could not getTimeList() on forecast from nomads server.");
     }
     std::string filename;
     filename = bpt::to_iso_string(oTimes[0].utc_time());
@@ -297,7 +300,7 @@ std::vector<std::string> NomadsWxModel::getVariableList()
 {
     if( !ppszModelData )
     {
-        throw badForecastFile( "Invalid model" );
+        throw badForecastFile("Model not found.");
     }
     char **papszTokens = NULL;
     papszTokens = CSLTokenizeString2( ppszModelData[NOMADS_VARIABLES], ",", 0 );
@@ -321,7 +324,7 @@ std::string NomadsWxModel::getForecastReadable( const char bySwapWithSpace )
 {
     if( !ppszModelData )
     {
-        throw badForecastFile( "Invalid Model" );
+        throw badForecastFile("Model not found.");
     }
 
     char *p = NULL;
@@ -347,9 +350,13 @@ NomadsWxModel::getTimeList( const char *pszVariable,
     if( aoCachedTimes.size() > 0 )
         return aoCachedTimes;
     (void)pszVariable;
-    if( wxModelFileName == "" || ppszModelData == NULL )
+    if( !ppszModelData )
     {
-        throw badForecastFile( "Invalid forecast file name" );
+        throw badForecastFile("Model not found.");
+    }
+    if( wxModelFileName == "" )
+    {
+        throw badForecastFile("Invalid forecast file name");
     }
 
     int i, j;
@@ -368,7 +375,7 @@ NomadsWxModel::getTimeList( const char *pszVariable,
     int nCount = CSLCount( papszFileList );
     if( !nCount )
     {
-        throw badForecastFile( "Could not open forecast path" );
+        throw badForecastFile("Could not open forecast path");
     }
     qsort( (void*)papszFileList, nCount, sizeof( char * ), NomadsCompareStrings );
            //(int (*)(const void*, const void*))strcmp );
@@ -404,7 +411,7 @@ NomadsWxModel::getTimeList( const char *pszVariable,
             }
             else
             {
-                throw badForecastFile("Could not open forecast file with GDAL");
+                throw badForecastFile("Could not open forecast file with GDAL.");
             }
         }
         nBandCount = GDALGetRasterCount( hDS );
@@ -418,12 +425,11 @@ NomadsWxModel::getTimeList( const char *pszVariable,
                 CPLFree( (void*)pszPath );
                 CPLFree( (void*)pszFullPath );
                 GDALClose( hDS );
-                throw badForecastFile( "Could not fetch ref time or forecast time " \
-                                       "from GRIB file" );
+                throw badForecastFile("Could not fetch ref time or forecast time from GRIB file.");
             }
             if( CSLFindString( papszTimeList, pszValidTime ) == -1 ) {
                 papszTimeList = CSLAddString( papszTimeList, pszValidTime );
-                CPLDebug( "WINDNINJA", "Found valid time in grib: %s", pszValidTime );
+                CPLDebug("WINDNINJA", "Found valid time in grib: %s", pszValidTime);
             }
         }
         GDALClose( hDS );
@@ -563,19 +569,17 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
             }
             break;
         }
-
     }
     if( !pszForecastFile )
     {
-        throw badForecastFile( "Could not find forecast associated with " \
-                               "requested time step" );
+        throw badForecastFile("Could not find forecast file associated with the requested time step.");
     }
 
     hSrcDS = GDALOpenShared( pszForecastFile, GA_ReadOnly );
     if( hSrcDS == NULL ) {
-        throw badForecastFile( "Could not find forecast associated with " \
-                               "requested time step" );
+        throw std::runtime_error("NomadsWxModel::setSurfaceGrids(), Could not open forecast file with the requested time step.");
     }
+
     CPLFree( (void*) pszForecastFile );
     pszForecastFile = NULL;
     nBandCount = GDALGetRasterCount( hSrcDS );
@@ -607,6 +611,11 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
 //    }
 
     pszSrcWkt = GDALGetProjectionRef( hSrcDS );
+    if(pszSrcWkt == nullptr)
+    {
+        throw std::runtime_error("NomadsWxModel::setSurfaceGrids(), Could not get projection from forecast file, bad forecast file.");
+    }
+
     pszDstWkt = input.dem.prjString.c_str();
 
     CPLDebug( "COORD_TRANSFORM_ANGLES", "nomads, pre warp");
@@ -616,7 +625,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
     {
         if(!GDALCalculateAngleFromNorth( (GDALDataset*)hSrcDS, angleFromNorth ))
         {
-            printf("Warning: Unable to calculate angle departure from north for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate angle departure from north for the wxModel.");
         }
     }
 
@@ -629,7 +638,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
         // direct calculation of FROM wx TO dem, already has the appropriate sign
         if(!GDALCalculateCoordinateTransformationAngle( (GDALDataset*)hSrcDS, coordinateTransformationAngle, pszDstWkt ))  // this is FROM wx TO dem
         {
-            printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
         }
     }
 
@@ -642,6 +651,10 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
                                       GRA_NearestNeighbour, 1.0,
                                       psWarpOptions );
 #endif
+    if(hVrtDS == NULL)
+    {
+        throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+    }
 
     CPLDebug( "COORD_TRANSFORM_ANGLES", "nomads, post warp");
     //compute angle between N-S grid lines in the dataset and true north, going FROM true north TO the y coordinate grid line of the dataset
@@ -650,7 +663,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
     {
         if(!GDALCalculateAngleFromNorth( (GDALDataset*)hVrtDS, angleFromNorth ))
         {
-            printf("Warning: Unable to calculate angle departure from north for the wxModel.");
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate angle departure from north for the wxModel.");
         }
     }
 
@@ -795,7 +808,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
             hSrcDS = GDALOpenShared( pszNextFcst, GA_ReadOnly );
             if( hSrcDS == NULL )
             {
-                throw badForecastFile( "Could not load cloud data." );
+                throw badForecastFile("Could not load cloud data.");
             }
             pszSrcWkt = GDALGetProjectionRef( hSrcDS );
 #ifdef NOMADS_VRT
@@ -809,7 +822,7 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
 #endif
             if( hVrtDS == NULL )
             {
-                throw badForecastFile( "Could not load cloud data." );
+                throw badForecastFile("Could not load cloud data.");
             }
             int j = 0;
             for( j = 0; j < GDALGetRasterCount( hVrtDS ); j++ )
@@ -849,14 +862,12 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
             CPLFree( (void*)pszNextFcst );
             GDALClose( hSrcDS );
             GDALClose( hVrtDS );
-            CPLError( CE_Warning, CPLE_AppDefined, "Could not load cloud data "
-                      "from 0th time step, using time step 1." );
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Could not load cloud data from 0th time step, using time step 1.");
         }
         else
         {
 noCloudOK:
-            CPLError( CE_Warning, CPLE_AppDefined, "Could not load cloud data " \
-                      "from the forecast file, setting to 0." );
+            input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Could not load cloud data from the forecast file, setting to 0.");
 
             cloudGrid.set_headerData( uGrid );
             cloudGrid = 0.0;
@@ -1070,12 +1081,18 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     }
     if( !pszForecastFile )
     {
-        throw badForecastFile( "Could not find forecast associated with " \
-                               "requested time step" );
+        throw badForecastFile("Could not find forecast associated with requested time step");
     }
 
     hDS = GDALOpenShared( pszForecastFile, GA_ReadOnly );
+    if(hDS == NULL)
+    {
+        throw std::runtime_error("NomadsWxModel::set3dGrids(), Could not open forecast file, bad forecast file.");
+    }
+
+    // wouldn't this here kill the opened file?? Shouldn't it be done later after the file gets closed??
     CPLFree( (void*)pszForecastFile );
+
     int nBandCount = GDALGetRasterCount( hDS );
     hBand = GDALGetRasterBand( hDS, 1 );
     int bSuccess;
@@ -1097,7 +1114,13 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
                              "INIT_DEST", "-9999.0" );
 
     pszSrcWkt = GDALGetProjectionRef( hDS );
+    if(pszSrcWkt == nullptr)
+    {
+        throw std::runtime_error("NomadsWxModel::set3dGrids(), Could not get projection from forecast file, bad forecast file.");
+    }
+
     pszDstWkt = input.dem.prjString.c_str();
+
 #ifdef NOMADS_VRT
     hVrtDS = NomadsAutoCreateWarpedVRT( hDS, pszSrcWkt, pszDstWkt,
                                       GRA_NearestNeighbour, 1.0,
@@ -1107,6 +1130,10 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
                                       GRA_NearestNeighbour, 1.0,
                                       psWarpOptions );
 #endif
+    if(hVrtDS == NULL)
+    {
+        throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+    }
 
     int nSkipRows, nSkipCols;
     hBand = GDALGetRasterBand( hVrtDS, 1 );

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -2607,12 +2607,19 @@ bool pointInitialization::fetchStationFromBbox(std::string demFile,
                                                std::vector<bpt::ptime> timeList,
                                                std::string timeZone, bool latest)
 {
+    bool doesFileExist = CPLCheckForFile((char*)demFile.c_str(), NULL);
+    if(!doesFileExist)
+    {
+        error_msg="demFile '"+demFile+"' does not exist.";
+        throw std::runtime_error(error_msg);
+    }
+
     GDALDataset  *poDS;
     poDS = (GDALDataset *) GDALOpen(demFile.c_str(), GA_ReadOnly );
     if (poDS==NULL)
     {
-        CPLDebug("STATION_FETCH", "Could not read DEM file for station fetching");
-        return false;
+        error_msg="Could not read DEM file for station fetching.";
+        throw std::runtime_error("Could not read DEM file for station fetching.");
     }
 
     double bounds[4];
@@ -2621,9 +2628,8 @@ bool pointInitialization::fetchStationFromBbox(std::string demFile,
     bRet=GDALGetBounds(poDS,bounds);
     if (bRet==false)
     {
-        error_msg="GDALGetBounds returned false, DEM file is lacking readable data.";
-        throw std::runtime_error("GDALGetBounds returned false, DEM file is lacking readable data.");
-        return false;
+        error_msg="GDALGetBounds() returned false, DEM file is lacking readable data.";
+        throw std::runtime_error("GDALGetBounds() returned false, DEM file is lacking readable data.");
 
     }
 
@@ -2637,10 +2643,8 @@ bool pointInitialization::fetchStationFromBbox(std::string demFile,
             //Greater than 100 miles
             error_msg="Selected Buffer around DEM is too big! Greater than 100 miles. Use a custom API token to enable larger buffers.";
             throw std::runtime_error("Selected Buffer around DEM is too big! Greater than 100 miles. Use a custom API token to enable larger buffers.");
-            return false;
         }
     }
-
 
     CPLDebug("STATION_FETCH", "Adding %fm to DEM for station fetching.", buffer);
 
@@ -2933,8 +2937,7 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
     if (hDS==NULL) //This is mainly caused by a bad URL, the user enters something wrong
     {
         CPLDebug("STATION_FETCH", "URL: %s", URL.c_str());
-        error_msg="OGROpen could not read the station file.\nPossibly no stations exist for the given parameters.";
-        return false;
+        error_msg="Could not open the station file for reading.\nPossibly no stations exist for the given parameters.";
         throw std::runtime_error(error_msg);
     }
     //get the data
@@ -3142,10 +3145,10 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
                     stationChecks.push_back(write_this_station);
                     if(fCount==1)
                     {
-                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sesnors!";
                         CPLDebug("STATION_FETCH","%s failed to return valid data...",writeID);
+                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sensors!";
+                        //throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
                         return false;
-                        throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
                     }
                 }
 
@@ -3247,9 +3250,9 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
                     stationChecks.push_back(write_this_station);
                     if(fCount==1)
                     {
-                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sesnors!";
+                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sensors!";
+                        //throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
                         return false;
-                        throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
                     }
                 }
             }
@@ -3259,8 +3262,9 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
     GDALClose(hDS);
     if(stationChecks.size()>=fCount)
     {
-        error_msg="ERROR: Data check failed on all stations, likley stations are missing sensors.";
         CPLDebug("STATION_FETCH","DATA CHECK FAILED ON ALL STATIONS...");
+        error_msg="ERROR: Data check failed on all stations, likely stations are missing sensors.";
+        //throw std::runtime_error( error_msg );
         return false;
     }
     else

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -149,10 +149,11 @@ void pointInitialization::setInitializationGrids(WindNinjaInputs& input)
     //Check one grid to be sure that the interpolation completely filled the grid
     if(cloudCoverGrid.checkForNoDataValues())
     {
-        throw std::runtime_error("Fill interpolation from the wx stations didn't completely fill the grids. " \
-                        "To be sure everything is filled, let at least one wx station have an infinite influence radius. " \
-                        "This is specified by defining the influence radius to be a value less than zero in the wx " \
-                        "station file.");
+        error_msg = "Fill interpolation from the wx stations didn't completely fill the grids. " \
+                    "To be sure everything is filled, let at least one wx station have an infinite influence radius. " \
+                    "This is specified by defining the influence radius to be a value less than zero in the wx " \
+                    "station file.";
+        throw std::runtime_error(error_msg);
     }
 
     double U_star, anthropogenic_, cg_, bowen_, albedo_;
@@ -701,11 +702,11 @@ vector<wxStation> pointInitialization::interpolateFromDisk(std::string demFile,
         bool a=wxStation::check_station(readyToGo[i]);
         if (a != true)
         {
-            CPLDebug("STATION_FETCH", "check_station failed on #%d: %s", i, readyToGo[i].get_stationName().c_str());
+            CPLError(CE_Warning, CPLE_AppDefined, "wxStation::check_station() failed on station[%d] '%s'", i, readyToGo[i].get_stationName().c_str());
         }
         else
         {
-            CPLDebug("STATION_FETCH", "check_station passed on #%d: %s", i, readyToGo[i].get_stationName().c_str());
+            CPLDebug("STATION_FETCH", "wxStation::check_station() passed on station[%d] '%s'", i, readyToGo[i].get_stationName().c_str());
         }
     }
     return readyToGo;
@@ -733,7 +734,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         oErrorString = "Cannot open csv file: ";
         oErrorString += stationLoc;
         error_msg = oErrorString;
-        throw( std::runtime_error( oErrorString ) );
+        throw std::runtime_error(oErrorString);
     }
 
     double dfTempValue = 0.0;
@@ -783,7 +784,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
                 oErrorString += " at station: ";
                 oErrorString += oStationName;
                 error_msg = oErrorString;
-                throw( std::domain_error( oErrorString ) );
+                throw std::runtime_error(oErrorString);
             }
 
             //check for valid longitude in degrees
@@ -798,7 +799,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
                 oErrorString += " at station: ";
                 oErrorString += oStationName;
                 error_msg = oErrorString;
-                throw( std::domain_error( oErrorString ) );
+                throw std::runtime_error(oErrorString);
             }
 
             const char *pszDatum = poFeature->GetFieldAsString( 2 );
@@ -809,7 +810,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
                 oErrorString += " at station: ";
                 oErrorString += oStationName;
                 error_msg = oErrorString;
-                throw( std::domain_error( oErrorString ) );
+                throw std::runtime_error(oErrorString);
             }
 
             oStation.coord_y=poFeature->GetFieldAsDouble(3); //coords are Lat/Lon
@@ -829,7 +830,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
                 oWarnString += " for PROJCS at station: ";
                 oWarnString += oStationName;
                 oWarnString += " and using datum WGS84";
-                std::cout << oWarnString << std::endl;
+                CPLError(CE_Warning, CPLE_AppDefined, oWarnString.c_str());
             }
 
             oStation.coord_y=poFeature->GetFieldAsDouble(3); //coords are XCoord/YCoord, in the projection of the dem
@@ -844,7 +845,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         //MIDDLE STUFF
@@ -858,7 +859,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
         if( EQUAL( pszKey, "meters" ) )
         {
@@ -877,7 +878,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         //WIND SPEED
@@ -892,7 +893,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         if ( EQUAL( pszKey, "mps" ) )
@@ -922,7 +923,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         //WIND DIRECTION
@@ -965,7 +966,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         //CLOUD COVER
@@ -1015,7 +1016,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         datetime=poFeature->GetFieldAsString(15);
@@ -1038,7 +1039,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            throw( std::domain_error( oErrorString ) );
+            throw std::runtime_error(oErrorString);
         }
 
         oStations.push_back(oStation);
@@ -1066,7 +1067,7 @@ vector<std::string> pointInitialization::fetchWxStationID()
         if(hDS == NULL)
         {
             error_msg = "Cannot open stationFile '"+stationFiles[k]+"'.";
-            throw( std::runtime_error( error_msg ) );
+            throw std::runtime_error(error_msg);
         }
 
         OGRLayer *poLayer;
@@ -1075,7 +1076,7 @@ vector<std::string> pointInitialization::fetchWxStationID()
         if(poLayer == NULL)
         {
             error_msg = "Cannot read OGRLayer in stationFile '"+stationFiles[k]+"'.";
-            throw( std::runtime_error( error_msg ) );
+            throw std::runtime_error(error_msg);
         }
 
         std::string oStationName;
@@ -1085,7 +1086,7 @@ vector<std::string> pointInitialization::fetchWxStationID()
         if(hLayer == NULL)
         {
             error_msg = "Cannot read OGRLayerH in stationFile '"+stationFiles[k]+"'.";
-            throw( std::runtime_error( error_msg ) );
+            throw std::runtime_error(error_msg);
         }
         OGR_L_ResetReading(hLayer);
 
@@ -1124,6 +1125,7 @@ int pointInitialization::directTemporalInterpolation(int posIdx, int negIdx)
         return 2;
     }
 
+    error_msg = "invalid index combination";
     throw std::runtime_error("invalid index combination");
 }
 
@@ -1172,7 +1174,6 @@ bool pointInitialization::checkWxStationSize(vector<string> wxStationIDs)
                     "detected in one file! Each unique station must be in a unique file!";
         throw std::runtime_error("ERROR: Mutliple different Stations"
                                  " detected in one file! Each unique station must be in a unique file!");
-        return false;
     }
 
     return true;
@@ -2388,7 +2389,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
         if ( (start_ptime < start_dstStartTransition && end_ptime > start_dstStartTransition)
           || (start_ptime < start_dstEndTransition && end_ptime > start_dstEndTransition) )
         {
-            std::cout << "\nSTATION_FETCH warning: Chosen start and stop times span a daylight savings time transition.\n" << std::endl;
+            CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::getTimeList(), Chosen start and stop times span a daylight savings time transition.");
         }
     } else if (start_dstStartTransition > start_dstEndTransition ) // notice that if they are equal is ignored
     {
@@ -2397,7 +2398,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
         if ( (start_ptime < start_dstEndTransition && end_ptime > start_dstEndTransition)
           || (start_ptime < start_dstStartTransition && end_ptime > start_dstStartTransition) )
         {
-            std::cout << "\nSTATION_FETCH warning: Chosen start and stop times span a daylight savings time transition.\n" << std::endl;
+            CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::getTimeList(), Chosen start and stop times span a daylight savings time transition.");
         }
     }
     
@@ -2418,6 +2419,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
     {
         // note start_UTC > end_UTC, leaving it in that order so later checks should catch this and stop, 
         // no need to generate more of the timeList as the run should abort and let the user edit their chosen input values accordingly
+        CPLError(CE_Failure, CPLE_AppDefined, "pointInitialization::getTimeList(), stop_time is less than start_time.");
         std::vector<bpt::ptime> timeList;
         timeList.push_back(start_UTC);
         timeList.push_back(end_UTC);
@@ -2518,7 +2520,7 @@ bpt::ptime pointInitialization::generateSingleTimeObject(int year, int month, in
     boost::posix_time::ptime noTime;    // default constructor should fill it with not_a_date_time as the value
     if ( x_UTC == noTime )
     {
-        std::cout << "\nSTATION_FETCH warning: Chosen time is \"not_a_date_time\". This usually happens if the time is right on the daylight savings time transition.\n" << std::endl;
+        CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::generateSingleTimeObject(), Chosen time is \"not_a_date_time\". This usually happens if the time is right on the daylight savings time transition.");
     }
     
     CPLDebug("STATION_FETCH","x_local: %s",boost::lexical_cast<std::string>(x_local).c_str());
@@ -3227,7 +3229,6 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
                     CPLDebug("STATION_FETCH","Writing station: %s to file %s",writeID,tName.c_str());
 //                  std::string raws_height="10"; //This may get changed later
                     outFile.open(tName.c_str());
-//                  cout<<tName<<endl;
                     outFile<<header<<endl;
                     stationCSVNames.push_back(tName);
                     storeFileNames(stationCSVNames);
@@ -3264,7 +3265,7 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
     {
         CPLDebug("STATION_FETCH","DATA CHECK FAILED ON ALL STATIONS...");
         error_msg="ERROR: Data check failed on all stations, likely stations are missing sensors.";
-        //throw std::runtime_error( error_msg );
+        //throw std::runtime_error(error_msg);
         return false;
     }
     else

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -702,11 +702,11 @@ vector<wxStation> pointInitialization::interpolateFromDisk(std::string demFile,
         bool a=wxStation::check_station(readyToGo[i]);
         if (a != true)
         {
-            CPLError(CE_Warning, CPLE_AppDefined, "wxStation::check_station() failed on station[%d] '%s'", i, readyToGo[i].get_stationName().c_str());
+            CPLError(CE_Warning, CPLE_AppDefined, "station[%d] '%s' failed station checks.", i, readyToGo[i].get_stationName().c_str());
         }
         else
         {
-            CPLDebug("STATION_FETCH", "wxStation::check_station() passed on station[%d] '%s'", i, readyToGo[i].get_stationName().c_str());
+            CPLDebug("STATION_FETCH", "station[%d] '%s' passed station checks.", i, readyToGo[i].get_stationName().c_str());
         }
     }
     return readyToGo;
@@ -2389,7 +2389,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
         if ( (start_ptime < start_dstStartTransition && end_ptime > start_dstStartTransition)
           || (start_ptime < start_dstEndTransition && end_ptime > start_dstEndTransition) )
         {
-            CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::getTimeList(), Chosen start and stop times span a daylight savings time transition.");
+            CPLError(CE_Warning, CPLE_AppDefined, "Chosen start and stop times span a daylight savings time transition.");
         }
     } else if (start_dstStartTransition > start_dstEndTransition ) // notice that if they are equal is ignored
     {
@@ -2398,7 +2398,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
         if ( (start_ptime < start_dstEndTransition && end_ptime > start_dstEndTransition)
           || (start_ptime < start_dstStartTransition && end_ptime > start_dstStartTransition) )
         {
-            CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::getTimeList(), Chosen start and stop times span a daylight savings time transition.");
+            CPLError(CE_Warning, CPLE_AppDefined, "Chosen start and stop times span a daylight savings time transition.");
         }
     }
     
@@ -2419,7 +2419,7 @@ pointInitialization::getTimeList(int startYear, int startMonth, int startDay,
     {
         // note start_UTC > end_UTC, leaving it in that order so later checks should catch this and stop, 
         // no need to generate more of the timeList as the run should abort and let the user edit their chosen input values accordingly
-        CPLError(CE_Failure, CPLE_AppDefined, "pointInitialization::getTimeList(), stop_time is less than start_time.");
+        CPLError(CE_Failure, CPLE_AppDefined, "stop_time is less than start_time.");
         std::vector<bpt::ptime> timeList;
         timeList.push_back(start_UTC);
         timeList.push_back(end_UTC);
@@ -2520,7 +2520,7 @@ bpt::ptime pointInitialization::generateSingleTimeObject(int year, int month, in
     boost::posix_time::ptime noTime;    // default constructor should fill it with not_a_date_time as the value
     if ( x_UTC == noTime )
     {
-        CPLError(CE_Warning, CPLE_AppDefined, "pointInitialization::generateSingleTimeObject(), Chosen time is \"not_a_date_time\". This usually happens if the time is right on the daylight savings time transition.");
+        CPLError(CE_Warning, CPLE_AppDefined, "Chosen time is \"not_a_date_time\". This usually happens if the time is right on the daylight savings time transition.");
     }
     
     CPLDebug("STATION_FETCH","x_local: %s",boost::lexical_cast<std::string>(x_local).c_str());
@@ -2630,8 +2630,8 @@ bool pointInitialization::fetchStationFromBbox(std::string demFile,
     bRet=GDALGetBounds(poDS,bounds);
     if (bRet==false)
     {
-        error_msg="GDALGetBounds() returned false, DEM file is lacking readable data.";
-        throw std::runtime_error("GDALGetBounds() returned false, DEM file is lacking readable data.");
+        error_msg="Failed to get bounds of DEM file for station fetching. DEM file is lacking readable data.";
+        throw std::runtime_error("Failed to get bounds of DEM file for station fetching. DEM file is lacking readable data.");
 
     }
 

--- a/src/ninja/relief_fetch.cpp
+++ b/src/ninja/relief_fetch.cpp
@@ -112,12 +112,10 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
         //add error info detailing incompatible data types
         return SURF_FETCH_E_IO_ERR;
     }
-    
 
     const char *pszSrcWKT=NULL, *pszDstWKT = NULL;
     pszSrcWKT = GDALGetProjectionRef(hSrcDS);
 
-     
     OGRSpatialReference oSrcSRS, oDstSRS;
 
     oSrcSRS.importFromEPSG(4326);
@@ -144,7 +142,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
 
@@ -166,7 +164,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if(nPixels <= 0 || nLines <= 0)
     {
-        return SURF_FETCH_E_WARPER_ERR; /*assumption*/
+        return SURF_FETCH_E_WARPER_ERR;
     }
 
     adfDstGeoTransform[0] = dfMinX;
@@ -223,12 +221,11 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if( eErr != CE_None )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp image, " \
-                                               "download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         CPLFree((void*)pszDstWKT);
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
 
     CPLFree((void*)pszDstWKT);
@@ -240,9 +237,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     CPLSetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", NULL);
 
     return SURF_FETCH_E_NONE;
-
 }
-
 
 SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile, int nXSize, int nYSize )
 {
@@ -291,10 +286,9 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     GDALClose( inDS );
     if( NULL ==  pszDstWKT )
     {
-        return SURF_FETCH_E_WARPER_ERR;
+        return SURF_FETCH_E_IO_ERR;
     }
     /*finished with the input file */
-
 
     /*Get the final information from the source DS */
     hSrcDS = GDALOpen( path.c_str(), GA_ReadOnly );
@@ -352,7 +346,6 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     GDALSetProjection(hDstDS, pszDstWKT);
     GDALSetGeoTransform(hDstDS, dst_gt);
 
-
     /* warp the src ds to the output ds */
     GDALWarpOptions *psWarpOptions = GDALCreateWarpOptions();
 
@@ -381,14 +374,12 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     if( eErr != CE_None )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp image, " \
-                                               "download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
         CPLFree((void*)pszDstWKT);
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
-
 
     GDALClose(hDstDS);
     GDALClose(hSrcDS);
@@ -397,9 +388,4 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     return SURF_FETCH_E_NONE; 
 }
-
-
-
-
-
 

--- a/src/ninja/relief_fetch.cpp
+++ b/src/ninja/relief_fetch.cpp
@@ -103,7 +103,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     hSrcDS = GDALOpen(GetPath().c_str(), GA_ReadOnly);
     if(hSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox(), Could not open path for reading, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open path '%s' for reading, download failed.", GetPath().c_str());
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -111,7 +111,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     if( GDT_Byte != eDT )
     {
         //add error info detailing incompatible data types
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox(), band contains incompatible byte data types, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Raster band contains incompatible byte data types, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -183,7 +183,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final relief_fetch file for writing, Failed to create output file, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create final output file for writing, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -268,7 +268,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if(nNoDataCount > 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+        CPLError(CE_Failure, CPLE_AppDefined, "Final downloaded elevation file contains '%d' noDataValues", nNoDataCount);
     }
     return nNoDataCount;
 }
@@ -297,7 +297,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     inDS = GDALOpen( infile.c_str(), GA_ReadOnly );
     if( NULL == inDS )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not open infile for reading.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open infile '%s' for reading, makeReliefOf() failed.", infile.c_str());
         return SURF_FETCH_E_IO_ERR;
     }
     
@@ -321,7 +321,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     GDALClose( inDS );
     if( NULL ==  pszDstWKT )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not get dstWKT projection information.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get dstWKT projection information, makeReliefOf() failed.");
         return SURF_FETCH_E_IO_ERR;
     }
     /*finished with the input file */
@@ -330,14 +330,14 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     hSrcDS = GDALOpen( path.c_str(), GA_ReadOnly );
     if(hSrcDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not open path for reading.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open path '%s' for reading, makeReliefOf() failed.", path.c_str());
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
     }
     nbands = GDALGetRasterCount( hSrcDS );
     if( nbands == 0 )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Read dataset has no bands information.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Read dataset contains no bands information, makeReliefOf() failed.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -345,7 +345,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     eDT = GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) );
     if( GDT_Byte != eDT )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), band contains incompatible byte data types.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Raster band contains incompatible byte data types, makeReliefOf() failed.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -377,7 +377,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final relief_fetch file for writing, Failed to create output file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create final output file for writing, makeReliefOf() failed.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -414,7 +414,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     if( eErr != CE_None )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, makeReliefOf() failed.");
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
         CPLFree((void*)pszDstWKT);
@@ -456,7 +456,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     if(nNoDataCount > 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf() after prepping final output file, found '%d' noDataValues", nNoDataCount);
+        CPLError(CE_Failure, CPLE_AppDefined, "Final makeReliefOf() elevation file contains '%d' noDataValues", nNoDataCount);
     }
     return nNoDataCount;
 }

--- a/src/ninja/relief_fetch.cpp
+++ b/src/ninja/relief_fetch.cpp
@@ -103,6 +103,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     hSrcDS = GDALOpen(GetPath().c_str(), GA_ReadOnly);
     if(hSrcDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox(), Could not open path for reading, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -110,6 +111,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     if( GDT_Byte != eDT )
     {
         //add error info detailing incompatible data types
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox(), band contains incompatible byte data types, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -142,6 +144,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         return SURF_FETCH_E_WARPER_ERR;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
@@ -164,6 +167,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if(nPixels <= 0 || nLines <= 0)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid nPixels and/or nLines for warp. Could not warp image, download failed.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -179,6 +183,7 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final relief_fetch file for writing, Failed to create output file, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -228,6 +233,31 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
         return SURF_FETCH_E_WARPER_ERR;
     }
 
+    GDALRasterBandH hSrcBand;
+    GDALRasterBandH hDstBand;
+
+    hSrcBand = GDALGetRasterBand(hSrcDS, 1);
+    hDstBand = GDALGetRasterBand(hDstDS, 1);
+
+    double dfNoData = GDALGetRasterNoDataValue(hSrcBand, NULL);
+
+    GDALSetRasterNoDataValue(hDstBand, dfNoData);
+
+    double *padfScanline;
+    padfScanline = (double *) CPLMalloc(sizeof(double)*nPixels);
+    int nNoDataCount = 0;
+    for(int i = 0;i < nLines;i++)
+    {
+        GDALRasterIO(hDstBand, GF_Read, 0, i, nPixels, 1, 
+                     padfScanline, nPixels, 1, GDT_Float64, 0, 0);
+        for(int j = 0; j < nPixels;j++)
+        {
+            if(CPLIsEqual(padfScanline[j], dfNoData))
+                nNoDataCount++;
+        }
+    }
+
+    CPLFree((void*)padfScanline);
     CPLFree((void*)pszDstWKT);
 
     GDALClose(hDstDS);
@@ -236,7 +266,11 @@ SURF_FETCH_E ReliefFetch::FetchBoundingBox( double *bbox, double resolution,
     CPLSetConfigOption("GTIFF_DIRECT_IO", "NO");
     CPLSetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", NULL);
 
-    return SURF_FETCH_E_NONE;
+    if(nNoDataCount > 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+    }
+    return nNoDataCount;
 }
 
 SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile, int nXSize, int nYSize )
@@ -263,6 +297,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     inDS = GDALOpen( infile.c_str(), GA_ReadOnly );
     if( NULL == inDS )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not open infile for reading.");
         return SURF_FETCH_E_IO_ERR;
     }
     
@@ -286,6 +321,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     GDALClose( inDS );
     if( NULL ==  pszDstWKT )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not get dstWKT projection information.");
         return SURF_FETCH_E_IO_ERR;
     }
     /*finished with the input file */
@@ -294,12 +330,14 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     hSrcDS = GDALOpen( path.c_str(), GA_ReadOnly );
     if(hSrcDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Could not open path for reading.");
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
     }
     nbands = GDALGetRasterCount( hSrcDS );
     if( nbands == 0 )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), Read dataset has no bands information.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -307,6 +345,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
     eDT = GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) );
     if( GDT_Byte != eDT )
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf(), band contains incompatible byte data types.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -338,6 +377,7 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
 
     if(hDstDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final relief_fetch file for writing, Failed to create output file.");
         GDALClose( hSrcDS );
         CPLFree((void*)pszDstWKT);
         return SURF_FETCH_E_IO_ERR;
@@ -381,11 +421,43 @@ SURF_FETCH_E ReliefFetch::makeReliefOf( std::string infile, std::string outfile,
         return SURF_FETCH_E_WARPER_ERR;
     }
 
+    GDALRasterBandH hSrcBand;
+    GDALRasterBandH hDstBand;
+
+    hSrcBand = GDALGetRasterBand(hSrcDS, 1);
+    hDstBand = GDALGetRasterBand(hDstDS, 1);
+
+    double dfNoData = GDALGetRasterNoDataValue(hSrcBand, NULL);
+
+    GDALSetRasterNoDataValue(hDstBand, dfNoData);
+
+    double *padfScanline;
+    int nPixels = GDALGetRasterXSize(hDstDS);
+    int nLines = GDALGetRasterYSize(hDstDS);
+    padfScanline = (double *) CPLMalloc(sizeof(double)*nPixels);
+    int nNoDataCount = 0;
+    for(int i = 0;i < nLines;i++)
+    {
+        GDALRasterIO(hDstBand, GF_Read, 0, i, nPixels, 1, 
+                     padfScanline, nPixels, 1, GDT_Float64, 0, 0);
+        for(int j = 0; j < nPixels;j++)
+        {
+            if(CPLIsEqual(padfScanline[j], dfNoData))
+                nNoDataCount++;
+        }
+    }
+
+    CPLFree((void*)padfScanline);
+
     GDALClose(hDstDS);
     GDALClose(hSrcDS);
     CPLFree((void*)pszDstWKT);
     CPLSetConfigOption("GTIFF_DIRECT_IO", "NO");
 
-    return SURF_FETCH_E_NONE; 
+    if(nNoDataCount > 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "ReliefFetch::makeReliefOf() after prepping final output file, found '%d' noDataValues", nNoDataCount);
+    }
+    return nNoDataCount;
 }
 

--- a/src/ninja/srtmclient.cpp
+++ b/src/ninja/srtmclient.cpp
@@ -68,27 +68,24 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
                                                const char *filename,
                                                char **options )
 {
-    if( NULL == filename )
+    if(NULL == filename)
     {
         return SURF_FETCH_E_BAD_INPUT;
     }
 
     if(APIKey == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "SRTM download failed. No API key specified.");
+        // this one might be a good candidate, for a throw
+        CPLError(CE_Failure, CPLE_AppDefined, "SRTM download failed. No API key specified.");
         return SURF_FETCH_E_BAD_INPUT;
     }
 
-    /*
-    ** We have an arbitrary limit on request size, 0.001 degrees
-    */
+    // We have an arbitrary limit on request size, 0.001 degrees, 111 meters (roughly 364 feet)
     if( fabs( bbox[0] - bbox[2] ) < 0.001 || fabs( bbox[1] - bbox[3] ) < 0.001 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Bounding box too small, must be greater than " \
-                  "0.001 x 0.001 degrees." );
-        return SURF_FETCH_E_BAD_INPUT;
+        // this one might be a good candidate, for a throw
+        CPLError(CE_Failure, CPLE_AppDefined, "Bounding box too small, must be greater than 0.001 x 0.001 degrees.");
+        return SURF_FETCH_E_BOUNDS_ERR;
     }
 
     // calculate the final bbox to clip to, data will be downloaded using a buffered bbox then later clipped to this bbox
@@ -121,14 +118,12 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
                            buffered_bbox[1], buffered_bbox[0], buffered_bbox[3], buffered_bbox[0],
                            buffered_bbox[3], buffered_bbox[2], buffered_bbox[1], buffered_bbox[2],
                            buffered_bbox[1], buffered_bbox[0] );
-    CPLDebug( "SRTM_CLIENT", "Testing if %s contains %s", osDataPath.c_str(),
-              pszGeom );
-
+    CPLDebug("SRTM_CLIENT", "Testing if %s contains %s", osDataPath.c_str(), pszGeom);
     if( !NinjaOGRContain( pszGeom, osDataPath.c_str(), "srtm_region" ) )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Requested DEM is outside of the SRTM bounds." );
-        return SURF_FETCH_E_BAD_INPUT;
+        // this one might be a good candidate, for a throw
+        CPLError(CE_Failure, CPLE_AppDefined, "Requested DEM is outside of the SRTM bounds.");
+        return SURF_FETCH_E_BOUNDS_ERR;
     }
 
     const char *pszUrl;
@@ -137,13 +132,11 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     //get UTM zone as EPSG
     nEpsgCode = BoundingBoxUtm( bbox );
 
-    /*
-    ** Better check?
-    */
+    // Better check?
     if( nEpsgCode < 1 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Invalid EPSG code." );
-        return SURF_FETCH_E_BAD_INPUT;
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid EPSG code.");
+        return SURF_FETCH_E_BOUNDS_ERR;
     }
 
     /*-----------------------------------------------------------------------------
@@ -152,36 +145,33 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     pszUrl = CPLSPrintf( SRTM_REQUEST_TEMPLATE, buffered_bbox[2], buffered_bbox[0], buffered_bbox[3], buffered_bbox[1], APIKey );
     psResult = NULL;
     psResult = CPLHTTPFetch( pszUrl, NULL );
-    CPLDebug( "SRTM_CLIENT", "Request URL: %s", pszUrl );
+    CPLDebug("SRTM_CLIENT", "Request URL: %s", pszUrl);
 
      /*-----------------------------------------------------------------------------
      *  Check the result of the request
      *-----------------------------------------------------------------------------*/
-    CPLDebug( "SRTM_CLIENT", "Response: %s", psResult->pabyData );
+    CPLDebug("SRTM_CLIENT", "Response: %s", psResult->pabyData);
     if( !psResult || psResult->nStatus != 0 || psResult->nDataLen < 1 || psResult->pszErrBuf != NULL) 
     {
         if( strstr( (char*)psResult->pszErrBuf, "HTTP error code : 401" ) )
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to download file, bad API key." );
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to download file, bad API key.");
         }
         else
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Failed to download file." );
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to download file.");
         }
         CPLHTTPDestroyResult( psResult );
-        return SURF_FETCH_E_BAD_INPUT;
+        return SURF_FETCH_E_TIMEOUT;  // no download failed error code?? use the next closest thing
     }
 
     //make a temporary file to hold the result of the HTTP request (in lat/lon coordinates)
-    CPLDebug( "SRTM_CLIENT", "Writing temporary file to: %s", CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"));
+    CPLDebug("SRTM_CLIENT", "Writing temporary file to: %s", CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"));
     VSILFILE *fout;
     fout = VSIFOpenL( CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"), "wb" );
     if( !fout )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Failed to open srtm file for writing." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open srtm file for writing.");
         CPLHTTPDestroyResult( psResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -192,7 +182,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
      /*-----------------------------------------------------------------------------
      *  Warp and clip to UTM coords
      *-----------------------------------------------------------------------------*/
-    CPLDebug( "SRTM_CLIENT", "Warping to UTM..." );
+    CPLDebug("SRTM_CLIENT", "Warping to UTM...");
 
     GDALResampleAlg eAlg = GRA_NearestNeighbour;
 
@@ -206,7 +196,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     hSrcDS = GDALOpen(CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"), GA_ReadOnly);
     if(hSrcDS == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Failed to open downloaded image for warp, download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open downloaded image for warp, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
     hDriver = GDALGetDriverByName("GTiff");
@@ -241,8 +231,8 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     CPLPopErrorHandler();
     if(eErr != CE_None)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp image, download failed." );
-        return SURF_FETCH_E_IO_ERR;
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
+        return SURF_FETCH_E_WARPER_ERR;
     }
     GDALDestroyGenImgProjTransformer(hTransformArg);
 
@@ -260,8 +250,8 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(nPixels <= 0 || nLines <= 0)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Invalid nPixels and/or nLines for warp. Could not warp image, download failed." );
-        return SURF_FETCH_E_WARPER_ERR;  // assumption
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid nPixels and/or nLines for warp. Could not warp image, download failed.");
+        return SURF_FETCH_E_WARPER_ERR;
     }
 
     adfDstGeoTransform[0] = dfMinX;
@@ -274,7 +264,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Failed to open final srtm file for writing, download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final srtm file for writing, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -319,13 +309,12 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if( eErr != CE_None )
     {
-        CPLError( CE_Failure, CPLE_AppDefined, "Could not warp image, download failed." );
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not warp image, download failed.");
         CPLFree((void*)pszDstWKT);
         GDALClose(hDstDS);
         GDALClose(hSrcDS);
-        return SURF_FETCH_E_IO_ERR;
+        return SURF_FETCH_E_WARPER_ERR;
     }
-
 
     GDALRasterBandH hSrcBand;
     GDALRasterBandH hDstBand;
@@ -354,7 +343,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     if(nNoDataCount > 0)
     {
         std::string oErrorString = "SRTMClient::fetchBoundingBox() after downloading, warping, and clipping, found noDataValues!!!";
-        CPLError( CE_Failure, CPLE_AppDefined, oErrorString.c_str() );
+        CPLError(CE_Failure, CPLE_AppDefined, oErrorString.c_str());
         return nNoDataCount;
     }
 

--- a/src/ninja/srtmclient.cpp
+++ b/src/ninja/srtmclient.cpp
@@ -70,6 +70,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 {
     if(NULL == filename)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "SRTMClient::FetchBoundingBox(), Input filename is NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
 
@@ -122,7 +123,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     if( !NinjaOGRContain( pszGeom, osDataPath.c_str(), "srtm_region" ) )
     {
         // this one might be a good candidate, for a throw
-        CPLError(CE_Failure, CPLE_AppDefined, "Requested DEM is outside of the SRTM bounds.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to locate product. Requested DEM is outside of the SRTM bounds.");
         return SURF_FETCH_E_BOUNDS_ERR;
     }
 
@@ -171,7 +172,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     fout = VSIFOpenL( CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"), "wb" );
     if( !fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open srtm file for writing.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open temporary srtm file for writing, Failed to create output file, download failed.");
         CPLHTTPDestroyResult( psResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -264,7 +265,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final srtm file for writing, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final srtm file for writing, Failed to create output file, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -340,13 +341,6 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
         }
     }
 
-    if(nNoDataCount > 0)
-    {
-        std::string oErrorString = "SRTMClient::fetchBoundingBox() after downloading, warping, and clipping, found noDataValues!!!";
-        CPLError(CE_Failure, CPLE_AppDefined, oErrorString.c_str());
-        return nNoDataCount;
-    }
-
     CPLFree((void*)padfScanline);
     CPLFree((void*)pszDstWKT);
 
@@ -358,6 +352,10 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     CPLSetConfigOption("GTIFF_DIRECT_IO", "NO");
     CPLSetConfigOption("CPL_VSIL_CURL_ALLOWED_EXTENSIONS", NULL);
 
-    return SURF_FETCH_E_NONE;
+    if(nNoDataCount > 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "SRTMClient::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+    }
+    return nNoDataCount;
 }
 

--- a/src/ninja/srtmclient.cpp
+++ b/src/ninja/srtmclient.cpp
@@ -70,7 +70,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 {
     if(NULL == filename)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SRTMClient::FetchBoundingBox(), Input filename is NULL.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input, The input filename is NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
 
@@ -172,7 +172,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
     fout = VSIFOpenL( CPLFormFilename(CPLGetPath(filename), "NINJA_SRTM", ".tif"), "wb" );
     if( !fout )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open temporary srtm file for writing, Failed to create output file, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create temporary srtm file for writing, download failed.");
         CPLHTTPDestroyResult( psResult );
         return SURF_FETCH_E_IO_ERR;
     }
@@ -265,7 +265,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(hDstDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to open final srtm file for writing, Failed to create output file, download failed.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create final output file for writing, download failed.");
         return SURF_FETCH_E_IO_ERR;
     }
 
@@ -354,7 +354,7 @@ SURF_FETCH_E SRTMClient::FetchBoundingBox( double *bbox, double resolution,
 
     if(nNoDataCount > 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SRTMClient::FetchBoundingBox() after downloading, warping, and clipping, found '%d' noDataValues", nNoDataCount);
+        CPLError(CE_Failure, CPLE_AppDefined, "Final downloaded elevation file contains '%d' noDataValues", nNoDataCount);
     }
     return nNoDataCount;
 }

--- a/src/ninja/surface_fetch.cpp
+++ b/src/ninja/surface_fetch.cpp
@@ -92,7 +92,7 @@ SURF_FETCH_E SurfaceFetch::makeReliefOf( std::string infile, std::string outfile
  * @param point x, y point in WGS 84 longitude, latitude
  * @param buffer length of the buffer for x and y
  * @param units buffer units
- * @param resoultion output cell resolution
+ * @param resolution output cell resolution
  * @param filename output filename
  * @param options list of options, not checked in here.
  * @return number of no data values on success, < 0 on error
@@ -115,12 +115,12 @@ SURF_FETCH_E SurfaceFetch::FetchPoint(double *point, double *buffer,
  * @param point a x,y point in WGS 84 longitude, latitude
  * @param buffer length of a buffer in the x and y directions
  * @param units the units for the buffer
- * @param the 4 element array to be filled in by the function, clockwise from
- *        north:
+ * @param the 4 element array to be filled in by the function, clockwise from north:
  *        bbox[0] -> north
  *        bbox[1] -> east
  *        bbox[2] -> south
  *        bbox[3] -> west
+ *
  * @return zero on success, negative otherwise
  */
 SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer, 
@@ -129,7 +129,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
 {
     if(point == NULL || buffer == NULL || bbox == NULL)
     {
-        fprintf(stderr, "Invalid input\n");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input");
         return SURF_FETCH_E_BAD_INPUT;
     }
     OGRSpatialReference oSrcSRS, oDstSRS;
@@ -230,8 +230,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
 
     if( pszArchive == NULL || pszDstFile == NULL || pszFile == NULL )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Invalid input" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input");
         return SURF_FETCH_E_BAD_INPUT;
     }
     const char *pszVSIName = CPLSPrintf( "/vsizip/%s", pszArchive );
@@ -241,8 +240,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     int nCount = CSLCount( papszFileList );
     if( nCount < 1 )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "Archive is empty" );
+        CPLError(CE_Failure, CPLE_AppDefined, "Archive is empty");
         return SURF_FETCH_E_IO_ERR;
     }
     /*
@@ -261,8 +259,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     }
     if( !bFound )
     {
-        CPLError( CE_Failure, CPLE_AppDefined,
-                  "File could not be found in archive" );
+        CPLError(CE_Failure, CPLE_AppDefined, "File could not be found in archive");
         CSLDestroy( papszFileList );
         return SURF_FETCH_E_BAD_INPUT;
     }
@@ -279,8 +276,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
         fout = VSIFOpenL( pszDstFile, "wb" );
         if( !fout || !fin )
         {
-            CPLError( CE_Failure, CPLE_AppDefined,
-                      "Failed to open files" );
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to open files");
             CPLFree( pabyData );
             CSLDestroy( papszFileList );
             return SURF_FETCH_E_IO_ERR;

--- a/src/ninja/surface_fetch.cpp
+++ b/src/ninja/surface_fetch.cpp
@@ -129,7 +129,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
 {
     if(point == NULL || buffer == NULL || bbox == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), Invalid input, one or more of 'point', 'buffer', and 'bbox' are NULL.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input, One or more of the inputs 'point', 'buffer', and 'bbox' are NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
     OGRSpatialReference oSrcSRS, oDstSRS;
@@ -151,7 +151,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
     poCT = OGRCreateCoordinateTransformation( &oSrcSRS, &oDstSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), could not generate OGRCoordinateTransformation, could not warp point.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not generate OGRCoordinateTransformation, could not warp point.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -170,7 +170,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
     poCT = OGRCreateCoordinateTransformation(&oDstSRS, &oSrcSRS);
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), could not generate OGRCoordinateTransformation, could not warp buffered bbox.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not generate OGRCoordinateTransformation, could not warp buffered bbox.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -199,7 +199,7 @@ SURF_FETCH_E SurfaceFetch::WarpBoundingBox(double *bbox)
     poCT = OGRCreateCoordinateTransformation( &oSrcSRS, &oDstSRS );
     if(poCT == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::WarpBoundingBox(), could not generate OGRCoordinateTransformation, could not warp bbox.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not generate OGRCoordinateTransformation, could not warp bbox.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -233,7 +233,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
 
     if( pszArchive == NULL || pszDstFile == NULL || pszFile == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Invalid input, one or more of 'pszArchive', 'pszFile', and 'pszDstFile' are NULL.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input, One or more of the inputs 'pszArchive', 'pszFile', and 'pszDstFile' are NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
     const char *pszVSIName = CPLSPrintf( "/vsizip/%s", pszArchive );
@@ -243,7 +243,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     int nCount = CSLCount( papszFileList );
     if( nCount < 1 )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Archive is empty.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Archive is empty, Failed to extract file from zip.");
         return SURF_FETCH_E_IO_ERR;
     }
     /*
@@ -262,7 +262,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     }
     if( !bFound )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), File could not be found in archive.");
+        CPLError(CE_Failure, CPLE_AppDefined, "File could not be found in archive.");
         CSLDestroy( papszFileList );
         return SURF_FETCH_E_BAD_INPUT;
     }
@@ -279,7 +279,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
         fout = VSIFOpenL( pszDstFile, "wb" );
         if( !fout || !fin )
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Failed to open files for extraction.");
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to open files for extraction.");
             CPLFree( pabyData );
             CSLDestroy( papszFileList );
             return SURF_FETCH_E_IO_ERR;

--- a/src/ninja/surface_fetch.cpp
+++ b/src/ninja/surface_fetch.cpp
@@ -129,7 +129,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
 {
     if(point == NULL || buffer == NULL || bbox == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input");
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), Invalid input, one or more of 'point', 'buffer', and 'bbox' are NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
     OGRSpatialReference oSrcSRS, oDstSRS;
@@ -151,6 +151,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
     poCT = OGRCreateCoordinateTransformation( &oSrcSRS, &oDstSRS );
     if(poCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), could not generate OGRCoordinateTransformation, could not warp point.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -169,6 +170,7 @@ SURF_FETCH_E SurfaceFetch::CreateBoundingBox(double *point, double *buffer,
     poCT = OGRCreateCoordinateTransformation(&oDstSRS, &oSrcSRS);
     if(poCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::CreateBoundingBox(), could not generate OGRCoordinateTransformation, could not warp buffered bbox.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -197,6 +199,7 @@ SURF_FETCH_E SurfaceFetch::WarpBoundingBox(double *bbox)
     poCT = OGRCreateCoordinateTransformation( &oSrcSRS, &oDstSRS );
     if(poCT == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::WarpBoundingBox(), could not generate OGRCoordinateTransformation, could not warp bbox.");
         return SURF_FETCH_E_WARPER_ERR;
     }
 
@@ -230,7 +233,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
 
     if( pszArchive == NULL || pszDstFile == NULL || pszFile == NULL )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input");
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Invalid input, one or more of 'pszArchive', 'pszFile', and 'pszDstFile' are NULL.");
         return SURF_FETCH_E_BAD_INPUT;
     }
     const char *pszVSIName = CPLSPrintf( "/vsizip/%s", pszArchive );
@@ -240,7 +243,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     int nCount = CSLCount( papszFileList );
     if( nCount < 1 )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Archive is empty");
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Archive is empty.");
         return SURF_FETCH_E_IO_ERR;
     }
     /*
@@ -259,7 +262,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
     }
     if( !bFound )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "File could not be found in archive");
+        CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), File could not be found in archive.");
         CSLDestroy( papszFileList );
         return SURF_FETCH_E_BAD_INPUT;
     }
@@ -276,7 +279,7 @@ int SurfaceFetch::ExtractFileFromZip( const char *pszArchive,
         fout = VSIFOpenL( pszDstFile, "wb" );
         if( !fout || !fin )
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "Failed to open files");
+            CPLError(CE_Failure, CPLE_AppDefined, "SurfaceFetch::ExtractFileFromZip(), Failed to open files for extraction.");
             CPLFree( pabyData );
             CSLDestroy( papszFileList );
             return SURF_FETCH_E_IO_ERR;

--- a/src/ninja/surface_fetch.h
+++ b/src/ninja/surface_fetch.h
@@ -37,6 +37,8 @@
 #include "ninjaUnits.h"
 #include "ninja_conv.h"
 
+// note, a return of nNoDataCount is done if success, which is equal to SURF_FETCH_E_NONE
+// when zero NO_DATA values are found in the fetched data at the end of the fetching process
 typedef int SURF_FETCH_E;
 #define SURF_FETCH_E_NONE          0
 #define SURF_FETCH_E_IO_ERR       -1
@@ -44,7 +46,7 @@ typedef int SURF_FETCH_E;
 #define SURF_FETCH_E_WARPER_ERR   -3
 #define SURF_FETCH_E_BAD_INPUT    -4
 #define SURF_FETCH_E_SIZE_LIMIT   -5
-#define SURF_FETCH_E_NO_GDAL_DATA -6
+#define SURF_FETCH_E_NO_GDAL_DATA -6  // not really used, instead we output the numNoDataValues
 #define SURF_FETCH_E_TIMEOUT      -7
 
 class SurfaceFetch
@@ -59,6 +61,16 @@ public:
     SurfaceFetch();
     virtual ~SurfaceFetch();
 
+    /**
+    * \brief Fetch surface data for a bounding box.
+    *
+    * \param bbox north, east, south west bounding box
+    * \param resolution output resolution in meters
+    * \param filename file to write data into
+    * \param options key/value options, unused
+    *
+    * \return number of no data values on success, < 0 on error
+    */
     virtual SURF_FETCH_E FetchBoundingBox(double *bbox, double resolution,
                                           const char *filename,
                                           char **options) = 0;

--- a/src/ninja/wrf3dInitialization.cpp
+++ b/src/ninja/wrf3dInitialization.cpp
@@ -228,11 +228,11 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     if ( dstWkt.empty() ) {
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
@@ -245,7 +245,7 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     poDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
     CPLPopErrorHandler();
     if( poDS == NULL ) {
-        throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS); // close original wxModel file
     
@@ -271,7 +271,7 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         CPLPopErrorHandler();
         if( srcDS == NULL ) {
-            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         CPLDebug("WX_MODEL_INITIALIZATION", "var3dList[i] = %s", var3dList[i].c_str());
@@ -355,12 +355,12 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
 
         if(poCT==NULL || !poCT->Transform(1, &xCenter, &yCenter))
         {
-            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Transformation failed.");
+            throw std::runtime_error("Transformation failed.");
         }
 
         //if(poCT==NULL || !poCT->Transform(2, xCenterArray, yCenterArray))  //for testing
         //{
-        //    throw std::runtime_error("wrf3dInitialization::set3dGrids(), Transformation failed.");
+        //    throw std::runtime_error("Transformation failed.");
         //}
 
 

--- a/src/ninja/wrf3dInitialization.cpp
+++ b/src/ninja/wrf3dInitialization.cpp
@@ -228,11 +228,11 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     if ( dstWkt.empty() ) {
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw("Cannot open dem file in wrf3dInitialization::set3dGrids()");
+            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw("Cannot open dem file in wrfedInitialization::set3dGrids()");
+            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
@@ -245,11 +245,9 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     poDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
     CPLPopErrorHandler();
     if( poDS == NULL ) {
-        throw badForecastFile("Cannot open forecast file in wrf3dInitialization::set3dGrids()");
+        throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not open forecast file, bad forecast file.");
     }
-    else {
-        GDALClose((GDALDatasetH) poDS ); // close original wxModel file
-    }
+    GDALClose((GDALDatasetH) poDS); // close original wxModel file
     
     int nLayers;
     int numStripRows = 0; //number of rows to strip from warped image
@@ -273,10 +271,10 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         CPLPopErrorHandler();
         if( srcDS == NULL ) {
-            throw badForecastFile("Cannot open forecast file in wrf3dInitialization::set3dGrids()");
+            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
-        //cout<<"var3dList[i] = " <<var3dList[i]<<endl;
+        CPLDebug("WX_MODEL_INITIALIZATION", "var3dList[i] = %s", var3dList[i].c_str());
 
         /*
          * Set up spatial reference stuff for setting projections
@@ -356,10 +354,14 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         delete poLatLong;
 
         if(poCT==NULL || !poCT->Transform(1, &xCenter, &yCenter))
-            printf("Transformation failed.\n");
+        {
+            throw std::runtime_error("wrf3dInitialization::set3dGrids(), Transformation failed.");
+        }
 
         //if(poCT==NULL || !poCT->Transform(2, xCenterArray, yCenterArray))  //for testing
-            //printf("Transformation failed.\n");
+        //{
+        //    throw std::runtime_error("wrf3dInitialization::set3dGrids(), Transformation failed.");
+        //}
 
 
         /*
@@ -406,6 +408,10 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,
                                                         1.0, NULL );
+        if(wrpDS == NULL)
+        {
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+        }
 
 
         //=======for testing==================================//
@@ -443,7 +449,6 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         //temp2Grid.ascii2png( outFilename, scalarLegendFilename, legendUnits, legendTitle, writeLegend, keepTiff );*/
         //=======end testing=================================//
         
-       
         
         if(var3dList[i] == "U" || var3dList[i] == "V" || var3dList[i] == "T" || var3dList[i] == "QCLOUD"){
             nLayers = wxModel_nLayers - 1;
@@ -566,7 +571,7 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
             }
 
             
-            //cout<<"Grabbing band number: " <<bandNum<<endl;
+            CPLDebug("WX_MODEL_INITIALIZATION", "Grabbing band number: %d", bandNum);
 
             if( var3dList[i] == "T" ) {
                 GDAL2AsciiGrid( wrpDS, bandNum, airGrid );
@@ -726,9 +731,9 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
                             input.dem.prjString.c_str());
     testGrid = -1;
 	
-	//cout<<"uGrid rows, cols = "<<uGrid.get_nRows()<< ", "<<uGrid.get_nCols()<<endl;
-	//cout<<"uArray rows, cols = "<<uArray.rows_<<", "<<uArray.cols_<<endl;
-	//cout<<"testGrid rows, cols = "<<testGrid.get_nRows() <<", "<<testGrid.get_nCols()<<endl;
+	//std::cout << "uGrid rows, cols = " << uGrid.get_nRows() << ", " << uGrid.get_nCols() << std::endl;
+	//std::cout << "uArray rows, cols = " << uArray.rows_ << ", " << uArray.cols_ << std::endl;
+	//std::cout << "testGrid rows, cols = " << testGrid.get_nRows() << ", " << testGrid.get_nCols() << std::endl;
 	
 	//std::string outFilename = "uArray0.png";
     //std::string scalarLegendFilename = "uArray_legend";
@@ -784,7 +789,6 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     endWxInterpolation = omp_get_wtime();
     input.Com->ninjaCom(ninjaComClass::ninjaNone, "Interpolation time was %lf seconds.",endWxInterpolation-startWxInterpolation);
     #endif
-    
 
     /*
      * deallocate temporary storage.
@@ -1024,7 +1028,6 @@ void wrf3dInitialization::setGlobalAttributes(WindNinjaInputs &input)
         throw std::runtime_error( os.str() );
     }
 
-    
 }
 
 

--- a/src/ninja/wrfSurfInitialization.cpp
+++ b/src/ninja/wrfSurfInitialization.cpp
@@ -337,11 +337,11 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not open input dem file.");
+            throw std::runtime_error("Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
+            throw std::runtime_error("Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
@@ -560,7 +560,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     poDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
     CPLPopErrorHandler();
     if( poDS == NULL ) {
-        throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
     }
     GDALClose((GDALDatasetH) poDS); // close original wxModel file
 
@@ -582,7 +582,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         CPLPopErrorHandler();
         if( srcDS == NULL ) {
-            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
+            throw std::runtime_error("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
         CPLDebug("WRF", "varList[i] = %s", varList[i].c_str());
@@ -630,11 +630,14 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                           PARAMETER[\"latitude_of_origin\","+boost::lexical_cast<std::string>(moadCenLat)+"],\
                           UNIT[\"Meter\",1]]";
         }
-        else if(mapProj == 6){  //lat/long
-            throw badForecastFile("Cannot initialize with a forecast file in lat/long spacing. \
-                                   Forecast file must be in a projected coordinate system.");
+        else if(mapProj == 6)  // lat/long
+        {
+            throw badForecastFile("Cannot initialize with a forecast file in lat/long spacing. Forecast file must be in a projected coordinate system.");
         }
-        else throw badForecastFile("Cannot determine projection from the forecast file information.");
+        else
+        {
+            throw badForecastFile("Cannot determine projection from the forecast file information.");
+        }
 
         OGRSpatialReference oSRS, *poLatLong;
         char *srcWKT = NULL;
@@ -667,7 +670,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         if(poCT==NULL || !poCT->Transform(1, &xCenter, &yCenter))
         {
-            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Transformation failed.");
+            throw std::runtime_error("Transformation failed.");
         }
 
         CPLDebug("WRF", "xCenter, yCenter= %f, %f", xCenter, yCenter);

--- a/src/ninja/wrfSurfInitialization.cpp
+++ b/src/ninja/wrfSurfInitialization.cpp
@@ -128,8 +128,15 @@ int wrfSurfInitialization::getEndHour()
 */
 void wrfSurfInitialization::checkForValidData()
 {
-    // open ds variable by variable
     GDALDataset *srcDS;
+    srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
+    if(srcDS == NULL)
+    {
+        throw std::runtime_error("Could not open forecast file, bad forecast file.");
+    }
+    GDALClose((GDALDatasetH)srcDS);
+
+    // open ds variable by variable
     std::string temp;
     std::string srcWkt;
     int nBands = 0;
@@ -146,18 +153,17 @@ void wrfSurfInitialization::checkForValidData()
     for( unsigned int i = 0;i < varList.size();i++ ) {
 
         temp = "NETCDF:\"" + wxModelFileName + "\":" + varList[i];
-        //cout << "temp = " <<temp<<endl;
+        CPLDebug("WRF", "temp = %s", temp.c_str());
 
         CPLPushErrorHandler(&CPLQuietErrorHandler);
         srcDS = (GDALDataset*)GDALOpen( temp.c_str(), GA_ReadOnly );
         CPLPopErrorHandler();
         if( srcDS == NULL )
-            throw badForecastFile("Cannot open forecast file.");
+            throw badForecastFile("Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
 
         //Get total bands (time steps)
         nBands = srcDS->GetRasterCount();
-        //cout<<"nBands = " <<nBands<<endl;
-        nBands = srcDS->GetRasterCount();
+        CPLDebug("WRF", "bands = %d", nBands);
         int nXSize, nYSize;
         GDALRasterBand *poBand;
         int pbSuccess;
@@ -167,8 +173,8 @@ void wrfSurfInitialization::checkForValidData()
         nXSize = srcDS->GetRasterXSize();
         nYSize = srcDS->GetRasterYSize();
 
-        //cout<<"nXsize = " <<nXSize<<endl;
-        //cout<<"nYsize = " <<nYSize<<endl;
+        CPLDebug("WRF", "nXSize = %d", nXSize);
+        CPLDebug("WRF", "nYSize = %d", nYSize);
 
         //loop over all bands for this variable (bands are time steps)
         for(int j = 1; j <= nBands; j++)
@@ -315,7 +321,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         if(input.ninjaTime == timeList[i])
         {
             bandNum = i + 1;
-            //cout<<"Grabbing band number: " <<bandNum<<endl;
+            CPLDebug("WRF", "Grabbing band number: %d", bandNum);
             break;
         }
     }
@@ -331,15 +337,11 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         //try to open original
         poDS = (GDALDataset*)GDALOpen( input.dem.fileName.c_str(), GA_ReadOnly );
         if( poDS == NULL ) {
-            CPLDebug( "wrfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            throw("Cannot open dem file in wrfInitialization::setSurfaceGrids()");
+            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not open input dem file.");
         }
         dstWkt = poDS->GetProjectionRef();
         if( dstWkt.empty() ) {
-            CPLDebug( "wrfInitialization::setSurfaceGrids()",
-                    "Bad projection reference" );
-            throw("Cannot open dem file in wrfInitialization::setSurfaceGrids()");
+            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not get projection reference from input dem file.");
         }
         GDALClose((GDALDatasetH) poDS );
     }
@@ -384,7 +386,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         status = nc_get_att_int( ncid, NC_GLOBAL, "MAP_PROJ", &mapProj );
     }
 
-    //cout<<"MAP_PROJ = "<<mapProj<<endl;
+    CPLDebug("WRF", "MAP_PROJ = %d", mapProj);
 
     /*
      * Get global attributes DX, DY
@@ -558,14 +560,10 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     poDS = (GDALDataset*)GDALOpenShared( input.forecastFilename.c_str(), GA_ReadOnly );
     CPLPopErrorHandler();
     if( poDS == NULL ) {
-        CPLDebug( "wrfInitialization::setSurfaceGrids()",
-                 "Bad forecast file");
-        throw badForecastFile("Cannot open forecast file in wrfInitialization::setSurfaceGrids()");
+        throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not open forecast file, bad forecast file.");
     }
-    else {
-        GDALClose((GDALDatasetH) poDS ); // close original wxModel file
-    }
-        
+    GDALClose((GDALDatasetH) poDS); // close original wxModel file
+
     // open ds one by one, set projection, warp, then write to grid
     GDALDataset *srcDS, *wrpDS;
     std::string temp;
@@ -584,11 +582,10 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         srcDS = (GDALDataset*)GDALOpenShared( temp.c_str(), GA_ReadOnly );
         CPLPopErrorHandler();
         if( srcDS == NULL ) {
-            CPLDebug( "wrfInitialization::setSurfaceGrids()",
-                    "Bad forecast file" );
+            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Could not get NETCDF variable '"+varList[i]+"' from forecast file, bad forecast file.");
         }
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "varList[i] = %s", varList[i].c_str());
+        CPLDebug("WRF", "varList[i] = %s", varList[i].c_str());
 
         /*
          * Set up spatial reference stuff for setting projections
@@ -645,7 +642,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         oSRS.importFromWkt(&prj2);
         oSRS.exportToWkt(&srcWKT);
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "srcWKT= %s", srcWKT);
+        CPLDebug("WRF", "srcWKT= %s", srcWKT);
 
         OGRCoordinateTransformation *poCT;
         poLatLong = oSRS.CloneGeogCS();
@@ -669,9 +666,11 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         delete poLatLong;
 
         if(poCT==NULL || !poCT->Transform(1, &xCenter, &yCenter))
-            printf("Transformation failed.\n");
+        {
+            throw std::runtime_error("wrfInitialization::setSurfaceGrids(), Transformation failed.");
+        }
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "xCenter, yCenter= %f, %f", xCenter, yCenter);
+        CPLDebug("WRF", "xCenter, yCenter= %f, %f", xCenter, yCenter);
 
         /*
          * Set the geostransform for the WRF file
@@ -689,9 +688,9 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                     (yCenter+(nrows*dy)),
                                     0, -(dy)};
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "ulcornerX, ulcornerY= %f, %f", (xCenter-(ncols*dx)), (yCenter+(nrows*dy)));
-        CPLDebug("WX_MODEL_INITIALIZATION", "nXSize, nYsize= %d, %d", nXSize, nYSize);
-        CPLDebug("WX_MODEL_INITIALIZATION", "dx= %f", dx);
+        CPLDebug("WRF", "ulcornerX, ulcornerY= %f, %f", (xCenter-(ncols*dx)), (yCenter+(nrows*dy)));
+        CPLDebug("WRF", "nXSize, nYsize= %d, %d", nXSize, nYSize);
+        CPLDebug("WRF", "dx= %f", dx);
 
         srcDS->SetGeoTransform(adfGeoTransform);
 
@@ -712,7 +711,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
 
         int nBandCount = srcDS->GetRasterCount();
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "band count = %d", nBandCount);
+        CPLDebug("WRF", "band count = %d", nBandCount);
 
         if( pbSuccess == false )
             dfNoData = -9999.0;
@@ -727,7 +726,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                 // direct calculation of FROM wx TO dem, already has the appropriate sign
                 if(!GDALCalculateCoordinateTransformationAngle( srcDS, coordinateTransformationAngle, dstWkt.c_str() ))  // this is FROM wx TO dem
                 {
-                    printf("Warning: Unable to calculate coordinate transform angle for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate coordinate transform angle for the wxModel.");
                 }
             }
         }
@@ -736,6 +735,10 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,
                                                         1.0, NULL );
+        if(wrpDS == NULL)
+        {
+            throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
+        }
 
         //=======for testing==================================//
         /*AsciiGrid<double> tempGrid;
@@ -758,7 +761,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         }*/
         //=======end testing=================================//
 
-        CPLDebug("WX_MODEL_INITIALIZATION", "band number to write = %d", bandNum);
+        CPLDebug("WRF", "band number to write = %d", bandNum);
 
         if( varList[i] == "T2" ) {
             GDAL2AsciiGrid( wrpDS, bandNum, airGrid );

--- a/src/ninja/wxModelInitialization.cpp
+++ b/src/ninja/wxModelInitialization.cpp
@@ -384,12 +384,17 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
                                getStartHour(), getEndHour() );
         throw std::logic_error(pszErrMsg);
     }
+
     GDALDataset *poDS = (GDALDataset*)GDALOpen( demFile.c_str(), GA_ReadOnly );
+    if(poDS == NULL)
+    {
+        throw badForecastFile("Could not download weather forecast, could not open DEM to get bounds.");
+    }
+
     double bounds[4];
     if( !GDALGetBounds( poDS, bounds ) )
     {
-        throw badForecastFile("Could not download weather forecast, invalid "
-                              "projection for the DEM");
+        throw badForecastFile("Could not download weather forecast, could not get bounds from the DEM.");
     }
 
     /*
@@ -422,14 +427,14 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     CPLDebug( "WINDNINJA", "Forecast URL: %s", urlAddress.c_str() );
     if( poResult == NULL )
     {
-      CPLHTTPDestroyResult( poResult );
-      throw ( badForecastFile( "CPLHTTPResult is NULL!" ) );
+        CPLHTTPDestroyResult(poResult);
+        throw badForecastFile("CPLHTTPResult is NULL!");
     }
 
     if( poResult->nStatus != 0 )
     {
-      CPLHTTPDestroyResult( poResult );
-      throw ( badForecastFile( poResult->pszErrBuf ) );
+        CPLHTTPDestroyResult(poResult);
+        throw badForecastFile(poResult->pszErrBuf);
     }
 
     if (poResult->pszErrBuf && urlAddress.find("NDFD") != std::string::npos)
@@ -461,8 +466,8 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     fout = VSIFOpenL( tempFileName.c_str(), "w" );
     if( fout == NULL )
     {
-      CPLHTTPDestroyResult( poResult );
-      throw ( badForecastFile( "Failed to download forecast." ) );
+      CPLHTTPDestroyResult(poResult);
+      throw badForecastFile("Failed to download forecast.");
     }
     VSIFWriteL( poResult->pabyData, poResult->nDataLen, 1, fout );
     CPLHTTPDestroyResult( poResult );
@@ -485,7 +490,7 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
         {
             VSIUnlink( tempFileName.c_str() );
         }
-        throw ( badForecastFile( "Failed to download forecast. File is not an *.nc file" ) );
+        throw badForecastFile("Failed to download forecast. File is not an *.nc file");
     }
     nc_close( ncid );
     }
@@ -535,10 +540,14 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     }
     wxModelFileName = newFileName;
     try	{
-    checkForValidData();
+        checkForValidData();
     }
     catch( badForecastFile &e ) {
-    std::cout << endl << endl << endl << endl << e.what() << endl << endl << endl << endl;
+        if(!bSaveForecast)
+        {
+            VSIUnlink(wxModelFileName.c_str()); // do some clean-up (delete the bad file)
+        }
+        throw;  // rethrow the exception to be caught somewhere else
     }
 
     return newFileName;
@@ -670,17 +679,14 @@ wxModelInitialization::getTimeList(const char *pszVariable,
         else{        
             srcDS = (GDALDataset*)GDALOpenShared( wxModelFileName.c_str(), GA_ReadOnly );
         }
-
-
         if( srcDS == NULL ) {
-            CPLDebug( "wxModelInitialization::getTimeList()",
-                    "Bad forecast file" );
+            throw std::runtime_error("wxModelInitialization::getTimeList(), Could not open forecast file, bad forecast file.");
         }
 
         //get time info from 10u band
         GDALRasterBand *poBand = get10UBand(srcDS);
         if (poBand == NULL) {
-            CPLDebug( "wxModelInitialization::getTimeList()", " getTimeList() failed - no 10m UGRD band");
+            throw std::runtime_error("wxModelInitialization::getTimeList() failed, no 10m UGRD band.");
         }
 
         const char *vt;
@@ -847,7 +853,7 @@ wxModelInitialization::getTimeList(const char *pszVariable,
          */
         //int dimid;
         status = nc_inq_dimid(ncid, "DateStrLen", &dimid );
-        //cout<<"dimid =" <<dimid<<endl;
+        CPLDebug("WINDNINJA", "dimid = %d", dimid);
         if( status != NC_NOERR ) {
             ostringstream os;
             os << "The dimension \"DateStrLen\" "
@@ -1708,8 +1714,7 @@ double wxModelInitialization::GetWindHeight(std::string varName)
   {
       free(units);
       nc_close(ncid);
-      throw badForecastFile("Cannot determine wind height units in "
-                            "forecast file");
+      throw badForecastFile("Cannot determine wind height units in forecast file.");
   }
   free(units);
   nc_close(ncid);
@@ -1766,8 +1771,7 @@ std::string wxModelInitialization::GetTimeName(const char *pszVariable)
     }
     if (status != NC_NOERR) {
         nc_close(ncid);
-        throw badForecastFile(CPLSPrintf(
-            "Could not identify time dimension for variable: %s", pszVariable));
+        throw badForecastFile(CPLSPrintf("Could not identify time dimension for variable: %s.", pszVariable));
     }
     status = nc_inq_var(ncid, varid, 0, &vartype, &varndims, vardimids, &varnatts);
     for(int i = 0; i < varndims; i++) {
@@ -1781,8 +1785,7 @@ std::string wxModelInitialization::GetTimeName(const char *pszVariable)
             tp[namelength] = '\0';
             if(strcmp("time", tp) == 0) {
                 timestring =  std::string(timename);
-                CPLDebug( "WINDNINJA", "Found time: %s for variable: %s",
-                          timename, pszVariable );
+                CPLDebug("WINDNINJA", "Found time: %s for variable: %s", timename, pszVariable);
                 free( (void*)tp );
                 break;
             }

--- a/src/ninja/wxModelInitialization.cpp
+++ b/src/ninja/wxModelInitialization.cpp
@@ -388,13 +388,13 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     GDALDataset *poDS = (GDALDataset*)GDALOpen( demFile.c_str(), GA_ReadOnly );
     if(poDS == NULL)
     {
-        throw badForecastFile("Could not download weather forecast, could not open DEM to get bounds.");
+        throw badForecastFile("Could not open DEM to get bounds. Failed to download weather forecast.");
     }
 
     double bounds[4];
     if( !GDALGetBounds( poDS, bounds ) )
     {
-        throw badForecastFile("Could not download weather forecast, could not get bounds from the DEM.");
+        throw badForecastFile("Could not get bounds from the DEM. Failed to download weather forecast.");
     }
 
     /*
@@ -424,11 +424,11 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     urlAddress.append(url);
 
     CPLHTTPResult *poResult = CPLHTTPFetch( urlAddress.c_str(), NULL );
-    CPLDebug( "WINDNINJA", "Forecast URL: %s", urlAddress.c_str() );
+    CPLDebug("WINDNINJA", "Forecast URL: %s", urlAddress.c_str());
     if( poResult == NULL )
     {
         CPLHTTPDestroyResult(poResult);
-        throw badForecastFile("CPLHTTPResult is NULL!");
+        throw badForecastFile("CPLHTTPResult is NULL. Failed to download weather forecast.");
     }
 
     if( poResult->nStatus != 0 )
@@ -453,7 +453,7 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
 
       if (poResult == NULL)
       {
-        throw badForecastFile("CPLHTTPResult is NULL!");
+        throw badForecastFile("CPLHTTPResult is NULL. Failed to download weather forecast.");
       }
 
       if (poResult->nStatus != 0)
@@ -490,7 +490,7 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
         {
             VSIUnlink( tempFileName.c_str() );
         }
-        throw badForecastFile("Failed to download forecast. File is not an *.nc file");
+        throw badForecastFile("File is not an *.nc file. Failed to download weather forecast.");
     }
     nc_close( ncid );
     }
@@ -680,13 +680,13 @@ wxModelInitialization::getTimeList(const char *pszVariable,
             srcDS = (GDALDataset*)GDALOpenShared( wxModelFileName.c_str(), GA_ReadOnly );
         }
         if( srcDS == NULL ) {
-            throw std::runtime_error("wxModelInitialization::getTimeList(), Could not open forecast file, bad forecast file.");
+            throw std::runtime_error("Could not open forecast file, bad forecast file. Failed to get times from forecast file.");
         }
 
         //get time info from 10u band
         GDALRasterBand *poBand = get10UBand(srcDS);
         if (poBand == NULL) {
-            throw std::runtime_error("wxModelInitialization::getTimeList() failed, no 10m UGRD band.");
+            throw std::runtime_error("No 10m UGRD band in forecast file. Failed to get times from forecast file.");
         }
 
         const char *vt;
@@ -1146,11 +1146,11 @@ void wxModelInitialization::ninjaFoamInitializeFields(WindNinjaInputs &input,
     input.inputDirection_proj = meanDir;
     input.inputDirection_geog = wrap0to360( input.inputDirection_proj + input.dem.getAngleFromNorth() ); //convert FROM projected TO geographic coordinates
 
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "wxModelInitialization::ninjaFoamInitializeFields()" );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "input.inputSpeed = %lf", input.inputSpeed );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "input.inputDirection (geographic coordinates) = %lf", input.inputDirection_geog );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "angleFromNorth (N_to_dem) = %lf", input.dem.getAngleFromNorth() );
-    CPLDebug( "COORD_TRANSFORM_ANGLES", "input.inputDirection (projection coordinates) = %lf", input.inputDirection_proj );
+    CPLDebug("COORD_TRANSFORM_ANGLES", "wxModelInitialization::ninjaFoamInitializeFields()");
+    CPLDebug("COORD_TRANSFORM_ANGLES", "input.inputSpeed = %lf", input.inputSpeed);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "input.inputDirection (geographic coordinates) = %lf", input.inputDirection_geog);
+    CPLDebug("COORD_TRANSFORM_ANGLES", "angleFromNorth (N_to_dem) = %lf", input.dem.getAngleFromNorth());
+    CPLDebug("COORD_TRANSFORM_ANGLES", "input.inputDirection (projection coordinates) = %lf", input.inputDirection_proj);
 
     //write wx model grids
     writeWxModelGrids(input);
@@ -1626,11 +1626,11 @@ void wxModelInitialization::writeWxModelGrids(WindNinjaInputs &input)
             double angleFromNorth = 0.0;
             if( CSLTestBoolean(CPLGetConfigOption("DISABLE_COORDINATE_TRANSFORMATION_ANGLE_CALCULATIONS", "FALSE")) == false )
             {
-                CPLDebug( "COORD_TRANSFORM_ANGLES", "calculating angleFromNorth val, for the wxModel, in wxModelInitialization::writeWxModelGrids()");
+                CPLDebug("COORD_TRANSFORM_ANGLES", "calculating angleFromNorth val, for the wxModel, in wxModelInitialization::writeWxModelGrids()");
                 GDALDatasetH hDS = dirInitializationGrid_wxModel.ascii2GDAL();
                 if(!GDALCalculateAngleFromNorth( hDS, angleFromNorth ))
                 {
-                    printf("Warning: Unable to calculate angle departure from north for the wxModel.");
+                    input.Com->ninjaCom(ninjaComClass::ninjaWarning, "Unable to calculate angle departure from north for the wxModel.");
                 }
                 GDALClose(hDS);
             }*/
@@ -1816,7 +1816,7 @@ int wxModelInitialization::LoadFromCsv()
     }
     else
     {
-        CPLDebug( "WINDNINJA", "Using cached thredds csv values" );
+        CPLDebug("WINDNINJA", "Using cached thredds csv values.");
         papszLines = CSLDuplicate( papszThreddsCsv );
     }
     int nRecords = CSLCount( papszLines );

--- a/src/ninja/wxModelInitializationFactory.cpp
+++ b/src/ninja/wxModelInitializationFactory.cpp
@@ -40,7 +40,9 @@
 wxModelInitialization* wxModelInitializationFactory::makeWxInitialization( std::string fileName )
 {
     if(fileName.empty())
-    throw std::runtime_error("The weather model initialization filename has not been set.");
+    {
+        throw std::runtime_error("The weather model initialization filename has not been set.");
+    }
 
     ncepNdfdInitialization ncepNdfd;
     ncepNamSurfInitialization ncepNamSurf;
@@ -52,7 +54,7 @@ wxModelInitialization* wxModelInitializationFactory::makeWxInitialization( std::
     wrf3dInitialization wrf3d;
     ncepNamGrib2SurfInitialization ncepNamGrib2Surf;
     ncepHrrrSurfInitialization ncepHrrrSurf;
-    GCPWxModel arrhrr;
+    GCPWxModel archiveHrrr;
 
 #ifdef WITH_NOMADS_SUPPORT
     NomadsWxModel nomad;
@@ -76,46 +78,54 @@ wxModelInitialization* wxModelInitializationFactory::makeWxInitialization( std::
         //Determine what type of weather model the file came from
         //Check netcdf first, otherwise grib_api spews out crap
         if(ncepNdfd.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepNdfd.identify()");
             ncepNdfd.setModelFileName( fileName );
             return new ncepNdfdInitialization(ncepNdfd);
         }
         else if(ncepNamSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepNamSurf.identify()");
             ncepNamSurf.setModelFileName( fileName );
             return new ncepNamSurfInitialization(ncepNamSurf);
         }
         else if(ncepRapSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepRapSurf.identify()");
             ncepRapSurf.setModelFileName( fileName );
             return new ncepRapSurfInitialization(ncepRapSurf);
         }
         else if(ncepNamAlaskaSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepNamAlaskaSurf.identify()");
             ncepNamAlaskaSurf.setModelFileName( fileName );
             return new ncepNamAlaskaSurfInitialization(ncepNamAlaskaSurf);
         }
         else if(ncepGfsSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepGfsSurf.identify()");
             ncepGfsSurf.setModelFileName( fileName );
             return new ncepGfsSurfInitialization(ncepGfsSurf);
         }
 #ifdef NOMADS_ENABLE_3D
         else if(wrf3d.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), wrf3d.identify()");
             wrf3d.setModelFileName( fileName );
-            CPLDebug("WX_MODEL_INITIALIZATION", "wrf3d.identify(fileName) = %i\n", wrf3d.identify(fileName));
             return new wrf3dInitialization(wrf3d);
         }
 #endif
         else if(wrfSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), wrfSurf.identify()");
             wrfSurf.setModelFileName( fileName );
-            CPLDebug("WX_MODEL_INITIALIZATION", "wrfSurf.identify(fileName) = %i\n", wrfSurf.identify(fileName));
             return new wrfSurfInitialization(wrfSurf);
         }
         if(ncepNamGrib2Surf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepNamGrib2Surf.identify()");
             ncepNamGrib2Surf.setModelFileName( fileName );
             return new ncepNamGrib2SurfInitialization(ncepNamGrib2Surf);
         }
         else if(ncepHrrrSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), ncepHrrrSurf.identify()");
             ncepHrrrSurf.setModelFileName( fileName );
             return new ncepHrrrSurfInitialization(ncepHrrrSurf);
         }
         else if(genericSurf.identify(fileName)) {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), genericSurf.identify()");
             genericSurf.setModelFileName( fileName );
             return new genericSurfInitialization(genericSurf);
         }
@@ -128,14 +138,16 @@ wxModelInitialization* wxModelInitializationFactory::makeWxInitialization( std::
     }
     else
     {
-      if(arrhrr.identify(fileName))
+      if(archiveHrrr.identify(fileName))
       {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), archiveHrrr.identify()");
         return new GCPWxModel(fileName);
       }
       else {
 #ifdef WITH_NOMADS_SUPPORT
         if(nomad.identify(fileName))
         {
+            CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitialization(), nomad.identify()");
             const char **ppszKey = nomad.FindModelKey( fileName.c_str() );
             if( ppszKey )
                 return new NomadsWxModel( fileName );
@@ -169,7 +181,9 @@ wxModelInitialization* wxModelInitializationFactory::makeWxInitialization( std::
 wxModelInitialization* wxModelInitializationFactory::makeWxInitializationFromId( std::string identifier )
 {
     if(identifier.empty())
-    throw std::runtime_error("The weather model initialization filename has not been set.");
+    {
+        throw std::runtime_error("The weather model initialization filename has not been set.");
+    }
 
     ncepNdfdInitialization ncepNdfd;
     ncepNamSurfInitialization ncepNamSurf;
@@ -181,49 +195,59 @@ wxModelInitialization* wxModelInitializationFactory::makeWxInitializationFromId(
     wrf3dInitialization wrf3d;
     ncepNamGrib2SurfInitialization ncepNamGrib2Surf;
     ncepHrrrSurfInitialization ncepHrrrSurf;
-    GCPWxModel archrrr;
+    GCPWxModel archiveHrrr;
 
 
 //Determine what type of weather model the file came from
     //Check netcdf first, otherwise grib_api spews out crap
     if(ncepNdfd.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepNdfd.identify()");
         return new ncepNdfdInitialization(ncepNdfd);
     }
     else if(ncepNamSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepNamSurf.identify()");
         return new ncepNamSurfInitialization(ncepNamSurf);
     }
     else if(ncepRapSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepRapSurf.identify()");
         return new ncepRapSurfInitialization(ncepRapSurf);
     }
     else if(ncepNamAlaskaSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepNamAlaskaSurf.identify()");
         return new ncepNamAlaskaSurfInitialization(ncepNamAlaskaSurf);
     }
     else if(ncepGfsSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepGfsSurf.identify()");
         return new ncepGfsSurfInitialization(ncepGfsSurf);
     }
     else if(wrfSurf.getForecastReadable() == identifier) {
-        CPLDebug("WX_MODEL_INITIALIZATION", "wrfSurf.getForecastReadable() == identifier = %i\n", wrfSurf.getForecastReadable() == identifier);
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), wrfSurf.identify()");
         return new wrfSurfInitialization(wrfSurf);
     }
     else if(wrf3d.getForecastReadable() == identifier) {    //fix this later to read either wrf3d or wrfSurf
-        CPLDebug("WX_MODEL_INITIALIZATION", "wrf3d.getForecastReadable() == identifier = %i\n", wrf3d.getForecastReadable() == identifier);
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), wrf3d.identify()");
         return new wrf3dInitialization(wrf3d);
     }
     else if(ncepNamGrib2Surf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepNamGrib2Surf.identify()");
         return new ncepNamGrib2SurfInitialization(ncepNamGrib2Surf);
     }
     else if(ncepHrrrSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), ncepHrrrSurf.identify()");
         return new ncepHrrrSurfInitialization(ncepHrrrSurf);
     }
     else if(genericSurf.getForecastReadable() == identifier) {
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), genericSurf.identify()");
         return new genericSurfInitialization(genericSurf);
     }
-    else if(archrrr.getForecastReadable() == identifier)
+    else if(archiveHrrr.getForecastReadable() == identifier)
     {
-      return new GCPWxModel(archrrr);
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), archiveHrrr.identify()");
+        return new GCPWxModel(archiveHrrr);
     }
     else {
 #ifdef WITH_NOMADS_SUPPORT
+        CPLDebug("WX_MODEL_INITIALIZATION", "wxModelInitializationFactory::makeWxInitializationFromId(), attempting nomad.identify()");
         int i = 0;
         int bFound = FALSE;
         const char *s;

--- a/src/ninja/wxModelInitializationFactory.h
+++ b/src/ninja/wxModelInitializationFactory.h
@@ -62,7 +62,6 @@ class wxModelInitializationFactory
         static wxModelInitialization* makeWxInitialization( std::string fileName );
         static wxModelInitialization* makeWxInitializationFromId( std::string identifier );
 
-
 }; 
 /* -----  end of class WxModelInitializationFactory  ----- */
 

--- a/src/ninja/wxStation.cpp
+++ b/src/ninja/wxStation.cpp
@@ -295,8 +295,7 @@ void wxStation::set_stationName( std::string Name )
  * @param Yord y coordinate in projection system coordinates (dem projection coordinates)
  * @param demFile name of the dem file used to create the coordinate transformation
  */
-void wxStation::set_location_projected( double Xord, double Yord,
-                    std::string demFile )
+void wxStation::set_location_projected( double Xord, double Yord, std::string demFile )
 {
     coordType = PROJCS;
     datumType = WGS84;  // always use WGS84 for the datum for PROJCS regardless of the input datum type
@@ -304,35 +303,22 @@ void wxStation::set_location_projected( double Xord, double Yord,
     projXord = Xord;
     projYord = Yord;
 
-    if( demFile.empty() || demFile == "" ){
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), input demFile is empty.");
-        xord = Xord;
-        yord = Yord;
-        lon = Xord;
-        lat = Yord;
-        return;
+    if(demFile.empty() || demFile == "")
+    {
+        throw std::runtime_error("wxStation::set_location_projected(), input demFile is empty.");
     }
 
     GDALDataset *poDS = (GDALDataset*) GDALOpen( demFile.c_str(), GA_ReadOnly );
-    if( poDS == NULL ){
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), Cannot open input demFile.");
-        xord = Xord;
-        yord = Yord;
-        lon = Xord;
-        lat = Yord;
-        return;
+    if(poDS == NULL)
+    {
+        throw std::runtime_error("wxStation::set_location_projected(), Cannot open input demFile.");
     }
 
     //get llcorner to subtract
     double adfGeoTransform[6];
-
-    if( poDS->GetGeoTransform( adfGeoTransform ) != CE_None ) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), Could not get GeoTransform from input demFile.");
-        xord = Xord;
-        yord = Yord;
-        lon = Xord;
-        lat = Yord;
-        return;
+    if(poDS->GetGeoTransform(adfGeoTransform) != CE_None)
+    {
+        throw std::runtime_error("wxStation::set_location_projected(), Could not get GeoTransform from input demFile.");
     }
 
     double llx = adfGeoTransform[0];
@@ -344,7 +330,10 @@ void wxStation::set_location_projected( double Xord, double Yord,
     double lonx = projXord;
     double laty = projYord;
 
-    GDALPointToLatLon( lonx, laty, poDS, "WGS84" );
+    if(!GDALPointToLatLon(lonx, laty, poDS, "WGS84"))
+    {
+        throw std::runtime_error("wxStation::set_location_projected(), Failed to warp point to lat lon.");
+    }
 
     lon = lonx;
     lat = laty;
@@ -364,61 +353,57 @@ void wxStation::set_location_projected( double Xord, double Yord,
  */
 void wxStation::set_location_LatLong( double Lat, double Lon,
                                       const std::string demFile,
-                      const char *datum )
+                                      const char *datum )
 {
+    coordType = GEOGCS;
+
     if( EQUAL( datum, "WGS84" ) )
+    {
         datumType = WGS84;
+    }
     else if( EQUAL( datum, "NAD83" ) )
+    {
         datumType = NAD83;
+    }
     else if ( EQUAL( datum, "NAD27" ) )
+    {
         datumType = NAD27;
+    }
     else
     {
-        std::string oErrorString = "wxStation::set_location_LatLong() input datum \"";
-        oErrorString += datum;
-        oErrorString += "\" is not valid! options are \"WGS84\", \"NAD83\", \"NAD27\"";
-        throw std::runtime_error(oErrorString);
+        throw std::runtime_error("wxStation::set_location_LatLong(), input datum '"+std::string(datum)+"' is not valid. options are 'WGS84', 'NAD83', 'NAD27'");
     }
-    coordType = GEOGCS;
 
     lon = Lon;
     lat = Lat;
 
-    if( demFile.empty() || demFile == "" ){
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), input demFile is empty.");
-        projXord = Lon;
-        projYord = Lat;
-        xord = Lon;
-        yord = Lat;
-        return;
+    if(demFile.empty() || demFile == "")
+    {
+        throw std::runtime_error("wxStation::set_location_LatLong(), input demFile is empty.");
     }
 
     GDALDataset *poDS = (GDALDataset*)GDALOpen( demFile.c_str(), GA_ReadOnly );
-    if( poDS == NULL ){
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), Cannot open input demFile.");
-        projXord = Lon;
-        projYord = Lat;
-        xord = Lon;
-        yord = Lat;
-        return;
+    if(poDS == NULL)
+    {
+        throw std::runtime_error("wxStation::set_location_LatLong(), Cannot open input demFile.");
     }
 
     double projX = lon;
     double projY = lat;
 
-    GDALPointFromLatLon( projX, projY, poDS, datum );
+    if(!GDALPointFromLatLon(projX, projY, poDS, datum))
+    {
+        throw std::runtime_error("wxStation::set_location_LatLong(), Failed to warp point from lat lon.");
+    }
 
     projXord = projX;
     projYord = projY;
 
     //get llcorner to subtract
     double adfGeoTransform[6];
-
-    if( poDS->GetGeoTransform( adfGeoTransform ) != CE_None ){
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), Could not get GeoTransform from input demFile.");
-        xord = projXord;
-        yord = projYord;
-        return;
+    if(poDS->GetGeoTransform(adfGeoTransform) != CE_None)
+    {
+        throw std::runtime_error("wxStation::set_location_LatLong(), Could not get GeoTransform from input demFile.");
     }
 
     double llx = adfGeoTransform[0];

--- a/src/ninja/wxStation.cpp
+++ b/src/ninja/wxStation.cpp
@@ -305,20 +305,20 @@ void wxStation::set_location_projected( double Xord, double Yord, std::string de
 
     if(demFile.empty() || demFile == "")
     {
-        throw std::runtime_error("wxStation::set_location_projected(), input demFile is empty.");
+        throw std::runtime_error("Invalid input, The input demFile is empty.");
     }
 
     GDALDataset *poDS = (GDALDataset*) GDALOpen( demFile.c_str(), GA_ReadOnly );
     if(poDS == NULL)
     {
-        throw std::runtime_error("wxStation::set_location_projected(), Cannot open input demFile.");
+        throw std::runtime_error("Cannot open input demFile.");
     }
 
     //get llcorner to subtract
     double adfGeoTransform[6];
     if(poDS->GetGeoTransform(adfGeoTransform) != CE_None)
     {
-        throw std::runtime_error("wxStation::set_location_projected(), Could not get GeoTransform from input demFile.");
+        throw std::runtime_error("Could not get GeoTransform from input demFile.");
     }
 
     double llx = adfGeoTransform[0];
@@ -332,7 +332,7 @@ void wxStation::set_location_projected( double Xord, double Yord, std::string de
 
     if(!GDALPointToLatLon(lonx, laty, poDS, "WGS84"))
     {
-        throw std::runtime_error("wxStation::set_location_projected(), Failed to warp point to lat lon.");
+        throw std::runtime_error("Failed to warp station point to lat lon.");
     }
 
     lon = lonx;
@@ -371,7 +371,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
     }
     else
     {
-        throw std::runtime_error("wxStation::set_location_LatLong(), input datum '"+std::string(datum)+"' is not valid. options are 'WGS84', 'NAD83', 'NAD27'");
+        throw std::runtime_error("The station datum '"+std::string(datum)+"' is not valid. options are 'WGS84', 'NAD83', 'NAD27'");
     }
 
     lon = Lon;
@@ -379,13 +379,13 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
 
     if(demFile.empty() || demFile == "")
     {
-        throw std::runtime_error("wxStation::set_location_LatLong(), input demFile is empty.");
+        throw std::runtime_error("Invalid input, The input demFile is empty.");
     }
 
     GDALDataset *poDS = (GDALDataset*)GDALOpen( demFile.c_str(), GA_ReadOnly );
     if(poDS == NULL)
     {
-        throw std::runtime_error("wxStation::set_location_LatLong(), Cannot open input demFile.");
+        throw std::runtime_error("Cannot open input demFile.");
     }
 
     double projX = lon;
@@ -393,7 +393,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
 
     if(!GDALPointFromLatLon(projX, projY, poDS, datum))
     {
-        throw std::runtime_error("wxStation::set_location_LatLong(), Failed to warp point from lat lon.");
+        throw std::runtime_error("Failed to warp station point from lat lon.");
     }
 
     projXord = projX;
@@ -403,7 +403,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
     double adfGeoTransform[6];
     if(poDS->GetGeoTransform(adfGeoTransform) != CE_None)
     {
-        throw std::runtime_error("wxStation::set_location_LatLong(), Could not get GeoTransform from input demFile.");
+        throw std::runtime_error("Could not get GeoTransform from input demFile.");
     }
 
     double llx = adfGeoTransform[0];
@@ -648,19 +648,19 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     hDS = OGROpen(pszFilename, FALSE, NULL);
     int rc = 0;
     if (hDS == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not open station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open station file.");
         return -1;
     }
     OGRLayerH hLayer = NULL;
     hLayer = OGR_DS_GetLayer(hDS, 0);
     if (hLayer == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get layer from station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get layer from station file.");
         rc = -1;
     }
     OGRFeatureDefnH hDefn = NULL;
     hDefn = OGR_L_GetLayerDefn(hLayer);
     if (hDefn == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get layer definition from station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get layer definition from station file.");
         rc = -1;
     }
     // If we failed to open or get metadata, bail
@@ -696,7 +696,7 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     { //Check the new header...
         if(xt!=n2) //if it doesn't equal the new header size....
         { //kill it
-            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Number of header columns in station file does not match station file format.");
+            CPLError(CE_Failure, CPLE_AppDefined, "Number of header columns in station file does not match station file format.");
             return -1;
         }
     }
@@ -708,13 +708,13 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     for (i = 0; i < n; i++) {
         hFldDefn = OGR_FD_GetFieldDefn(hDefn, i);
         if (hFldDefn == NULL) {
-            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get header definition for column '%d' in station file.", i);
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not get header definition for column '%d' in station file.", i);
             rc = -1;
         }
         if (!EQUAL(OGR_Fld_GetNameRef(hFldDefn), apszValidHeader1[i])) {
             if(!EQUAL(OGR_Fld_GetNameRef(hFldDefn), oldSpeedHeadStr))
             {
-                CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Header field for column '%d' in station file does not match station file format.", i);
+                CPLError(CE_Failure, CPLE_AppDefined, "Header field for column '%d' in station file does not match station file format.", i);
                 rc = -1;
             }
         }
@@ -734,11 +734,11 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     if (OGR_FD_GetFieldCount(hDefn) > n) {
         hFldDefn = OGR_FD_GetFieldDefn(hDefn, i);
         if (hFldDefn == NULL) {
-            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get header definition for column '%d' in station file.", i);
+            CPLError(CE_Failure, CPLE_AppDefined, "Could not get header definition for column '%d' in station file.", i);
             return -1;
         }
         if (!EQUAL(OGR_Fld_GetNameRef(hFldDefn), apszValidHeader2[i])) {
-            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Header field for column '%d' in station file does not match station file format.", i);
+            CPLError(CE_Failure, CPLE_AppDefined, "Header field for column '%d' in station file does not match station file format.", i);
             return -1;
         }
         /* TODO: If we silently accept version 1 files, would do a read/check of additional columns and return 1 here.
@@ -761,14 +761,14 @@ int wxStation::GetFirstStationLine(const char *xFilename)
     hDS = OGROpen( xFilename, FALSE, NULL );
     if(hDS == NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not open station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open station file.");
         return -1; //very bad!
     }
 
     poLayer = (OGRLayer*)OGR_DS_GetLayer( hDS, 0 );
     hLayer=OGR_DS_GetLayer(hDS,0);
     if (hLayer == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not get layer from station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get layer from station file.");
         return -1; //very bad!
     }
 
@@ -777,7 +777,7 @@ int wxStation::GetFirstStationLine(const char *xFilename)
     poFeature = poLayer->GetFeature(iBig);
     if (poFeature==NULL)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not get feature from layer from station file. Possibly no station data in the station file.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not get feature from layer from station file. Possibly no station data in the station file.");
         return -1; //If there are no stations in the csv!
     }
     std::string start_datetime(poFeature->GetFieldAsString(15));
@@ -800,13 +800,13 @@ int wxStation::GetFirstStationLine(const char *xFilename)
 void wxStation::writeBlankStationFile(std::string outFileName)
 {
     if (outFileName.empty() || outFileName == "") {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeBlankStationFile(), the input outFileName is empty.");
+        CPLError(CE_Failure, CPLE_AppDefined, "Invalid input, The input outFileName is empty.");
         return;
     }
     FILE *fout;
     fout = fopen(outFileName.c_str(), "w");
     if (fout == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeBlankStationFile(), Could not open outFileName '%s' for writing.", outFileName.c_str());
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open outFileName '%s' for writing.", outFileName.c_str());
         return;
     }
     int n = CSLCount( (char**)apszValidHeader2 );
@@ -857,11 +857,11 @@ void wxStation::writeStationFile( std::vector<wxStation>StationVect,
 
     if( outFileNameStamp.empty() || outFileNameStamp == "" )
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeStationFile(), The generated outFileNameStamp is empty.");
+        CPLError(CE_Failure, CPLE_AppDefined, "The generated outFileNameStamp is empty.");
         return;
     }
     if( StationVect.empty() ) {
-        CPLError(CE_Warning, CPLE_AppDefined, "wxStation::writeStationFile(), The input StationVect is empty, writing blank station file.");
+        CPLError(CE_Warning, CPLE_AppDefined, "The input StationVect is empty, writing blank station file.");
         writeBlankStationFile( outFileNameStamp );
         return;
     }
@@ -869,7 +869,7 @@ void wxStation::writeStationFile( std::vector<wxStation>StationVect,
     FILE *fout;
     fout = fopen( outFileNameStamp.c_str(), "w" );
     if (fout == NULL) {
-        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeStationFile(), Could not open the generated outFileNameStamp '%s' for writing.", outFileNameStamp.c_str());
+        CPLError(CE_Failure, CPLE_AppDefined, "Could not open the generated outFileNameStamp '%s' for writing.", outFileNameStamp.c_str());
         return;
     }
     int n = CSLCount((char **)apszValidHeader1);
@@ -944,7 +944,7 @@ void wxStation::writeKmlFile( std::vector<wxStation> stations,
 
     if( stations.size() == 0 )
     {
-        CPLError(CE_Warning, CPLE_AppDefined, "wxStation::writeKmlFile(), The input stations is empty, skipping kml file.");
+        CPLError(CE_Warning, CPLE_AppDefined, "The input stations is empty, skipping kml file.");
         return;
     }
 

--- a/src/ninja/wxStation.cpp
+++ b/src/ninja/wxStation.cpp
@@ -305,6 +305,7 @@ void wxStation::set_location_projected( double Xord, double Yord,
     projYord = Yord;
 
     if( demFile.empty() || demFile == "" ){
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), input demFile is empty.");
         xord = Xord;
         yord = Yord;
         lon = Xord;
@@ -314,6 +315,7 @@ void wxStation::set_location_projected( double Xord, double Yord,
 
     GDALDataset *poDS = (GDALDataset*) GDALOpen( demFile.c_str(), GA_ReadOnly );
     if( poDS == NULL ){
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), Cannot open input demFile.");
         xord = Xord;
         yord = Yord;
         lon = Xord;
@@ -325,6 +327,7 @@ void wxStation::set_location_projected( double Xord, double Yord,
     double adfGeoTransform[6];
 
     if( poDS->GetGeoTransform( adfGeoTransform ) != CE_None ) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_projected(), Could not get GeoTransform from input demFile.");
         xord = Xord;
         yord = Yord;
         lon = Xord;
@@ -374,7 +377,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
         std::string oErrorString = "wxStation::set_location_LatLong() input datum \"";
         oErrorString += datum;
         oErrorString += "\" is not valid! options are \"WGS84\", \"NAD83\", \"NAD27\"";
-        throw std::runtime_error( oErrorString );
+        throw std::runtime_error(oErrorString);
     }
     coordType = GEOGCS;
 
@@ -382,6 +385,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
     lat = Lat;
 
     if( demFile.empty() || demFile == "" ){
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), input demFile is empty.");
         projXord = Lon;
         projYord = Lat;
         xord = Lon;
@@ -391,6 +395,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
 
     GDALDataset *poDS = (GDALDataset*)GDALOpen( demFile.c_str(), GA_ReadOnly );
     if( poDS == NULL ){
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), Cannot open input demFile.");
         projXord = Lon;
         projYord = Lat;
         xord = Lon;
@@ -410,6 +415,7 @@ void wxStation::set_location_LatLong( double Lat, double Lon,
     double adfGeoTransform[6];
 
     if( poDS->GetGeoTransform( adfGeoTransform ) != CE_None ){
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::set_location_LatLong(), Could not get GeoTransform from input demFile.");
         xord = projXord;
         yord = projYord;
         return;
@@ -548,64 +554,57 @@ bool wxStation::check_station(wxStation station)
 {
     if(station.stationName.empty() || station.stationName == "")
     {
-        cout<<"failed Name Check"<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed name check");
         return false;
     }
     if(station.coordType != GEOGCS && station.coordType != PROJCS)
     {
-        cout<<"failed Coord Check"<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed coordType check");
         return false;
     }
     if(station.datumType != WGS84 && station.datumType != NAD83 && station.datumType !=NAD27)
     {
-        cout<<"failed datum Check"<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed datum check");
         return false;
     }
 
     if(station.lat < -90.0 || station.lat > 90.0)
     {
-        cout<<"failed lat Check: "<<station.lat<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed latitude check");
         return false;
     }
     if(station.lon < -180.0 || station.lon > 360.0)
     {
-        cout<<"failed lon Check: "<<station.lon<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed longitude check");
         return false;
     }
-
-
 
     for (int i=0;i<station.heightList.size();i++)
     {        
         //Changing all isnan() to std::isnan() for MSVC2010
         if(station.heightList[i] < 0.0|| std::isnan(station.heightList[i]))
         {
-            cout<<"failed height Check on "<<i<<endl;
-            cout<<station.heightList[i]<<endl;
+            CPLError(CE_Failure, CPLE_AppDefined, "station failed height check on height[%d] '%lf'", i, station.heightList[i]);
             return false;
         }
         if(station.speedList[i] < 0.0 || std::isnan(station.speedList[i]) || station.speedList[i]>105.0)
         {
-            cout<<"failed speed Check on "<<i<<endl;
-            cout<<station.speedList[i]<<endl;
+            CPLError(CE_Failure, CPLE_AppDefined, "station failed speed check on speed[%d] '%lf'", i, station.speedList[i]);
             return false;
         }
         if(station.directionList[i] < 0.0 || station.directionList[i] > 360.0 || std::isnan(station.directionList[i]))
         {
-            cout<<"failed direction Check on "<<i<<endl;
-            cout<<station.directionList[i]<<endl;
+            CPLError(CE_Failure, CPLE_AppDefined, "station failed direction check on direction[%d] '%lf'", i, station.directionList[i]);
             return false;
         }
         if(station.temperatureList[i]< 173.15 || station.temperatureList[i] > 330.00 || std::isnan(station.temperatureList[i]))
         {
-            cout<<"failed temperature Check on "<<i<<endl;
-            cout<<station.temperatureList[i]<<endl;
+            CPLError(CE_Failure, CPLE_AppDefined, "station failed temperature check on temperature[%d] '%lf'", i, station.temperatureList[i]);
             return false;
         }
         if(station.cloudCoverList[i]<0.0||station.cloudCoverList[i]>1.10 || std::isnan(station.cloudCoverList[i]))
         {
-            cout<<"failed cloud check on "<<i<<endl;
-            cout<<station.cloudCoverList[i]<<endl;
+            CPLError(CE_Failure, CPLE_AppDefined, "station failed cloud cover check on cloudCover[%d] '%lf'", i, station.cloudCoverList[i]);
 //            station.cloudCoverList[i]=0.0;
             return false;
         }
@@ -613,7 +612,7 @@ bool wxStation::check_station(wxStation station)
 
     if(station.w_speed < 0.0 || std::isnan(station.w_speed))
     {
-        cout<<"failed vert_speed Check"<<endl;
+        CPLError(CE_Failure, CPLE_AppDefined, "station failed vertical speed check");
         return false;
     }
 
@@ -664,16 +663,19 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     hDS = OGROpen(pszFilename, FALSE, NULL);
     int rc = 0;
     if (hDS == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not open station file.");
         return -1;
     }
     OGRLayerH hLayer = NULL;
     hLayer = OGR_DS_GetLayer(hDS, 0);
     if (hLayer == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get layer from station file.");
         rc = -1;
     }
     OGRFeatureDefnH hDefn = NULL;
     hDefn = OGR_L_GetLayerDefn(hLayer);
     if (hDefn == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get layer definition from station file.");
         rc = -1;
     }
     // If we failed to open or get metadata, bail
@@ -709,6 +711,7 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     { //Check the new header...
         if(xt!=n2) //if it doesn't equal the new header size....
         { //kill it
+            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Number of header columns in station file does not match station file format.");
             return -1;
         }
     }
@@ -720,11 +723,13 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     for (i = 0; i < n; i++) {
         hFldDefn = OGR_FD_GetFieldDefn(hDefn, i);
         if (hFldDefn == NULL) {
+            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get header definition for column '%d' in station file.", i);
             rc = -1;
         }
         if (!EQUAL(OGR_Fld_GetNameRef(hFldDefn), apszValidHeader1[i])) {
             if(!EQUAL(OGR_Fld_GetNameRef(hFldDefn), oldSpeedHeadStr))
             {
+                CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Header field for column '%d' in station file does not match station file format.", i);
                 rc = -1;
             }
         }
@@ -742,10 +747,18 @@ int wxStation::GetHeaderVersion(const char *pszFilename)
     */
     rc = 1;
     if (OGR_FD_GetFieldCount(hDefn) > n) {
-        if (!EQUAL(OGR_Fld_GetNameRef(hFldDefn), apszValidHeader2[i])) {
-            /* If we silently except version 1 files, return 1 here. */
-            rc = -1;
+        hFldDefn = OGR_FD_GetFieldDefn(hDefn, i);
+        if (hFldDefn == NULL) {
+            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Could not get header definition for column '%d' in station file.", i);
+            return -1;
         }
+        if (!EQUAL(OGR_Fld_GetNameRef(hFldDefn), apszValidHeader2[i])) {
+            CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetHeaderVersion(), Header field for column '%d' in station file does not match station file format.", i);
+            return -1;
+        }
+        /* TODO: If we silently accept version 1 files, would do a read/check of additional columns and return 1 here.
+        ** But would need to revise the above, because it flat out rejects if the first additional column isn't specifically the rc = 2 format, or rc = 2 format would break.
+        */
         rc = 2;
     }
     GDALClose(hDS);
@@ -763,15 +776,23 @@ int wxStation::GetFirstStationLine(const char *xFilename)
     hDS = OGROpen( xFilename, FALSE, NULL );
     if(hDS == NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not open station file.");
         return -1; //very bad!
     }
+
     poLayer = (OGRLayer*)OGR_DS_GetLayer( hDS, 0 );
     hLayer=OGR_DS_GetLayer(hDS,0);
+    if (hLayer == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not get layer from station file.");
+        return -1; //very bad!
+    }
+
     OGR_L_ResetReading(hLayer);
     poLayer->ResetReading();
     poFeature = poLayer->GetFeature(iBig);
     if (poFeature==NULL)
     {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::GetFirstStationLine(), Could not get feature from layer from station file. Possibly no station data in the station file.");
         return -1; //If there are no stations in the csv!
     }
     std::string start_datetime(poFeature->GetFieldAsString(15));
@@ -794,11 +815,13 @@ int wxStation::GetFirstStationLine(const char *xFilename)
 void wxStation::writeBlankStationFile(std::string outFileName)
 {
     if (outFileName.empty() || outFileName == "") {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeBlankStationFile(), the input outFileName is empty.");
         return;
     }
     FILE *fout;
     fout = fopen(outFileName.c_str(), "w");
     if (fout == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeBlankStationFile(), Could not open outFileName '%s' for writing.", outFileName.c_str());
         return;
     }
     int n = CSLCount( (char**)apszValidHeader2 );
@@ -848,8 +871,12 @@ void wxStation::writeStationFile( std::vector<wxStation>StationVect,
     outFileNameStamp=outFileNameMod+"-"+timestream.str()+".csv";
 
     if( outFileNameStamp.empty() || outFileNameStamp == "" )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeStationFile(), The generated outFileNameStamp is empty.");
         return;
+    }
     if( StationVect.empty() ) {
+        CPLError(CE_Warning, CPLE_AppDefined, "wxStation::writeStationFile(), The input StationVect is empty, writing blank station file.");
         writeBlankStationFile( outFileNameStamp );
         return;
     }
@@ -857,6 +884,7 @@ void wxStation::writeStationFile( std::vector<wxStation>StationVect,
     FILE *fout;
     fout = fopen( outFileNameStamp.c_str(), "w" );
     if (fout == NULL) {
+        CPLError(CE_Failure, CPLE_AppDefined, "wxStation::writeStationFile(), Could not open the generated outFileNameStamp '%s' for writing.", outFileNameStamp.c_str());
         return;
     }
     int n = CSLCount((char **)apszValidHeader1);
@@ -928,19 +956,22 @@ void wxStation::writeKmlFile( std::vector<wxStation> stations,
     {
         outFileNameStamp = std::string(CPLFormFilename(outPath.c_str(),filePart.c_str(),".kml"));
     }
-    if( stations.size() == 0 )
-        return;
-    CPLDebug("STATION_FETCH","KML PATH: %s",outFileNameStamp.c_str());
-    FILE *fout = fopen( outFileNameStamp.c_str(), "w" );
 
+    if( stations.size() == 0 )
+    {
+        CPLError(CE_Warning, CPLE_AppDefined, "wxStation::writeKmlFile(), The input stations is empty, skipping kml file.");
+        return;
+    }
+
+    CPLDebug("STATION_FETCH", "KML PATH: %s", outFileNameStamp.c_str());
+    FILE *fout = fopen( outFileNameStamp.c_str(), "w" );
     if( fout == NULL )
     {
-        printf( "Cannot open kml file: %s for writing.", outFileNameStamp.c_str() );
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot open kml file: %s for writing.", outFileNameStamp.c_str());
         return;
     }
 
     double heightTemp, speedTemp, directionTemp, ccTemp, temperatureTemp, radOfInflTemp;
-
 
     fprintf( fout, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
     fprintf( fout, "<kml>\n" );
@@ -1039,18 +1070,14 @@ void wxStation::writeKMZFile(std::vector<wxStation> stations, string basePath, s
     std::string outFileSubName=subDem;
     fullPath = basePath+subDem+"_stations_"+timeComponent+".kmz";
 
-    cout<<outFileSubName<<endl;
-    cout<<fullPath<<endl;
+    CPLDebug("STATION_FETCH", "outFileSubName = '%s'", outFileSubName.c_str());
+    CPLDebug("STATION_FETCH", "fullPath = '%s'", fullPath.c_str());
 
 //    for (int i=0;i<stations[0].temperatureList.size();i++)
 //    {
-//        cout<<stationKmlNames[i]<<endl;
+//        CPLDebug("STATION_FETCH", "stationKmlNames[%d] = '%s'", i, stationKmlNames[i].c_str());
 //    }
 
-
 //    writeKmlFile(stations,"test-1");
-
-
-
 
 }


### PR DESCRIPTION
Started out with the intent of extending `ninjaCom` to the underlying `ninjaTools` functions. But it became cleanup and unification of the various `messaging methods`, not just of the underlying `ninjaTools` functions, but of the full underlying files called by the underlying `ninjaTools` functions.

To do this, I effectively searched for each and every instance of `cout`, `cerr`, `fprintf`, `CPLDebug`, `CPLError`, `throw`, `return`, etc within the various files, added `messages` where they were missing, tried to clean up the code `whitespace` and `parenthesis` use a bit where needed, and updated the `messages` to be clearer. During this part of the process, I tried to replace every `messaging` instance method with `CPLError`, `CPLDebug`, and `throw`. I used `CPLError` whenever the `message` needed to get out to the user every single time, and I used `CPLDebug` when the `message` was better to just send to the coder.

I attempted to use `throw` every time when it was better to just halt the code with an `error` rather than continue on with a `warning` or an `error code` and `error message`. But, it was easy to use `throw` for the various underlying 10 or so individual `wxModel` codes, with `pointInitialization.cpp` and a lot with `wxStation.cpp`; I was able to use `throw` instead of `CPLError` half and half for `wxModelInitialization.cpp`, `nomads_wx_init.cpp`, and `gcp_wx_init.cpp`; I ended up leaving it as `CPLError` `error codes` with `error messages` for `nomads.c`, `gdal_util.cpp`, and the various `surface_fetch.cpp` files.

Technically I probably could have just used `throw` instead of `error codes` and `error messages` for the `surface_fetch.cpp`, `gdal_util.cpp`, and `nomads.c` files, as well as parts of `wxStation.cpp`, but we wanted to attempt to keep the `surface_fetch` `error codes` for now, `nomads.c` has enough quirky stuff going on that I didn't feel ready to tackle that quite yet, and `gdal_util.cpp` is used by so many things withOUT the `try/catch` wrappers that it felt best to wait on it. BUT, leaving the code in this state, those spots are where the `CPLError` instances still could potentially be swapped to `throws`, and anything left that still has `CPLError`, including `wxModelInitialization.cpp`, `nomads_wx_init.cpp`, and `gcp_wx_init.cpp`, would eventually need each `CPLError` instances replaced with `ninjaCom` instances, with `ninjaCom` extended to that part of the code. So this work SHOULD leave this set of files in a really nice spot, a MUCH nicer spot, for extending `ninjaCom` to the various remaining underlying parts of the code, if we even still want to do that when all gets said and done.

So, performs a large chunk of work for issue #749.

Also a few small fixes, using the `surface_fetch` `error codes` more properly, I also caught a small error in `wxStation.cpp` where it was using the 2nd to last column of a `station file` instead of the last column during a `stationHeaderType` check, it was being ignored so it worked out, but now it is improved.

Actually, a LOT of the checks SHOULD print out more/better `error messages`, for when things go wrong, than we have seen before. I did my best to cleanup the `message` text for these new `error messages`, hopefully it will be good enough.