### PR TITLE
Fix wxModel NO_DATA warp collar

### DIFF
--- a/src/hrrr_to_kmz/hrrr_to_kmz.cpp
+++ b/src/hrrr_to_kmz/hrrr_to_kmz.cpp
@@ -321,7 +321,7 @@ void setSurfaceGrids( const std::string &wxModelFileName, const int &timeBandIdx
                     std::string bandName( gc );
                     if( bandName.find( "10-HTGL" ) != bandName.npos ){
                         bandList.push_back( j );  // 10u    
-                        dfNoData = poBand->GetNoDataValue( &pbSuccess );
+                        dfNoData = poBand->GetNoDataValue(&pbSuccess);
                         break;
                     }
                 }
@@ -371,14 +371,18 @@ void setSurfaceGrids( const std::string &wxModelFileName, const int &timeBandIdx
     poLatLong->exportToWkt(&dstWkt);
     delete poLatLong;
 
+    int nBandCount = bandList.size();
+
+    if(pbSuccess == false)
+    {
+        dfNoData = -9999.0;
+    }
 
     GDALDataset *wrpDS;
     GDALWarpOptions* psWarpOptions;
 
+    // Setup warp options
     psWarpOptions = GDALCreateWarpOptions();
-
-
-    int nBandCount = bandList.size();
 
     psWarpOptions->nBandCount = nBandCount;
 
@@ -400,10 +404,17 @@ void setSurfaceGrids( const std::string &wxModelFileName, const int &timeBandIdx
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
     psWarpOptions->padfDstNoDataImag =
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
+    for(int b = 0; b < nBandCount; b++)
+    {
+        psWarpOptions->padfDstNoDataReal[b] = dfNoData;
+        psWarpOptions->padfDstNoDataImag[b] = dfNoData;
+    }
 
-
-    if( pbSuccess == false )
-        dfNoData = -9999.0;
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
     // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
     // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/KmlVector.cpp
+++ b/src/ninja/KmlVector.cpp
@@ -1836,94 +1836,97 @@ bool KmlVector::writeVectors(VSILFILE *fileOut)
     {
         for(int j = 0;j < nC;j++)
         {
-            yScale = 0.5;
-            s = spd(i,j);
-            // geTheta is the printed value (geographic coordinates), theta is the drawn value (projected coordinates) which is then reprojected (from projected to geographic coordinates)
-            // the formula for going from one projection to another is always prj2 = prj1 - coordinateTransformAngle_from_prj1_to_prj2
-            // but in this case, prj1 = dem, prj2 = kmz, and coordinateTransformAngle_from_dem_to_kmz = -coordinateTransformAngle_from_kmz_to_dem = -angleFromNorth
-            // this is because angleFromNorth is stored as a value going FROM N TO dem, but here we are going FROM dem TO N,
-            // so we need to use a negative value for angleFromNorth rather than a positive value
-            // so for this case, prj2 = prj1 - (-angleFromNorth) = prj1 + angleFromNorth, the two negative signs cancel
-            // But, if using coordinateTransformAngle_from_dem_to_kmz instead of the angleFromNorth value, make sure to go back to only a single "-" sign in the formula
-            geTheta = wrap0to360( dir(i,j) + angleFromNorth ); //convert FROM projected TO geographic coordinates
-            theta = dir(i,j) + 180.0;
-
-            if(s <= splitValue[1])
-                yScale *= 0.40;
-            else if(s <= splitValue[2])
-                yScale *= 0.60;
-            else if(s <= splitValue[3])
-                yScale *= 0.80;
-            else if(s <= splitValue[4])
-                yScale *= 1.0;
-            xScale = yScale * 0.40;
-
-            spd.get_cellPosition(i, j, &xCenter, &yCenter);
-
-            //xCenter = (cSize / 2.0) + (j * cSize + spd.get_xllCorner());
-            //yCenter = (cSize / 2.0) + ((nR - i - 1) * cSize) + spd.get_yllCorner();
-
-            if(theta > 360)
+            if(spd(i,j) != spd.get_noDataValue() && dir(i,j) != dir.get_noDataValue())
             {
-                theta -= 360;
-            }
-            theta = 360 - theta;
+                yScale = 0.5;
+                s = spd(i,j);
 
-            theta = theta * (PI / 180);
+                // geTheta is the printed value (geographic coordinates), theta is the drawn value (projected coordinates) which is then reprojected (from projected to geographic coordinates)
+                // the formula for going from one projection to another is always prj2 = prj1 - coordinateTransformAngle_from_prj1_to_prj2
+                // but in this case, prj1 = dem, prj2 = kmz, and coordinateTransformAngle_from_dem_to_kmz = -coordinateTransformAngle_from_kmz_to_dem = -angleFromNorth
+                // this is because angleFromNorth is stored as a value going FROM N TO dem, but here we are going FROM dem TO N,
+                // so we need to use a negative value for angleFromNorth rather than a positive value
+                // so for this case, prj2 = prj1 - (-angleFromNorth) = prj1 + angleFromNorth, the two negative signs cancel
+                // But, if using coordinateTransformAngle_from_dem_to_kmz instead of the angleFromNorth value, make sure to go back to only a single "-" sign in the formula
+                geTheta = wrap0to360( dir(i,j) + angleFromNorth ); //convert FROM projected TO geographic coordinates
+                theta = dir(i,j) + 180.0;
 
-            if( areEqual( s, 0.0 ) )
-            {
-                double square_size = 16;
-                xTip = xCenter - cSize / square_size;
-                yTip = yCenter + cSize / square_size;
-                xTail = xCenter + cSize / square_size;
-                yTail = yCenter + cSize / square_size;
-                xHeadLeft = xCenter - cSize / square_size;
-                yHeadLeft = yCenter - cSize / square_size;
-                xHeadRight = xCenter + cSize / square_size;
-                yHeadRight = yCenter - cSize / square_size;
-            }
-            else
-            {
-                xPoint = 0;
-                yPoint = (cSize * yScale);
+                if(s <= splitValue[1])
+                    yScale *= 0.40;
+                else if(s <= splitValue[2])
+                    yScale *= 0.60;
+                else if(s <= splitValue[3])
+                    yScale *= 0.80;
+                else if(s <= splitValue[4])
+                    yScale *= 1.0;
+                xScale = yScale * 0.40;
 
-                //compute tip coordinates
-                xTip = (xPoint * cos(theta)) - (yPoint * sin(theta));
-                yTip = (xPoint * sin(theta)) + (yPoint * cos(theta));
-                //compute tail coordinates
-                xTail = -xTip;
-                yTail = -yTip;
+                spd.get_cellPosition(i, j, &xCenter, &yCenter);
 
-                //compute right and left coordinates for head
-                xPoint = (cSize * xScale);
-                yPoint = (cSize * yScale)-(cSize * xScale);
+                //xCenter = (cSize / 2.0) + (j * cSize + spd.get_xllCorner());
+                //yCenter = (cSize / 2.0) + ((nR - i - 1) * cSize) + spd.get_yllCorner();
 
-                xHeadRight = (xPoint * cos(theta)) - (yPoint * sin(theta));
-                yHeadRight = (xPoint * sin(theta)) + (yPoint * cos(theta));
+                if(theta > 360)
+                {
+                    theta -= 360;
+                }
+                theta = 360 - theta;
 
-                xPoint = -(cSize * xScale);
-                yPoint = (cSize * yScale) - (cSize * xScale);
-                xHeadLeft = (xPoint * cos(theta)) - (yPoint * sin(theta));
-                yHeadLeft = (xPoint * sin(theta)) + (yPoint * cos(theta));
+                theta = theta * (PI / 180);
 
-                //shift to global coordinates
-                xTip+=xCenter;
-                yTip+=yCenter;
-                xTail+=xCenter;
-                yTail+=yCenter;
-                xHeadRight += xCenter;
-                yHeadRight += yCenter;
-                xHeadLeft += xCenter;
-                yHeadLeft += yCenter;
-            }
-            coordTransform->Transform(1, &xTip, &yTip);
-            coordTransform->Transform(1, &xTail, &yTail);
-            coordTransform->Transform(1, &xHeadRight, &yHeadRight);
-            coordTransform->Transform(1, &xHeadLeft, &yHeadLeft);
+                if( areEqual( s, 0.0 ) )
+                {
+                    double square_size = 16;
+                    xTip = xCenter - cSize / square_size;
+                    yTip = yCenter + cSize / square_size;
+                    xTail = xCenter + cSize / square_size;
+                    yTail = yCenter + cSize / square_size;
+                    xHeadLeft = xCenter - cSize / square_size;
+                    yHeadLeft = yCenter - cSize / square_size;
+                    xHeadRight = xCenter + cSize / square_size;
+                    yHeadRight = yCenter - cSize / square_size;
+                }
+                else
+                {
+                    xPoint = 0;
+                    yPoint = (cSize * yScale);
 
-            if(s != spd.get_noDataValue() && theta != dir.get_noDataValue())
-            {
+                    //compute tip coordinates
+                    xTip = (xPoint * cos(theta)) - (yPoint * sin(theta));
+                    yTip = (xPoint * sin(theta)) + (yPoint * cos(theta));
+                    //compute tail coordinates
+                    xTail = -xTip;
+                    yTail = -yTip;
+
+                    //compute right and left coordinates for head
+                    xPoint = (cSize * xScale);
+                    yPoint = (cSize * yScale)-(cSize * xScale);
+
+                    xHeadRight = (xPoint * cos(theta)) - (yPoint * sin(theta));
+                    yHeadRight = (xPoint * sin(theta)) + (yPoint * cos(theta));
+
+                    xPoint = -(cSize * xScale);
+                    yPoint = (cSize * yScale) - (cSize * xScale);
+                    xHeadLeft = (xPoint * cos(theta)) - (yPoint * sin(theta));
+                    yHeadLeft = (xPoint * sin(theta)) + (yPoint * cos(theta));
+
+                    //shift to global coordinates
+                    xTip+=xCenter;
+                    yTip+=yCenter;
+                    xTail+=xCenter;
+                    yTail+=yCenter;
+                    xHeadRight += xCenter;
+                    yHeadRight += yCenter;
+                    xHeadLeft += xCenter;
+                    yHeadLeft += yCenter;
+                }
+                coordTransform->Transform(1, &xTip, &yTip);
+                coordTransform->Transform(1, &xTail, &yTail);
+                coordTransform->Transform(1, &xHeadRight, &yHeadRight);
+                coordTransform->Transform(1, &xHeadLeft, &yHeadLeft);
+
+                // now start writing to the kml file
+
                 VSIFPrintfL(fileOut, "<Placemark>");
                 //fprintf(fileOut, "\n<Icon><href>ffs_icon.ico</href></Icon>");
                 VSIFPrintfL(fileOut, "\n\t<name>Cell %d,%d</name>", i, j);

--- a/src/ninja/gcp_wx_init.cpp
+++ b/src/ninja/gcp_wx_init.cpp
@@ -668,7 +668,10 @@ void GCPWxModel::setSurfaceGrids(WindNinjaInputs& input,
     GDALRasterBandH hBand = GDALGetRasterBand(hSrcDS, 1);
     int bSuccess;
     dfNoData = GDALGetRasterNoDataValue(hBand, &bSuccess);
-    if (!bSuccess) dfNoData = -9999.0;
+    if(!bSuccess)
+    {
+        dfNoData = -9999.0;
+    }
 
     // Setup warp options
     psWarpOptions = GDALCreateWarpOptions();
@@ -677,6 +680,12 @@ void GCPWxModel::setSurfaceGrids(WindNinjaInputs& input,
     for (int i = 0; i < nBandCount; ++i) {
         psWarpOptions->padfDstNoDataReal[i] = dfNoData;
         psWarpOptions->padfDstNoDataImag[i] = dfNoData;
+    }
+
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(bSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
     }
 
     pszSrcWkt = GDALGetProjectionRef(hSrcDS);

--- a/src/ninja/gdal_util.cpp
+++ b/src/ninja/gdal_util.cpp
@@ -1507,9 +1507,13 @@ bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDs
     int nBandCount = GDALGetRasterCount( hDstDS );
 
     double dfNoData = GDALGetRasterNoDataValue(hSrcBand, NULL);
+    // TODO: check to see if this is needed, when checking "INIT_DEST"="NO_DATA" methods
+    //int bSuccess;
+    //double dfNoData = GDALGetRasterNoDataValue(hSrcBand, &bSuccess);
 
     GDALSetRasterNoDataValue(hDstBand, dfNoData);
 
+    // Setup warp options
     GDALWarpOptions *psWarpOptions = GDALCreateWarpOptions();
 
     psWarpOptions->hSrcDS = hSrcDS;
@@ -1522,12 +1526,20 @@ bool GDALWarpToUtm(const char* filename, GDALDatasetH& hSrcDS, GDALDatasetH& hDs
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
     psWarpOptions->padfDstNoDataReal[0] = dfNoData;
     psWarpOptions->padfDstNoDataImag[0] = dfNoData;
+
     psWarpOptions->panSrcBands = 
         (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
     psWarpOptions->panSrcBands[0] = 1;
     psWarpOptions->panDstBands = 
         (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
     psWarpOptions->panDstBands[0] = 1;
+
+    // TODO: not sure how this affects surface_fetch products yet. Need to also check if this is needed for the other gdalWarpToUtm() function as well.
+    //psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    //if(bSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    //{
+    //    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    //}
 
     psWarpOptions->pTransformerArg = 
         GDALCreateGenImgProjTransformer( hSrcDS, 
@@ -1684,8 +1696,8 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
 
     GDALDatasetH hBand = GDALGetRasterBand( hSrcDS, band );
     int bSuccess = false;
-    double dfNoData = GDALGetRasterNoDataValue( hBand, &bSuccess );
-    if( bSuccess == false )
+    double dfNoData = GDALGetRasterNoDataValue(hBand, &bSuccess);
+    if(bSuccess == false)
     {
         dfNoData = -9999.0;
     }
@@ -1693,6 +1705,7 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
     const char *pszSrcWkt;
     pszSrcWkt = GDALGetProjectionRef( hSrcDS );
 
+    // Setup warp options
     GDALWarpOptions *psWarpOptions;
     psWarpOptions = GDALCreateWarpOptions();
 
@@ -1716,10 +1729,10 @@ bool GDALWarpToWKT_GDALAutoCreateWarpedVRT( GDALDatasetH& hSrcDS, int band, GDAL
         psWarpOptions->padfDstNoDataImag[i] = dfNoData;
     }
 
-    psWarpOptions->papszWarpOptions = CSLSetNameValue( psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA" );
-    if( bSuccess == false )  // if GDALGetRasterNoDataValue( hBand, &bSuccess ) fails to return that a NO_DATA value is in the source dataset
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(bSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
     {
-        psWarpOptions->papszWarpOptions = CSLSetNameValue( psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str() );
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
     }
 
     hDstDS = GDALAutoCreateWarpedVRT( hSrcDS, pszSrcWkt, pszDstWkt,

--- a/src/ninja/genericSurfInitialization.cpp
+++ b/src/ninja/genericSurfInitialization.cpp
@@ -414,17 +414,20 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
+        int nBandCount = srcDS->GetRasterCount();
+
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
         GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
         int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == false)
+        {
+            dfNoData = -9999.0;
+        }
 
+        // Setup warp options
         psWarpOptions = GDALCreateWarpOptions();
-
-        int nBandCount = srcDS->GetRasterCount();
 
         psWarpOptions->nBandCount = nBandCount;
 
@@ -438,12 +441,11 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             psWarpOptions->padfDstNoDataImag[b] = dfNoData;
         }
 
-        if( pbSuccess == false )
-            dfNoData = -9999.0;
-
-        psWarpOptions->papszWarpOptions =
-            CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                            "INIT_DEST", "NO_DATA" );
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepGfsSurfInitialization.cpp
+++ b/src/ninja/ncepGfsSurfInitialization.cpp
@@ -488,28 +488,26 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
          */
         srcWkt = "GEOGCS[\"Custom-defined CS\", DATUM[\"unknown\", SPHEROID[\"Sphere\",6371229,0]], PRIMEM[\"Greenwich\",0], UNIT[\"degree\",0.0174532925199433]]";
 
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
+        int nBandCount = srcDS->GetRasterCount();
 
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
         GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
         int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == false)
+        {
+            dfNoData = -9999.0;
+        }
+
+        // Setup warp options
         psWarpOptions = GDALCreateWarpOptions();
 
-        int nBandCount = srcDS->GetRasterCount();
         psWarpOptions->nBandCount = nBandCount;
         psWarpOptions->panSrcBands = 
             (int*) CPLMalloc( sizeof( int ) * nBandCount );
         psWarpOptions->panDstBands = 
             (int*) CPLMalloc( sizeof( int ) * nBandCount );
-        psWarpOptions->padfDstNoDataReal =
-            (double*) CPLMalloc( sizeof( double ) * nBandCount );
-        psWarpOptions->padfDstNoDataImag =
-            (double*) CPLMalloc( sizeof( double ) * nBandCount );
-
-
         psWarpOptions->padfDstNoDataReal =
             (double*) CPLMalloc( sizeof( double ) * nBandCount );
         psWarpOptions->padfDstNoDataImag =
@@ -522,12 +520,11 @@ void ncepGfsSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             psWarpOptions->panDstBands[b] = b + 1;
         }
 
-        if( pbSuccess == false )
-            dfNoData = -9999.0;
-
-        psWarpOptions->papszWarpOptions =
-        CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                 "INIT_DEST", "NO_DATA" );
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepHrrrSurfInitialization.cpp
+++ b/src/ninja/ncepHrrrSurfInitialization.cpp
@@ -273,7 +273,7 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
                     std::string bandName( gc );
                     if( bandName.find( "10-HTGL" ) != bandName.npos ){
                         bandList.push_back( j );  // 10u    
-                        dfNoData = poBand->GetNoDataValue( &pbSuccess );
+                        dfNoData = poBand->GetNoDataValue(&pbSuccess);
                         break;
                     }
                 }
@@ -318,9 +318,15 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
-    psWarpOptions = GDALCreateWarpOptions();
-
     int nBandCount = bandList.size();
+
+    if(pbSuccess == false)
+    {
+        dfNoData = -9999.0;
+    }
+
+    // Setup warp options
+    psWarpOptions = GDALCreateWarpOptions();
 
     psWarpOptions->nBandCount = nBandCount;
     psWarpOptions->panSrcBands =
@@ -331,15 +337,11 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
     psWarpOptions->padfDstNoDataImag =
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
-
-
-    psWarpOptions->padfDstNoDataReal =
-        (double*) CPLMalloc( sizeof( double ) * nBandCount );
-    psWarpOptions->padfDstNoDataImag =
-        (double*) CPLMalloc( sizeof( double ) * nBandCount );
-
-    if( pbSuccess == false )
-        dfNoData = -9999.0;
+    for(int b = 0; b < nBandCount; b++)
+    {
+        psWarpOptions->padfDstNoDataReal[b] = dfNoData;
+        psWarpOptions->padfDstNoDataImag[b] = dfNoData;
+    }
 
     psWarpOptions->panSrcBands =
         (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
@@ -354,6 +356,12 @@ void ncepHrrrSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     psWarpOptions->panDstBands[1] = 2;
     psWarpOptions->panDstBands[2] = 3;
     psWarpOptions->panDstBands[3] = 4;
+
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
     // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
     // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepNamAlaskaSurfInitialization.cpp
+++ b/src/ninja/ncepNamAlaskaSurfInitialization.cpp
@@ -456,17 +456,20 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
-    /*
-     * Grab the first band to get the nodata value for the variable,
-     * assume all bands have the same ndv
-     */
+    int nBandCount = srcDS->GetRasterCount();
 
+    // Grab the first band to get the NO_DATA value for the variable,
+    // assume all bands have the same NO_DATA value
     GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
     int pbSuccess;
     double dfNoData = poBand->GetNoDataValue( &pbSuccess );
-    psWarpOptions = GDALCreateWarpOptions();
+    if(pbSuccess == false)
+    {
+        dfNoData = -9999.0;
+    }
 
-    int nBandCount = srcDS->GetRasterCount();
+    // Setup warp options
+    psWarpOptions = GDALCreateWarpOptions();
 
     psWarpOptions->nBandCount = nBandCount;
     psWarpOptions->panSrcBands = 
@@ -485,12 +488,11 @@ void ncepNamAlaskaSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         psWarpOptions->panDstBands[b] = b + 1;
     }
 
-    if( pbSuccess == false )
-        dfNoData = -9999.0;
-
-    psWarpOptions->papszWarpOptions =
-        CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                 "INIT_DEST", "NO_DATA" );
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepNamGrib2SurfInitialization.cpp
+++ b/src/ninja/ncepNamGrib2SurfInitialization.cpp
@@ -240,13 +240,18 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
     }
 
+    int nBandCount = bandList.size();
+
     GDALRasterBand *poBand = srcDS->GetRasterBand( 9 );
     int pbSuccess;
-    double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+    double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+    if(pbSuccess == false)
+    {
+        dfNoData = -9999.0;
+    }
 
+    // Setup warp options
     psWarpOptions = GDALCreateWarpOptions();
-
-    int nBandCount = bandList.size();
 
     psWarpOptions->nBandCount = nBandCount;
     psWarpOptions->panSrcBands =
@@ -257,9 +262,11 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
     psWarpOptions->padfDstNoDataImag =
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
-
-    if( pbSuccess == false )
-        dfNoData = -9999.0;
+    for(int b = 0; b < nBandCount; b++)
+    {
+        psWarpOptions->padfDstNoDataReal[b] = dfNoData;
+        psWarpOptions->padfDstNoDataImag[b] = dfNoData;
+    }
 
     psWarpOptions->panSrcBands =
         (int *) CPLMalloc(sizeof(int) * psWarpOptions->nBandCount );
@@ -274,6 +281,12 @@ void ncepNamGrib2SurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     psWarpOptions->panDstBands[1] = 2;
     psWarpOptions->panDstBands[2] = 3;
     psWarpOptions->panDstBands[3] = 4;
+
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
     // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
     // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepNamSurfInitialization.cpp
+++ b/src/ninja/ncepNamSurfInitialization.cpp
@@ -455,17 +455,21 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
+        int nBandCount = srcDS->GetRasterCount();
+
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
         GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
         int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == FALSE)
+        {
+            dfNoData = -9999.0;
+        }
 
+        // Setup warp options
         psWarpOptions = GDALCreateWarpOptions();
 
-        int nBandCount = srcDS->GetRasterCount();
         psWarpOptions->nBandCount = nBandCount;
         psWarpOptions->panSrcBands = 
             (int*) CPLMalloc( sizeof( int ) * nBandCount );
@@ -483,12 +487,11 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             psWarpOptions->panDstBands[b] = b + 1;
          }
 
-        if( pbSuccess == FALSE )
-            dfNoData = -9999.0;
-
-        psWarpOptions->papszWarpOptions =
-            CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                             "INIT_DEST", "NO_DATA" );
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset
@@ -505,10 +508,8 @@ void ncepNamSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             }
         }
 
-        /*
-        ** FIXME(kyle): valgrind reporting memory leak as psWarpOptions is
-        ** cloned internally and then not freed
-        */
+        // FIXME(kyle): valgrind reporting memory leak as psWarpOptions is
+        // cloned internally and then not freed
         wrpDS = (GDALDataset*) GDALAutoCreateWarpedVRT( srcDS, srcWkt.c_str(),
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,

--- a/src/ninja/ncepNdfdInitialization.cpp
+++ b/src/ninja/ncepNdfdInitialization.cpp
@@ -594,15 +594,19 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
             throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
         }
 
+    int nBandCount = srcDS->GetRasterCount();
+
     GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
     int pbSuccess;
-    double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+    double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+    if(pbSuccess == false)
+    {
+        dfNoData = -9999.0;
+    }
+
+    // Setup warp options
     psWarpOptions = GDALCreateWarpOptions();
 
-    if( pbSuccess == false )
-        dfNoData = -9999.0;
-
-    int nBandCount = srcDS->GetRasterCount();
     psWarpOptions->nBandCount = nBandCount;
     psWarpOptions->panSrcBands = 
         (int*) CPLMalloc( sizeof( int ) * nBandCount );
@@ -620,9 +624,11 @@ void ncepNdfdInitialization::setSurfaceGrids(  WindNinjaInputs &input,
         psWarpOptions->panDstBands[b] = b + 1;
     }
 
-    psWarpOptions->papszWarpOptions =
-        CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                 "INIT_DEST", "NO_DATA" );
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ncepRapSurfInitialization.cpp
+++ b/src/ninja/ncepRapSurfInitialization.cpp
@@ -434,17 +434,25 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
                 throw std::runtime_error("Could not get projection from forecast file, bad forecast file.");
             }
 
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
+        int nBandCount = srcDS->GetRasterCount();
+
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
         GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
         int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == false)
+        {
+            dfNoData = -9999.0;
+        }
 
+        if(dfNoData > 1e10)
+        {
+            dfNoData = std::numeric_limits<double>::quiet_NaN();
+        }
+
+        // Setup warp options
         psWarpOptions = GDALCreateWarpOptions();
-
-        int nBandCount = srcDS->GetRasterCount();
 
         psWarpOptions->panSrcBands =
             (int*) CPLMalloc( sizeof( int ) * nBandCount );
@@ -462,15 +470,11 @@ void ncepRapSurfInitialization::setSurfaceGrids(  WindNinjaInputs &input,
           psWarpOptions->panDstBands[b] = b + 1;
         }
 
-        if( pbSuccess == false)
-          dfNoData = -9999.0;
-
-        if( dfNoData > 1e10)
-          dfNoData = std::numeric_limits<double>::quiet_NaN();
-
-        psWarpOptions->papszWarpOptions =
-        CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                 "INIT_DEST", "NO_DATA" );
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset

--- a/src/ninja/ninjafoam.cpp
+++ b/src/ninja/ninjafoam.cpp
@@ -2444,6 +2444,15 @@ bool NinjaFoam::SampleRawOutput()
     GDAL2AsciiGrid( (GDALDataset *)hDS, 1, foamU );
     GDAL2AsciiGrid( (GDALDataset *)hDS, 2, foamV );
 
+    // If we failed to fill in the data for the entire grid, we've failed.
+    // Report a better message.
+    if(foamU.get_hasNoDataValues() || foamV.get_hasNoDataValues())
+    {
+        // testing this by forcing a value to be NO_DATA. For some odd reason, this message isn't going through.
+        CPLError( CE_Failure, CPLE_AppDefined, "The openfoam output could not be interpolated to a proper surface.");
+        return false;
+    }
+
     if(!CheckIfOutputWindHeightIsResolved()){
         //if the output wind height is not resolved, interpolate to output height using a log profile
         windProfile profile;
@@ -2483,12 +2492,7 @@ bool NinjaFoam::SampleRawOutput()
         }
     }
 
-    // If we failed to fill in the data for the entire grid, we've failed.
-    // Report a better message.
-    if( AngleGrid.get_hasNoDataValues() || VelocityGrid.get_hasNoDataValues() ) {
-        CPLError( CE_Failure, CPLE_AppDefined, "The openfoam output could not be interpolated to a proper surface.");
-        return false;
-    }
+    //final check, to see if values are greater than the largest known wind speed
     if(VelocityGrid.get_maxValue() > 220.0){
         CPLError( CE_Failure, CPLE_AppDefined, "The flow solution did not converge. This may occasionally "
                 "happen in very complex terrain when the mesh resolution is high. Try the simulation "

--- a/src/ninja/nomads.c
+++ b/src/ninja/nomads.c
@@ -1018,8 +1018,13 @@ GDALDatasetH NomadsAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
     {
         if (CSLFetchNameValue( psWO->papszWarpOptions, "INIT_DEST" ) == NULL)
         {
-            psWO->papszWarpOptions =
-                CSLSetNameValue(psWO->papszWarpOptions, "INIT_DEST", "NO_DATA");
+            psWO->papszWarpOptions = CSLSetNameValue(psWO->papszWarpOptions, "INIT_DEST", "NO_DATA");
+            int hasNoDataValue;
+            double noDataValue = GDALGetRasterNoDataValue(band, &hasNoDataValue);
+            if(hasNoDataValue == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+            {
+                psWO->papszWarpOptions = CSLSetNameValue(psWO->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(noDataValue).c_str());
+            }
         }
     }
 

--- a/src/ninja/nomads_wx_init.cpp
+++ b/src/ninja/nomads_wx_init.cpp
@@ -584,8 +584,8 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
     pszForecastFile = NULL;
     nBandCount = GDALGetRasterCount( hSrcDS );
     hBand = GDALGetRasterBand( hSrcDS, 1 );
-    dfNoData = GDALGetRasterNoDataValue( hBand, &bSuccess );
-    if( bSuccess == FALSE )
+    dfNoData = GDALGetRasterNoDataValue(hBand, &bSuccess);
+    if(bSuccess == FALSE)
     {
         dfNoData = -9999.0;
     }
@@ -601,14 +601,11 @@ void NomadsWxModel::setSurfaceGrids( WindNinjaInputs &input,
         psWarpOptions->padfDstNoDataImag[i] = dfNoData;
     }
 
-// this fix works to finally properly add NO_DATA values instead of 0.0 values to the dataset,
-// and surprisingly, the code runs fine to completion. The main difference I saw was that the kmz output
-// dropped all the bands of zeroes around the edges of the dataset.
-//    psWarpOptions->papszWarpOptions = CSLSetNameValue( psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA" );
-//    if( bSuccess == false )  // if GDALGetRasterNoDataValue( hBand, &bSuccess ) fails to return that a NO_DATA value is in the source dataset
-//    {
-//        psWarpOptions->papszWarpOptions = CSLSetNameValue( psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str() );
-//    }
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(bSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
     pszSrcWkt = GDALGetProjectionRef( hSrcDS );
     if(pszSrcWkt == nullptr)
@@ -969,7 +966,7 @@ noCloudOK:
         dirTmpGrid.deallocate();
     }
 
-    GDALDestroyWarpOptions( psWarpOptions );
+    GDALDestroyWarpOptions(psWarpOptions);
 }
 
 void NomadsWxModel::checkForValidData()
@@ -1096,9 +1093,12 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
     int nBandCount = GDALGetRasterCount( hDS );
     hBand = GDALGetRasterBand( hDS, 1 );
     int bSuccess;
-    double dfNoData = GDALGetRasterNoDataValue( hBand, &bSuccess );
-    if( !bSuccess )
+    double dfNoData = GDALGetRasterNoDataValue(hBand, &bSuccess);
+    if(!bSuccess)
+    {
         dfNoData = -9999.0;
+    }
+
     psWarpOptions = GDALCreateWarpOptions();
     psWarpOptions->padfDstNoDataReal =
         (double*) CPLMalloc( sizeof( double ) * nBandCount );
@@ -1109,9 +1109,12 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         psWarpOptions->padfDstNoDataReal[i] = dfNoData;
         psWarpOptions->padfDstNoDataImag[i] = dfNoData;
     }
-    psWarpOptions->papszWarpOptions =
-            CSLSetNameValue( psWarpOptions->papszWarpOptions,
-                             "INIT_DEST", "-9999.0" );
+
+    psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+    if(bSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+    {
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+    }
 
     pszSrcWkt = GDALGetProjectionRef( hDS );
     if(pszSrcWkt == nullptr)
@@ -1278,6 +1281,8 @@ void NomadsWxModel::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         fields[i]->allocate( &mesh );
         wxFields[i]->interpolateScalarData((*(fields[i])), mesh, input);
     }
+
+    GDALDestroyWarpOptions(psWarpOptions);
 #endif /* NOMADS_ENABLE_3D */
     return;
 }

--- a/src/ninja/wrf3dInitialization.cpp
+++ b/src/ninja/wrf3dInitialization.cpp
@@ -391,23 +391,40 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
 
 
         srcDS->SetGeoTransform(adfGeoTransform);
-        
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
-        GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
-        int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
 
         int nBandCount = srcDS->GetRasterCount();
-
         CPLDebug("WX_MODEL_INITIALIZATION", "band count = %d", nBandCount);
+        
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
+        GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
+        int pbSuccess;
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == false)
+        {
+            dfNoData = -9999.0;
+        }
+
+        // Setup warp options
+        psWarpOptions = GDALCreateWarpOptions();
+        psWarpOptions->padfDstNoDataReal = (double*)CPLMalloc(sizeof(double) * nBandCount);
+        psWarpOptions->padfDstNoDataImag = (double*)CPLMalloc(sizeof(double) * nBandCount);
+        for(int b = 0; b < nBandCount; b++)
+        {
+            psWarpOptions->padfDstNoDataReal[b] = dfNoData;
+            psWarpOptions->padfDstNoDataImag[b] = dfNoData;
+        }
+
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         wrpDS = (GDALDataset*) GDALAutoCreateWarpedVRT( srcDS, srcWKT,
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,
-                                                        1.0, NULL );
+                                                        1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
             throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
@@ -666,7 +683,8 @@ void wrf3dInitialization::set3dGrids( WindNinjaInputs &input, Mesh const& mesh )
         delete poCT;
         GDALClose((GDALDatasetH) srcDS );
         GDALClose((GDALDatasetH) wrpDS );
-        
+
+        GDALDestroyWarpOptions(psWarpOptions);
     } // end loop over variable
     
     

--- a/src/ninja/wrfSurfInitialization.cpp
+++ b/src/ninja/wrfSurfInitialization.cpp
@@ -310,6 +310,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         AsciiGrid<double> &vGrid,
         AsciiGrid<double> &wGrid )
 {
+    GDALWarpOptions* psWarpOptions = nullptr;
 
     int bandNum = -1;
 
@@ -704,20 +705,34 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             tempSrcGrid.write_Grid("before_warp", 2);
         }*/
 
-        /*
-         * Grab the first band to get the nodata value for the variable,
-         * assume all bands have the same ndv
-         */
-        GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
-        int pbSuccess;
-        double dfNoData = poBand->GetNoDataValue( &pbSuccess );
-
         int nBandCount = srcDS->GetRasterCount();
-
         CPLDebug("WRF", "band count = %d", nBandCount);
 
-        if( pbSuccess == false )
+        // Grab the first band to get the NO_DATA value for the variable,
+        // assume all bands have the same NO_DATA value
+        GDALRasterBand *poBand = srcDS->GetRasterBand( 1 );
+        int pbSuccess;
+        double dfNoData = poBand->GetNoDataValue(&pbSuccess);
+        if(pbSuccess == false)
+        {
             dfNoData = -9999.0;
+        }
+
+        // Setup warp options
+        psWarpOptions = GDALCreateWarpOptions();
+        psWarpOptions->padfDstNoDataReal = (double*)CPLMalloc(sizeof(double) * nBandCount);
+        psWarpOptions->padfDstNoDataImag = (double*)CPLMalloc(sizeof(double) * nBandCount);
+        for(int b = 0; b < nBandCount; b++)
+        {
+            psWarpOptions->padfDstNoDataReal[b] = dfNoData;
+            psWarpOptions->padfDstNoDataImag[b] = dfNoData;
+        }
+
+        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
+        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        {
+            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+        }
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset
@@ -737,7 +752,7 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         wrpDS = (GDALDataset*) GDALAutoCreateWarpedVRT( srcDS, srcWKT,
                                                         dstWkt.c_str(),
                                                         GRA_NearestNeighbour,
-                                                        1.0, NULL );
+                                                        1.0, psWarpOptions );
         if(wrpDS == NULL)
         {
             throw std::runtime_error("Could not warp the forecast file, possibly non-uniform grid.");
@@ -798,7 +813,10 @@ void wrfSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         delete poCT;
         GDALClose((GDALDatasetH) srcDS );
         GDALClose((GDALDatasetH) wrpDS );
+
+        GDALDestroyWarpOptions(psWarpOptions);
     }
+
     //don't allow small negative values in cloud cover
     for(int i=0; i<cloudGrid.get_nRows(); i++){
         for(int j=0; j<cloudGrid.get_nCols(); j++){


### PR DESCRIPTION
Fixes #647, at least for the wxModels. Seems the method actually applied to ALL warp types that use `GDALWarpOptions`, not just the specific `GDALAutoCreateWarpedVRT()` warping method.

So [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/gdal_util.cpp#L1516-L1563) and [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/gdal_util.cpp#L1633) in `gdal_util.cpp` still need checked (these functions seem to only be used by `surface_fetch.cpp` classes), all the various warps done in the various `surface_fetch.cpp` classes also need checked, and [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/ascii_grid.cpp#L2231-L2233), [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/ascii_grid.cpp#L2345-L2347), and [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/ascii_grid.cpp#L2535) need checked in `ascii_grid.cpp`. But the `wxModelInitialize.cpp` classes SHOULD be good to go.

I believe the remaining `surface_fetch.cpp` warps in the code work correctly, because the DEM datasets actually HAVE pre-defined NO_DATA values, and if not and it is putting zeroes in for NO_DATA, we still clip the dataset to a subset area, clipping off the NO_DATA edges anyways. I believe the `asciiToPng()` output works out correctly, because NO_DATA values should already be defined for the dataset, and if not, then zeroes technically works out because the pixels are defined as 0 to 255 with NO_DATA values as 0 anyways.

I am a bit more leery of the raw value `tiff` output in `ascii_grid.cpp` though, [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/ascii_grid.cpp#L2345-L2347) and [here](https://github.com/firelab/windninja/blob/19199972f8b2d00c77fe8edb735f12ccde40bcac/src/ninja/ascii_grid.cpp#L2535). NO_DATA values as zeroes probably works for the 'gtiff' datasets, but using the actual NO_DATA values would probably be better.