### PR TITLE
Various miscellaneous fixes to the Qt6 GUI

### DIFF
--- a/src/fetch_dem/fetch_dem.cpp
+++ b/src/fetch_dem/fetch_dem.cpp
@@ -487,7 +487,7 @@ int main(int argc, char *argv[])
         }
         else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
         {
-            fprintf(stderr, "Fetch was outside the bounds of the dataset.\n");
+            fprintf(stderr, "Fetch was outside the bounds of the dataset. Please select new data source or new area.\n");
         }
         else if(nDemError == SURF_FETCH_E_WARPER_ERR)
         {
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            fprintf(stderr, "Unknown error occurred during fetch.\n");
+            fprintf(stderr, "Unknown error occurred during fetch.\nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source.\n");
         }
         NinjaFinalize();
         return nDemError;

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -1600,37 +1600,28 @@ void MainWindow::plotKmzOutputs()
         // vars to be filled
         int numRuns = 0;
         char **kmzFilenames = NULL;
-        int *numStationKmlsPerRun = 0;
-        char ***stationKmlFilenames = NULL;
+        char **stationKmlFilenames = NULL;
         char **weatherModelKmzFilenames = NULL;
 
         char **papszOptions = nullptr;
-        ninjaErr = NinjaGetRunKmzFilenames(ninjaArmy, &numRuns, &kmzFilenames, &numStationKmlsPerRun, &stationKmlFilenames, &weatherModelKmzFilenames, papszOptions);
+        ninjaErr = NinjaGetRunKmzFilenames(ninjaArmy, &numRuns, &kmzFilenames, &stationKmlFilenames, &weatherModelKmzFilenames, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
             printf("NinjaGetRunKmzFilenames: ninjaErr = %d\n", ninjaErr);
         }
 
         std::vector<std::string> kmzFilenamesStr;
-        std::vector<std::vector<std::string>> stationKmlFilenamesStr;
+        std::vector<std::string> stationKmlFilenamesStr;
         std::vector<std::string> wxModelKmzFilenamesStr;
 
         kmzFilenamesStr.reserve(numRuns);
+        stationKmlFilenamesStr.reserve(numRuns);
         wxModelKmzFilenamesStr.reserve(numRuns);
         for(int i = 0; i < numRuns; i++)
         {
             kmzFilenamesStr.emplace_back(kmzFilenames[i]);
+            stationKmlFilenamesStr.emplace_back(stationKmlFilenames[i]);
             wxModelKmzFilenamesStr.emplace_back(weatherModelKmzFilenames[i]);
-        }
-
-        stationKmlFilenamesStr.resize(numRuns); // have to actually size it for the later reserves and emplace_back to work correctly
-        for(int i = 0; i < numRuns; i++)
-        {
-            stationKmlFilenamesStr[i].reserve(numStationKmlsPerRun[i]);
-            for(int j = 0; j < numStationKmlsPerRun[i]; j++)
-            {
-                stationKmlFilenamesStr[i].emplace_back(stationKmlFilenames[i][j]);
-            }
         }
 
         outputKmzFilenames.push_back(std::move( kmzFilenamesStr ));
@@ -1659,22 +1650,18 @@ void MainWindow::plotKmzOutputs()
 
             if(ui->pointInitializationGroupBox->isChecked() && ui->pointInitializationWriteStationKMLCheckBox->isChecked())
             {
-                for(int j = 0; j < numStationKmlsPerRun[i]; j++)
-                //for(int j = 0; j < 1; j++)
-                {
-                    QString outFileStr = QString::fromStdString(stationKmlFilenames[i][j]);
-                    qDebug() << "station kml outFile =" << outFileStr;
-                    QFile outFile(outFileStr);
-                    QFileInfo info(outFileStr);
-                    QString fileName = info.fileName();
+                QString outFileStr = QString::fromStdString(stationKmlFilenames[i]);
+                qDebug() << "station kml outFile =" << outFileStr;
+                QFile outFile(outFileStr);
+                QFileInfo info(outFileStr);
+                QString fileName = info.fileName();
 
-                    outFile.open(QIODevice::ReadOnly);
-                    QByteArray data = outFile.readAll();
-                    QString base64 = data.toBase64();
+                outFile.open(QIODevice::ReadOnly);
+                QByteArray data = outFile.readAll();
+                QString base64 = data.toBase64();
 
-                    QString jsCall3 = QString("loadKmzFromBase64('%1', '%2');").arg(base64, fileName);
-                    webEngineView->page()->runJavaScript(jsCall3);
-                }
+                QString jsCall3 = QString("loadKmzFromBase64('%1', '%2');").arg(base64, fileName);
+                webEngineView->page()->runJavaScript(jsCall3);
             }
 
             // // if it is a weather model run, and weather model kmzs were created for the run,
@@ -1696,7 +1683,7 @@ void MainWindow::plotKmzOutputs()
             }
         }
 
-        ninjaErr = NinjaDestroyRunKmzFilenames(numRuns, kmzFilenames, numStationKmlsPerRun, stationKmlFilenames, weatherModelKmzFilenames, papszOptions);
+        ninjaErr = NinjaDestroyRunKmzFilenames(numRuns, kmzFilenames, stationKmlFilenames, weatherModelKmzFilenames, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
             printf("NinjaDestroyRunKmzFilenames: ninjaErr = %d\n", ninjaErr);

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -175,7 +175,7 @@ void MainWindow::updateProgressMessage(const QString message)
         QMessageBox::critical(
             nullptr,
             QApplication::tr("Error"),
-            message
+            message+"\n"
         );
     }
 }
@@ -215,11 +215,9 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
 
     std::string msg = pszMessage;
 
-    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
-    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
-    // but now we are running into an issue where QMessageBox gets confused about how to size things,
-    // UNLESS an extra "\n" is in the text. So annoying and confusing.
-    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
+    // both the writeToConsole() function and the QProgressDialog do NOT like having a "\n" at the end of a given message,
+    // writeToConsole() adds extra empty lines all over the place and the QProgressDialog adds a weird looking space between the message and the progress bar.
+    // but ninjaCom likes to add "\n" to stuff and currently sends one "\n". So need to strip the "\n" character off of the message.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -272,21 +270,21 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Simulation was cancelled by the user." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation cancelled")+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation cancelled"));
             emit self->writeToConsoleSignal(QString::fromStdString("Simulation cancelled by user"), QColor(255, 140, 0));
         }
         else if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended with unknown error")+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended with unknown error"));
             emit self->writeToConsoleSignal(QString::fromStdString("unknown solver error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended in error:\n"+clipStr)+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended in error:\n"+clipStr));
             emit self->writeToConsoleSignal(QString::fromStdString("Solver error: "+clipStr), Qt::red);
         }
     }
@@ -299,14 +297,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("Solver ended in warning:\n"+clipStr)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString("Solver ended in warning:\n"+clipStr));
         emit self->writeToConsoleSignal(QString::fromStdString("Solver warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -166,7 +166,18 @@ void MainWindow::writeToConsole(QString message, QColor color)
 
 void MainWindow::updateProgressMessage(const QString message)
 {
-    progressDialog->setLabelText(message);
+    if(progressDialog)
+    {
+        progressDialog->setLabelText(message);
+    }
+    else
+    {
+        QMessageBox::critical(
+            nullptr,
+            QApplication::tr("Error"),
+            message
+        );
+    }
 }
 
 void MainWindow::updateProgressValue(int run, int progress)
@@ -203,6 +214,12 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
     MainWindow *self = static_cast<MainWindow*>(pUser);
 
     std::string msg = pszMessage;
+
+    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
+    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
+    // but now we are running into an issue where QMessageBox gets confused about how to size things,
+    // UNLESS an extra "\n" is in the text. So annoying and confusing.
+    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -255,21 +272,21 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Simulation was cancelled by the user." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation cancelled"));
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation cancelled")+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("Simulation cancelled by user"), QColor(255, 140, 0));
         }
         else if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended with unknown error"));
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended with unknown error")+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("unknown solver error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended in error:\n"+clipStr));
+            emit self->updateProgressMessageSignal(QString::fromStdString("Simulation ended in error:\n"+clipStr)+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("Solver error: "+clipStr), Qt::red);
         }
     }
@@ -282,14 +299,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("Solver ended in warning:\n"+clipStr));
+        emit self->updateProgressMessageSignal(QString::fromStdString("Solver ended in warning:\n"+clipStr)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString("Solver warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -1600,19 +1600,19 @@ void MainWindow::plotKmzOutputs()
         // vars to be filled
         int numRuns = 0;
         char **kmzFilenames = NULL;
-        int numStationKmls = 0;
-        char **stationKmlFilenames = NULL;
+        int *numStationKmlsPerRun = 0;
+        char ***stationKmlFilenames = NULL;
         char **weatherModelKmzFilenames = NULL;
 
         char **papszOptions = nullptr;
-        ninjaErr = NinjaGetRunKmzFilenames(ninjaArmy, &numRuns, &kmzFilenames, &numStationKmls, &stationKmlFilenames, &weatherModelKmzFilenames, papszOptions);
+        ninjaErr = NinjaGetRunKmzFilenames(ninjaArmy, &numRuns, &kmzFilenames, &numStationKmlsPerRun, &stationKmlFilenames, &weatherModelKmzFilenames, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
             printf("NinjaGetRunKmzFilenames: ninjaErr = %d\n", ninjaErr);
         }
 
         std::vector<std::string> kmzFilenamesStr;
-        std::vector<std::string> stationKmlFilenamesStr;
+        std::vector<std::vector<std::string>> stationKmlFilenamesStr;
         std::vector<std::string> wxModelKmzFilenamesStr;
 
         kmzFilenamesStr.reserve(numRuns);
@@ -1623,10 +1623,14 @@ void MainWindow::plotKmzOutputs()
             wxModelKmzFilenamesStr.emplace_back(weatherModelKmzFilenames[i]);
         }
 
-        stationKmlFilenamesStr.reserve(numStationKmls);
-        for(int j = 0; j < numStationKmls; j++)
+        stationKmlFilenamesStr.resize(numRuns); // have to actually size it for the later reserves and emplace_back to work correctly
+        for(int i = 0; i < numRuns; i++)
         {
-            stationKmlFilenamesStr.emplace_back(stationKmlFilenames[j]);
+            stationKmlFilenamesStr[i].reserve(numStationKmlsPerRun[i]);
+            for(int j = 0; j < numStationKmlsPerRun[i]; j++)
+            {
+                stationKmlFilenamesStr[i].emplace_back(stationKmlFilenames[i][j]);
+            }
         }
 
         outputKmzFilenames.push_back(std::move( kmzFilenamesStr ));
@@ -1653,14 +1657,12 @@ void MainWindow::plotKmzOutputs()
             QString jsCall = QString("loadKmzFromBase64('%1', '%2');").arg(base64, fileName);
             webEngineView->page()->runJavaScript(jsCall);
 
-            // if it is a point initialization run, and station kmls were created for the run,
-            // plot the station kmls of the first run
-            // (first run, because station kmls are SHARED across runs)
-            if(ui->pointInitializationGroupBox->isChecked() && ui->pointInitializationWriteStationKMLCheckBox->isChecked() && i == 0)
+            if(ui->pointInitializationGroupBox->isChecked() && ui->pointInitializationWriteStationKMLCheckBox->isChecked())
             {
-                for(int j = 0; j < numStationKmls; j++)
+                for(int j = 0; j < numStationKmlsPerRun[i]; j++)
+                //for(int j = 0; j < 1; j++)
                 {
-                    QString outFileStr = QString::fromStdString(stationKmlFilenames[j]);
+                    QString outFileStr = QString::fromStdString(stationKmlFilenames[i][j]);
                     qDebug() << "station kml outFile =" << outFileStr;
                     QFile outFile(outFileStr);
                     QFileInfo info(outFileStr);
@@ -1694,7 +1696,7 @@ void MainWindow::plotKmzOutputs()
             }
         }
 
-        ninjaErr = NinjaDestroyRunKmzFilenames(numRuns, kmzFilenames, numStationKmls, stationKmlFilenames, weatherModelKmzFilenames, papszOptions);
+        ninjaErr = NinjaDestroyRunKmzFilenames(numRuns, kmzFilenames, numStationKmlsPerRun, stationKmlFilenames, weatherModelKmzFilenames, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
             printf("NinjaDestroyRunKmzFilenames: ninjaErr = %d\n", ninjaErr);

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -147,7 +147,7 @@ private:
     void plotKmzOutputs();
 
     std::vector<std::vector<std::string>> outputKmzFilenames;
-    std::vector<std::vector<std::string>> outputStationKmlFilenames;
+    std::vector<std::vector<std::vector<std::string>>> outputStationKmlFilenames;
     std::vector<std::vector<std::string>> outputWxModelKmzFilenames;
 
     void connectSignals();

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -46,8 +46,8 @@
 #include <QFutureWatcher>
 #include <QtConcurrent/QtConcurrentRun>
 #include <QProgressDialog>
-#include <QMainWindow>
 #include <QMessageBox>
+#include <QMainWindow>
 #include <QTreeWidgetItem>
 #include <QDir>
 #include <QDirIterator>

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -147,7 +147,7 @@ private:
     void plotKmzOutputs();
 
     std::vector<std::vector<std::string>> outputKmzFilenames;
-    std::vector<std::vector<std::vector<std::string>>> outputStationKmlFilenames;
+    std::vector<std::vector<std::string>> outputStationKmlFilenames;
     std::vector<std::vector<std::string>> outputWxModelKmzFilenames;
 
     void connectSignals();

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -134,7 +134,7 @@ void PointInitializationInput::updateProgressMessage(const QString message)
         QMessageBox::critical(
             nullptr,
             QApplication::tr("Error"),
-            message
+            message+"\n"
         );
     }
 }
@@ -145,11 +145,9 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
 
     std::string msg = pszMessage;
 
-    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
-    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
-    // but now we are running into an issue where QMessageBox gets confused about how to size things,
-    // UNLESS an extra "\n" is in the text. So annoying and confusing.
-    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
+    // both the writeToConsole() function and the QProgressDialog do NOT like having a "\n" at the end of a given message,
+    // writeToConsole() adds extra empty lines all over the place and the QProgressDialog adds a weird looking space between the message and the progress bar.
+    // but ninjaCom likes to add "\n" to stuff and currently sends one "\n". So need to strip the "\n" character off of the message.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -174,16 +172,16 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended with unknown error")+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended with unknown error"));
             emit self->writeToConsoleSignal(QString::fromStdString("unknown StationFetch error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in error:\n"+clipStr)+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in error:\n"+clipStr));
             emit self->writeToConsoleSignal(QString::fromStdString("StationFetch error: "+clipStr), Qt::red);
         }
     }
@@ -196,14 +194,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in warning:\n"+clipStr)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in warning:\n"+clipStr));
         emit self->writeToConsoleSignal(QString::fromStdString("StationFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -119,18 +119,24 @@ void PointInitializationInput::weatherStationDataDownloadCancelButtonClicked()
 
 void PointInitializationInput::updateProgressMessage(const QString message)
 {
-//    QMessageBox::critical(
-//        nullptr,
-//        QApplication::tr("Error"),
-//        message
-//    );
-    progress->setLabelText(message);
-    progress->setWindowTitle(tr("Error"));
-    progress->setCancelButtonText(tr("Close"));
-    progress->setAutoClose(false);
-    progress->setAutoReset(false);
-    progress->setRange(0, 1);
-    progress->setValue(progress->maximum());
+    if(progress)
+    {
+        progress->setLabelText(message);
+        progress->setWindowTitle(tr("Error"));
+        progress->setCancelButtonText(tr("Close"));
+        progress->setAutoClose(false);
+        progress->setAutoReset(false);
+        progress->setRange(0, 1);
+        progress->setValue(progress->maximum());
+    }
+    else
+    {
+        QMessageBox::critical(
+            nullptr,
+            QApplication::tr("Error"),
+            message
+        );
+    }
 }
 
 static void comMessageHandler(const char *pszMessage, void *pUser)
@@ -138,6 +144,12 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
     PointInitializationInput *self = static_cast<PointInitializationInput*>(pUser);
 
     std::string msg = pszMessage;
+
+    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
+    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
+    // but now we are running into an issue where QMessageBox gets confused about how to size things,
+    // UNLESS an extra "\n" is in the text. So annoying and confusing.
+    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -162,16 +174,16 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended with unknown error"));
+            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended with unknown error")+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("unknown StationFetch error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in error:\n"+clipStr));
+            emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in error:\n"+clipStr)+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("StationFetch error: "+clipStr), Qt::red);
         }
     }
@@ -184,14 +196,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in warning:\n"+clipStr));
+        emit self->updateProgressMessageSignal(QString::fromStdString("StationFetch ended in warning:\n"+clipStr)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString("StationFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/pointInitializationInput.h
+++ b/src/gui/pointInitializationInput.h
@@ -39,6 +39,7 @@
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QProgressDialog>
+#include <QMessageBox>
 #include <QtConcurrent/QtConcurrent>
 #include <QFileSystemModel>
 

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -97,7 +97,7 @@ void SurfaceInput::updateProgressMessage(const QString message)
         QMessageBox::critical(
             nullptr,
             QApplication::tr("Error"),
-            message
+            message+"\n"
         );
     }
 }
@@ -108,11 +108,9 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
 
     std::string msg = pszMessage;
 
-    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
-    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
-    // but now we are running into an issue where QMessageBox gets confused about how to size things,
-    // UNLESS an extra "\n" is in the text. So annoying and confusing.
-    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
+    // both the writeToConsole() function and the QProgressDialog do NOT like having a "\n" at the end of a given message,
+    // writeToConsole() adds extra empty lines all over the place and the QProgressDialog adds a weird looking space between the message and the progress bar.
+    // but ninjaCom likes to add "\n" to stuff and currently sends one "\n". So need to strip the "\n" character off of the message.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -137,16 +135,16 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended with unknown error")+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended with unknown error"));
             emit self->writeToConsoleSignal(QString::fromStdString("unknown SurfaceFetch error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr)+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr));
             emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch error: "+clipStr), Qt::red);
         }
     }
@@ -159,14 +157,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr));
         emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -41,7 +41,7 @@ SurfaceInput::SurfaceInput(Ui::MainWindow *ui,
     ui->timeZoneDetailsTextEdit->setVisible(false);
     ui->ninjafoamCaseGroupBox->setVisible(false);
     ui->vegetationStackedWidget->setCurrentIndex(0);
-    ui->elevationInputTypeStackedWidget->setCurrentIndex(0);
+    ui->elevationInputTypeStackedWidget->setCurrentIndex(0);  // boundingBoxPage
 
     timeZoneAllZonesCheckBoxClicked();
 
@@ -104,35 +104,26 @@ void SurfaceInput::boundingBoxReceived(double north, double south, double east, 
 {
     qDebug() << "north south east west =" << QString::number(north) << QString::number(south) << QString::number(east) << QString::number(west);
 
-    ui->boundingBoxNorthLineEdit->blockSignals(true);
-    ui->boundingBoxEastLineEdit->blockSignals(true);
-    ui->boundingBoxSouthLineEdit->blockSignals(true);
-    ui->boundingBoxWestLineEdit->blockSignals(true);
+    // update information for one page OR the other, updating one triggers the signal to update the other
+    // but need to do it based off of what the current page index is at
 
-    ui->boundingBoxNorthLineEdit->setText(QString::number(north));
-    ui->boundingBoxEastLineEdit->setText(QString::number(east));
-    ui->boundingBoxSouthLineEdit->setText(QString::number(south));
-    ui->boundingBoxWestLineEdit->setText(QString::number(west));
+    if(ui->elevationInputTypeComboBox->currentIndex() == 0)  // boundingBoxPage
+    {
+        ui->boundingBoxNorthLineEdit->setText(QString::number(north));
+        ui->boundingBoxEastLineEdit->setText(QString::number(east));
+        ui->boundingBoxSouthLineEdit->setText(QString::number(south));
+        ui->boundingBoxWestLineEdit->setText(QString::number(west));
+    }
 
-    ui->boundingBoxNorthLineEdit->blockSignals(false);
-    ui->boundingBoxEastLineEdit->blockSignals(false);
-    ui->boundingBoxSouthLineEdit->blockSignals(false);
-    ui->boundingBoxWestLineEdit->blockSignals(false);
+    if(ui->elevationInputTypeComboBox->currentIndex() == 1)  // pointRadiusPage
+    {
+        double pointRadius[3];
+        computePointRadius(north, east, south, west, pointRadius);
 
-    double pointRadius[3];
-    computePointRadius(north, east, south, west, pointRadius);
-
-    ui->pointRadiusLatLineEdit->blockSignals(true);
-    ui->pointRadiusLonLineEdit->blockSignals(true);
-    ui->pointRadiusRadiusLineEdit->blockSignals(true);
-
-    ui->pointRadiusLatLineEdit->setText(QString::number(pointRadius[0]));
-    ui->pointRadiusLonLineEdit->setText(QString::number(pointRadius[1]));
-    ui->pointRadiusRadiusLineEdit->setText(QString::number(pointRadius[2]));
-
-    ui->pointRadiusLatLineEdit->blockSignals(false);
-    ui->pointRadiusLonLineEdit->blockSignals(false);
-    ui->pointRadiusRadiusLineEdit->blockSignals(false);
+        ui->pointRadiusLatLineEdit->setText(QString::number(pointRadius[0]));
+        ui->pointRadiusLonLineEdit->setText(QString::number(pointRadius[1]));
+        ui->pointRadiusRadiusLineEdit->setText(QString::number(pointRadius[2]));
+    }
 
     ui->elevationInputTypePushButton->setChecked(false);
 }
@@ -140,7 +131,7 @@ void SurfaceInput::boundingBoxReceived(double north, double south, double east, 
 
 void SurfaceInput::boundingBoxLineEditsTextChanged()
 {
-    if(ui->elevationInputTypeComboBox->currentIndex() == 0)
+    if(ui->elevationInputTypeComboBox->currentIndex() == 0)  // boundingBoxPage
     {
         bool isNorthValid, isEastValid, isSouthValid, isWestValid;
         double north = ui->boundingBoxNorthLineEdit->text().toDouble(&isNorthValid);
@@ -169,7 +160,7 @@ void SurfaceInput::boundingBoxLineEditsTextChanged()
 
 void SurfaceInput::pointRadiusLineEditsTextChanged()
 {
-    if (ui->elevationInputTypeComboBox->currentIndex() == 1)
+    if(ui->elevationInputTypeComboBox->currentIndex() == 1)  // pointRadiusPage
     {
         bool isLatValid, isLonValid, isRadiusValid;
         double lat = ui->pointRadiusLatLineEdit->text().toDouble(&isLatValid);

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -43,6 +43,10 @@ SurfaceInput::SurfaceInput(Ui::MainWindow *ui,
     ui->vegetationStackedWidget->setCurrentIndex(0);
     ui->elevationInputTypeStackedWidget->setCurrentIndex(0);  // boundingBoxPage
 
+    ui->elevationFileTypeComboBox->setItemData(0, "Partial world coverage Shuttle Radar Topography Mission data (SRTM) at 30 meter resolution.  Any existing holes in the data have been filled.", Qt::ToolTipRole);
+    ui->elevationFileTypeComboBox->setItemData(1, "World coverage Global Multi-resolution Terrain Elevation Data 2010 (GMTED2010) at 250 meter resolution.", Qt::ToolTipRole);
+    ui->elevationFileTypeComboBox->setItemData(2, "US coverage LANDFIRE 2023 Landscape data at 30 meter resolution.", Qt::ToolTipRole);
+
     timeZoneAllZonesCheckBoxClicked();
 
     connect(ui->boundingBoxNorthLineEdit, &QLineEdit::textChanged, this, &SurfaceInput::boundingBoxLineEditsTextChanged);
@@ -74,6 +78,97 @@ SurfaceInput::SurfaceInput(Ui::MainWindow *ui,
     connect(this, &SurfaceInput::updateProgressMessageSignal, this, &SurfaceInput::updateProgressMessage, Qt::QueuedConnection);
 
     connect(this, &SurfaceInput::updateState, &AppState::instance(), &AppState::updateSurfaceInputState);
+}
+
+void SurfaceInput::updateProgressMessage(const QString message)
+{
+    if(progress)
+    {
+        progress->setLabelText(message);
+        progress->setWindowTitle(tr("Error"));
+        progress->setCancelButtonText(tr("Close"));
+        progress->setAutoClose(false);
+        progress->setAutoReset(false);
+        progress->setRange(0, 1);
+        progress->setValue(progress->maximum());
+    }
+    else
+    {
+        QMessageBox::critical(
+            nullptr,
+            QApplication::tr("Error"),
+            message
+        );
+    }
+}
+
+static void comMessageHandler(const char *pszMessage, void *pUser)
+{
+    SurfaceInput *self = static_cast<SurfaceInput*>(pUser);
+
+    std::string msg = pszMessage;
+
+    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
+    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
+    // but now we are running into an issue where QMessageBox gets confused about how to size things,
+    // UNLESS an extra "\n" is in the text. So annoying and confusing.
+    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
+    if( msg.substr(msg.size()-1, 1) == "\n")
+    {
+        msg = msg.substr(0, msg.size()-1);
+    }
+
+    size_t pos;
+    size_t startPos;
+    size_t endPos;
+    std::string clipStr;
+
+    if( msg.find("Exception caught: ") != msg.npos || msg.find("ERROR: ") != msg.npos )
+    {
+        if( msg.find("Exception caught: ") != msg.npos )
+        {
+            pos = msg.find("Exception caught: ");
+            startPos = pos+18;
+        }
+        else // if( msg.find("ERROR: ") != msg.npos )
+        {
+            pos = msg.find("ERROR: ");
+            startPos = pos+7;
+        }
+        clipStr = msg.substr(startPos);
+        //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
+        if( clipStr == "Cannot determine exception type." )
+        {
+            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended with unknown error")+"\n");
+            emit self->writeToConsoleSignal(QString::fromStdString("unknown SurfaceFetch error"), Qt::red);
+        }
+        else
+        {
+            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr+"\n"));
+            emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch error: "+clipStr), Qt::red);
+        }
+    }
+    else if( msg.find("Warning: ") != msg.npos )
+    {
+        if( msg.find("Warning: ") != msg.npos )
+        {
+            pos = msg.find("Warning: ");
+            startPos = pos+9;
+        }
+        clipStr = msg.substr(startPos);
+        //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
+        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr+"\n"));
+        emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch warning: "+clipStr), QColor(255, 140, 0));
+    }
+    else
+    {
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
+        emit self->writeToConsoleSignal(QString::fromStdString(msg));
+    }
 }
 
 void SurfaceInput::meshResolutionUnitsComboBoxCurrentIndexChanged(int index)
@@ -219,11 +314,49 @@ void SurfaceInput::surfaceInputDownloadCancelButtonClicked()
 
 void SurfaceInput::surfaceInputDownloadButtonClicked()
 {
+    bool isNorthValid, isEastValid, isSouthValid, isWestValid;
+    double north = ui->boundingBoxNorthLineEdit->text().toDouble(&isNorthValid);
+    double east  = ui->boundingBoxEastLineEdit->text().toDouble(&isEastValid);
+    double south = ui->boundingBoxSouthLineEdit->text().toDouble(&isSouthValid);
+    double west  = ui->boundingBoxWestLineEdit->text().toDouble(&isWestValid);
+
+    if(!isNorthValid || !isEastValid || !isSouthValid || !isWestValid)
+    {
+        qCritical() << "ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool on the upper right corner of the map, entering a point and radius, or entering the bounding box coordinates.";
+        comMessageHandler("ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool on the upper right corner of the map, entering a point and radius, or entering the bounding box coordinates.", this);
+        return;
+    }
+
+    if(north == 0.0 || east == 0.0 || south == 0.0 || west == 0.0)
+    {
+        qCritical() << "ERROR: Please select an area on the map.";
+        comMessageHandler("ERROR: Please select an area on the map.", this);
+        return;
+    }
+
+    // need to update this logic for special cases, like wrapping around the earth
+    if(north < south || east < west)
+    {
+        qCritical() << "ERROR: North must be greater than South and East must be greater than West.";
+        comMessageHandler("ERROR: North must be greater than South and East must be greater than West.", this);
+        return;
+    }
+
+    if(ui->elevationFileTypeComboBox->currentIndex() == 0)
+    {
+        if(CPLGetConfigOption("CUSTOM_SRTM_API_KEY", NULL) == NULL && CPLGetConfigOption("NINJA_GUI_SRTM_API_KEY", NULL) == NULL)
+        {
+            qCritical() << "ERROR: API Key not specified. Please specify the environment variables NINJA_GUI_SRTM_API_KEY or CUSTOM_SRTM_API_KEY.";
+            comMessageHandler("ERROR: API Key not specified. Please specify the environment variables NINJA_GUI_SRTM_API_KEY or CUSTOM_SRTM_API_KEY.", this);
+            return;
+        }
+    }
+
     QVector<double> boundingBox = {
-        ui->boundingBoxNorthLineEdit->text().toDouble(),
-        ui->boundingBoxEastLineEdit->text().toDouble(),
-        ui->boundingBoxSouthLineEdit->text().toDouble(),
-        ui->boundingBoxWestLineEdit->text().toDouble()
+        north,
+        east,
+        south,
+        west
     };
 
     double resolution = 30;
@@ -756,97 +889,6 @@ QVector<QVector<QString>> SurfaceInput::fetchAllTimeZones(bool isShowAllTimeZone
     else
     {
         return americaData;
-    }
-}
-
-void SurfaceInput::updateProgressMessage(const QString message)
-{
-    if(progress)
-    {
-        progress->setLabelText(message);
-        progress->setWindowTitle(tr("Error"));
-        progress->setCancelButtonText(tr("Close"));
-        progress->setAutoClose(false);
-        progress->setAutoReset(false);
-        progress->setRange(0, 1);
-        progress->setValue(progress->maximum());
-    }
-    else
-    {
-        QMessageBox::critical(
-            nullptr,
-            QApplication::tr("Error"),
-            message
-        );
-    }
-}
-
-static void comMessageHandler(const char *pszMessage, void *pUser)
-{
-    SurfaceInput *self = static_cast<SurfaceInput*>(pUser);
-
-    std::string msg = pszMessage;
-
-    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
-    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
-    // but now we are running into an issue where QMessageBox gets confused about how to size things,
-    // UNLESS an extra "\n" is in the text. So annoying and confusing.
-    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
-    if( msg.substr(msg.size()-1, 1) == "\n")
-    {
-        msg = msg.substr(0, msg.size()-1);
-    }
-
-    size_t pos;
-    size_t startPos;
-    size_t endPos;
-    std::string clipStr;
-
-    if( msg.find("Exception caught: ") != msg.npos || msg.find("ERROR: ") != msg.npos )
-    {
-        if( msg.find("Exception caught: ") != msg.npos )
-        {
-            pos = msg.find("Exception caught: ");
-            startPos = pos+18;
-        }
-        else // if( msg.find("ERROR: ") != msg.npos )
-        {
-            pos = msg.find("ERROR: ");
-            startPos = pos+7;
-        }
-        clipStr = msg.substr(startPos);
-        //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
-        //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        if( clipStr == "Cannot determine exception type." )
-        {
-            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended with unknown error")+"\n");
-            emit self->writeToConsoleSignal(QString::fromStdString("unknown SurfaceFetch error"), Qt::red);
-        }
-        else
-        {
-            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr+"\n"));
-            emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch error: "+clipStr), Qt::red);
-        }
-    }
-    else if( msg.find("Warning: ") != msg.npos )
-    {
-        if( msg.find("Warning: ") != msg.npos )
-        {
-            pos = msg.find("Warning: ");
-            startPos = pos+9;
-        }
-        clipStr = msg.substr(startPos);
-        //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
-        //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr+"\n"));
-        emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch warning: "+clipStr), QColor(255, 140, 0));
-    }
-    else
-    {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
-        emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }
 

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -150,6 +150,13 @@ void SurfaceInput::boundingBoxLineEditsTextChanged()
 
         if (isNorthValid && isEastValid && isSouthValid && isWestValid)
         {
+            double pointRadius[3];
+            computePointRadius(north, east, south, west, pointRadius);
+
+            ui->pointRadiusLatLineEdit->setText(QString::number(pointRadius[0]));
+            ui->pointRadiusLonLineEdit->setText(QString::number(pointRadius[1]));
+            ui->pointRadiusRadiusLineEdit->setText(QString::number(pointRadius[2]));
+
             QString js = QString("drawBoundingBox(%1, %2, %3, %4);")
             .arg(north, 0, 'f', 10)
                 .arg(south, 0, 'f', 10)
@@ -168,11 +175,17 @@ void SurfaceInput::pointRadiusLineEditsTextChanged()
         double lat = ui->pointRadiusLatLineEdit->text().toDouble(&isLatValid);
         double lon = ui->pointRadiusLonLineEdit->text().toDouble(&isLonValid);
         double radius = ui->pointRadiusRadiusLineEdit->text().toDouble(&isRadiusValid);
-        double boundingBox[4];
 
         if(isLatValid && isLonValid && isRadiusValid)
         {
+            double boundingBox[4];
             computeBoundingBox(lat, lon, radius, boundingBox);
+
+            ui->boundingBoxNorthLineEdit->setText(QString::number(boundingBox[0]));
+            ui->boundingBoxEastLineEdit->setText(QString::number(boundingBox[1]));
+            ui->boundingBoxSouthLineEdit->setText(QString::number(boundingBox[2]));
+            ui->boundingBoxWestLineEdit->setText(QString::number(boundingBox[3]));
+
             QString js = QString("drawBoundingBox(%1, %2, %3, %4);")
                              .arg(boundingBox[0], 0, 'f', 10)
                              .arg(boundingBox[2], 0, 'f', 10)

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -128,7 +128,6 @@ void SurfaceInput::boundingBoxReceived(double north, double south, double east, 
     ui->elevationInputTypePushButton->setChecked(false);
 }
 
-
 void SurfaceInput::boundingBoxLineEditsTextChanged()
 {
     if(ui->elevationInputTypeComboBox->currentIndex() == 0)  // boundingBoxPage
@@ -401,7 +400,7 @@ void SurfaceInput::ninjafoamCaseButtonClicked()
     ui->ninjafoamCaseLineEdit->setProperty("fullpath", ninjafoamDir);
 
     ui->elevationInputFileLineEdit->setProperty("fullpath", demFilePath);
-    ui->elevationInputFileLineEdit->setText(QFileInfo(demFilePath).fileName());
+    elevationInputFileLineEditSetTextAndForceSignal(QFileInfo(demFilePath).fileName());
     ui->elevationInputFileLineEdit->setToolTip(demFilePath);
 
     ui->elevationInputFileDownloadButton->setEnabled(false);
@@ -449,7 +448,7 @@ void SurfaceInput::elevationInputFileOpenButtonClicked()
         if(!ui->elevationInputFileLineEdit->property("fullpath").toString().isEmpty())
         {
             ui->elevationInputFileLineEdit->setProperty("fullpath", ui->elevationInputFileLineEdit->property("fullpath").toString());
-            ui->elevationInputFileLineEdit->setText(QFileInfo(ui->elevationInputFileLineEdit->property("fullpath").toString()).fileName());
+            elevationInputFileLineEditSetTextAndForceSignal(QFileInfo(ui->elevationInputFileLineEdit->property("fullpath").toString()).fileName());
             ui->elevationInputFileLineEdit->setToolTip(ui->elevationInputFileLineEdit->property("fullpath").toString());
         }
         return;
@@ -477,7 +476,7 @@ void SurfaceInput::elevationInputFileOpenButtonClicked()
     }
 
     ui->elevationInputFileLineEdit->setProperty("fullpath", demFilePath);
-    ui->elevationInputFileLineEdit->setText(QFileInfo(demFilePath).fileName());
+    elevationInputFileLineEditSetTextAndForceSignal(QFileInfo(demFilePath).fileName());
     ui->elevationInputFileLineEdit->setToolTip(demFilePath);
 }
 
@@ -535,7 +534,7 @@ void SurfaceInput::fetchDEMFinished()
             if(retVal == true)
             {
                 ui->elevationInputFileLineEdit->setProperty("fullpath", pendingDownloadDemFilePath);
-                ui->elevationInputFileLineEdit->setText(QFileInfo(pendingDownloadDemFilePath).fileName());
+                elevationInputFileLineEditSetTextAndForceSignal(QFileInfo(pendingDownloadDemFilePath).fileName());
                 ui->elevationInputFileLineEdit->setToolTip(pendingDownloadDemFilePath);
                 ui->inputsStackedWidget->setCurrentIndex(3);
             }
@@ -1192,6 +1191,21 @@ bool SurfaceInput::loadDemMetadata(const QString demFilePath)
     emit writeToConsoleSignal("Metadata loaded from dem file successfully.", Qt::darkGreen);
 
     return true;
+}
+
+void SurfaceInput::elevationInputFileLineEditSetTextAndForceSignal(const QString &demFilePath)
+{
+    bool isTextSame = false;
+    if(ui->elevationInputFileLineEdit->text() == demFilePath)
+    {
+        isTextSame = true;
+    }
+
+    ui->elevationInputFileLineEdit->setText(demFilePath);
+    if(isTextSame == true)
+    {
+        emit elevationInputFileLineEditTextChanged(demFilePath);
+    }
 }
 
 double SurfaceInput::computeMeshResolution(int index, bool isMomemtumChecked)

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -146,7 +146,7 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr+"\n"));
+            emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in error:\n"+clipStr)+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch error: "+clipStr), Qt::red);
         }
     }
@@ -159,9 +159,9 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr+"\n"));
+        emit self->updateProgressMessageSignal(QString::fromStdString("SurfaceFetch ended in warning:\n"+clipStr)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString("SurfaceFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else

--- a/src/gui/surfaceInput.h
+++ b/src/gui/surfaceInput.h
@@ -70,6 +70,7 @@ public slots:
     void elevationInputFileOpenButtonClicked();
 
 private slots:
+    void updateProgressMessage(const QString message);
     void surfaceInputDownloadCancelButtonClicked();
     void surfaceInputDownloadButtonClicked();
     void meshResolutionUnitsComboBoxCurrentIndexChanged(int index);
@@ -84,7 +85,6 @@ private slots:
     void timeZoneDetailsCheckBoxClicked();
     void timeZoneComboBoxCurrentIndexChanged(int index);
     void timeZoneAllZonesCheckBoxClicked();
-    void updateProgressMessage(const QString message);
 
 private:
     Ui::MainWindow *ui;

--- a/src/gui/surfaceInput.h
+++ b/src/gui/surfaceInput.h
@@ -107,6 +107,7 @@ private:
     bool checkAndFillDownloadedDemNoDataValues(const QString demFilePath);
     bool checkAndFillToBeOpenedDemNoDataValues(const QString demFilePath, QString& nanFilledDemFilePath);
     bool loadDemMetadata(const QString demFilePath);
+    void elevationInputFileLineEditSetTextAndForceSignal(const QString &demFilePath);
     void computeBoundingBox(double centerLat, double centerLon, double radius, double boundingBox[4]);
     void computePointRadius(double north, double east, double south, double west, double pointRadius[3]);
     void startFetchDEM(QVector<double> boundingBox, std::string demFile, double resolution, std::string fetchType);

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -129,7 +129,7 @@ void WeatherModelInput::updateProgressMessage(const QString message)
         QMessageBox::critical(
             nullptr,
             QApplication::tr("Error"),
-            message
+            message+"\n"
         );
     }
 }
@@ -140,11 +140,9 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
 
     std::string msg = pszMessage;
 
-    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
-    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
-    // but now we are running into an issue where QMessageBox gets confused about how to size things,
-    // UNLESS an extra "\n" is in the text. So annoying and confusing.
-    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
+    // both the writeToConsole() function and the QProgressDialog do NOT like having a "\n" at the end of a given message,
+    // writeToConsole() adds extra empty lines all over the place and the QProgressDialog adds a weird looking space between the message and the progress bar.
+    // but ninjaCom likes to add "\n" to stuff and currently sends one "\n". So need to strip the "\n" character off of the message.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -169,16 +167,16 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended with unknown error")+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended with unknown error"));
             emit self->writeToConsoleSignal(QString::fromStdString("unknown WeatherModelFetch error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in error:\n"+clipStr)+"\n");
+            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in error:\n"+clipStr));
             emit self->writeToConsoleSignal(QString::fromStdString("WeatherModelFetch error: "+clipStr), Qt::red);
         }
     }
@@ -191,14 +189,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in warning:\n"+clipStr)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in warning:\n"+clipStr));
         emit self->writeToConsoleSignal(QString::fromStdString("WeatherModelFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -139,6 +139,12 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
     WeatherModelInput *self = static_cast<WeatherModelInput*>(pUser);
 
     std::string msg = pszMessage;
+
+    // hrm, this was the old stuff, that was put in because ninjaCom likes to add "\n" to stuff
+    // and the writeToConsole() function does NOT like having a "\n" on the end, it adds extra empty lines all over the place
+    // but now we are running into an issue where QMessageBox gets confused about how to size things,
+    // UNLESS an extra "\n" is in the text. So annoying and confusing.
+    // hrm, this means that I actually need BOTH functionalities, strip the "\n" for writeToConsole(), add a "\n" for updateProgressMessage() stuff.
     if( msg.substr(msg.size()-1, 1) == "\n")
     {
         msg = msg.substr(0, msg.size()-1);
@@ -162,17 +168,17 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
             startPos = pos+7;
         }
         clipStr = msg.substr(startPos);
-        //std::cout << "clipStr = \"" << clipStr << "\" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
         if( clipStr == "Cannot determine exception type." )
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended with unknown error"));
+            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended with unknown error")+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("unknown WeatherModelFetch error"), Qt::red);
         }
         else
         {
-            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in error:\n"+clipStr));
+            emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in error:\n"+clipStr)+"\n");
             emit self->writeToConsoleSignal(QString::fromStdString("WeatherModelFetch error: "+clipStr), Qt::red);
         }
     }
@@ -185,14 +191,14 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         }
         clipStr = msg.substr(startPos);
         //std::cout << "clipStr = \"" << clipStr << "\"" << std::endl;
-        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr));
+        //emit self->updateProgressMessageSignal(QString::fromStdString(clipStr)+"\n");
         //emit self->writeToConsoleSignal(QString::fromStdString(clipStr));
-        emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in warning:\n"+clipStr));
+        emit self->updateProgressMessageSignal(QString::fromStdString("WeatherModelFetch ended in warning:\n"+clipStr)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString("WeatherModelFetch warning: "+clipStr), QColor(255, 140, 0));
     }
     else
     {
-        emit self->updateProgressMessageSignal(QString::fromStdString(msg));
+        emit self->updateProgressMessageSignal(QString::fromStdString(msg)+"\n");
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
 }

--- a/src/ninja/ascii_grid.cpp
+++ b/src/ninja/ascii_grid.cpp
@@ -1286,8 +1286,57 @@ void AsciiGrid<T>::clipGridInPlaceSnapToCells(double west, double east, double s
     // this means slightly bigger than the bounding box for south and west, but slightly smaller than the bounding box for north and east
     get_cellIndex(west, south, &southIdx, &westIdx);
     get_cellIndex(east, north, &northIdx, &eastIdx);
-
     //std::cout << "westIdx,eastIdx,southIdx,northIdx = " << westIdx << "," << eastIdx << "," << southIdx << "," << northIdx << std::endl;
+    //std::cout << "nRows,nCols = " << get_nRows() << "," << get_nCols() << std::endl;
+
+    double clippedWest;
+    double clippedEast;
+    double clippedSouth;
+    double clippedNorth;
+    get_cellPosition(southIdx, westIdx, &clippedWest, &clippedSouth);
+    get_cellPosition(northIdx, eastIdx, &clippedEast, &clippedNorth);
+    // get_cellPosition grabs the location PLUS 1/2 a cell size, so need to take back out that 1/2 cell size
+    clippedWest = clippedWest - (cellSize / 2.0);
+    clippedEast = clippedEast - (cellSize / 2.0);
+    clippedSouth = clippedSouth - (cellSize / 2.0);
+    clippedNorth = clippedNorth - (cellSize / 2.0);
+    //std::cout << "        west,east,south,north = " << west << "," << east << "," << south << "," << north << std::endl;
+    //std::cout << "clipped west,east,south,north = " << clippedWest << "," << clippedEast << "," << clippedSouth << "," << clippedNorth << std::endl;
+
+    // adjust the found cell size based clipping area, to always encompass the desired clipping area.
+    // so round the cell size based clipping area, to the desired clipping area.
+    // note the + or - 1/2 cell size, instead of just comparing the areas,
+    //  that acts as a rounding method, similar to int(val+0.5) is equivalent to round(val)
+    if((clippedWest - (cellSize/2.0)) > west)
+    {
+        if(westIdx-1 > 0)
+        {
+            westIdx = westIdx - 1;
+        }
+    }
+    if((clippedEast + (cellSize/2.0)) < east)
+    {
+        if(eastIdx+1 < get_nCols())
+        {
+            eastIdx = eastIdx + 1;
+        }
+    }
+    if((clippedSouth - (cellSize/2.0)) > south)
+    {
+        if(southIdx-1 > 0)
+        {
+            southIdx = southIdx - 1;
+        }
+    }
+    if((clippedNorth + (cellSize/2.0)) < north)
+    {
+        if(northIdx+1 < get_nRows())
+        {
+            northIdx = northIdx + 1;
+        }
+    }
+    //std::cout << "westIdx,eastIdx,southIdx,northIdx = " << westIdx << "," << eastIdx << "," << southIdx << "," << northIdx << std::endl;
+    //std::cout << "nRows,nCols = " << get_nRows() << "," << get_nCols() << std::endl;
 
     if ( westIdx == eastIdx && southIdx == northIdx )
     {

--- a/src/ninja/cli.cpp
+++ b/src/ninja/cli.cpp
@@ -684,7 +684,7 @@ int windNinjaCLI(int argc, char* argv[])
                     }
                     else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
                     {
-                        std::cerr << "Fetch was outside the bounds of the dataset." << std::endl;
+                        std::cerr << "Fetch was outside the bounds of the dataset. Please select new data source or new area." << std::endl;
                     }
                     else if(nDemError == SURF_FETCH_E_WARPER_ERR)
                     {
@@ -708,7 +708,7 @@ int windNinjaCLI(int argc, char* argv[])
                     }
                     else
                     {
-                        std::cerr << "Unknown error occurred during fetch." << std::endl;
+                        std::cerr << "Unknown error occurred during fetch.\nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source." << std::endl;
                     }
                     VSIUnlink(new_elev.c_str());
                     exit(1);
@@ -862,7 +862,7 @@ int windNinjaCLI(int argc, char* argv[])
                 }
                 else if(nDemError == SURF_FETCH_E_BOUNDS_ERR)
                 {
-                    std::cerr << "Fetch was outside the bounds of the dataset." << std::endl;
+                    std::cerr << "Fetch was outside the bounds of the dataset. Please select new data source or new area." << std::endl;
                 }
                 else if(nDemError == SURF_FETCH_E_WARPER_ERR)
                 {
@@ -886,7 +886,7 @@ int windNinjaCLI(int argc, char* argv[])
                 }
                 else
                 {
-                    std::cerr << "Unknown error occurred during fetch." << std::endl;
+                    std::cerr << "Unknown error occurred during fetch.\nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source." << std::endl;
                 }
                 VSIUnlink(new_elev.c_str());
                 exit(1);

--- a/src/ninja/ninja.cpp
+++ b/src/ninja/ninja.cpp
@@ -248,8 +248,6 @@ bool ninja::simulate_wind()
 
 	input.Com->ninjaCom(ninjaComClass::ninjaNone, "Reading elevation file...");
 
-//throw std::runtime_error("I WANT CHOCOLATE!!! Yum.");
-
 	readInputFile();
 	set_position();
 

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -2671,7 +2671,7 @@ std::string ninjaArmy::getOutputPath( const int nIndex, char ** papszOptions )
     return std::string("");
 }
 
-int ninjaArmy::getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::vector<std::string>>& stationKmlFilenamesStr,
+int ninjaArmy::getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::string>& stationKmlFilenamesStr,
                                    std::vector<std::string>& wxModelKmzFilenamesStr, char ** papszOptions )
 {
     kmzFilenamesStr = kmzFilenames;
@@ -2710,25 +2710,24 @@ void ninjaArmy::setCurrentRunKmzFilenames(int runNumber)
 {
     kmzFilenames[runNumber] = ninjas[runNumber]->input.kmzFile;
 
-    std::vector<std::string> currentStationKmlFilenames;
     if(ninjas[runNumber]->input.stations.size() == 0)
     {
-        currentStationKmlFilenames.push_back( "" );
+        stationKmlFilenames[runNumber] = "";
     } else
     {
         if(ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size() == 0)
         {
-            currentStationKmlFilenames.push_back( "" );
+            stationKmlFilenames[runNumber] = "";
         } else
         {
-            for(int j = 0; j < ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size(); j++)
-            {
-                std::cout << "ninjas[" << runNumber << "]->input.stations[" << runNumber << "].stationKmlNames[" << j << "] = \"" << ninjas[runNumber]->input.stations[runNumber].stationKmlNames[j] << "\"" << std::endl;
-                currentStationKmlFilenames.push_back( ninjas[runNumber]->input.stations[runNumber].stationKmlNames[j] );
-            }
+            // all these cout statements are various ways to access the given wxStation::stationKmlNames, which is SHARED across ninjas[runNumber].input.stations[runNumber]
+            // the past attempt of doing a for loop over ninjas[runNumber]->input.stations[runNumber].stationKmlNames[stationIdx] makes NO sense, it results in DUPLICATION
+            //std::cout << "ninjas[0]->input.stations[0].stationKmlNames[" << runNumber << "] = \"" << ninjas[0]->input.stations[0].stationKmlNames[runNumber] << "\"" << std::endl;
+            //std::cout << "ninjas[" << runNumber << "]->input.stations[" << runNumber << "].stationKmlNames[" << runNumber << "] = \"" << ninjas[runNumber]->input.stations[runNumber].stationKmlNames[runNumber] << "\"" << std::endl;
+            //std::cout << "wxStation::stationKmlNames[" << runNumber << "] = \"" << wxStation::stationKmlNames[runNumber] << "\"" << std::endl;
+            stationKmlFilenames[runNumber] = ninjas[runNumber]->input.stations[runNumber].stationKmlNames[runNumber];
         }
     }
-    stationKmlFilenames[runNumber] = currentStationKmlFilenames;
 
     // oh, this one is set to "!set" for non-wxModel runs, the storage of this filename always exists for each ninjas[i]
     if(ninjas[runNumber]->input.wxModelKmzFile == "!set")

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -243,6 +243,21 @@ Com->ninjaCom(ninjaComClass::ninjaNone, "running ninjaArmy::makePointArmy.");
         //The function name is a bit misleading as to what it really does.
         ninjas[i]->set_initializationMethod(WindNinjaInputs::pointInitializationFlag, matchPoints);
    }
+
+    // hrm, turns out clearing these static values out in the moment before adding new ones, didn't work across runs.
+    // The idea is that we need to always clear these static values out before adding new ones,
+    // between each download/run, or they get kept across downloads/runs.
+    //
+    // looks like the ninjas[i]->input.stations[i].stationKmlNames get set during calls to wxStation::writeKmlFile(),
+    // which is called per ninjas[i] between calls to ninjaArmy::makePointArmy() and calls to ninjaArmy::startRuns().
+    // so clearing this data needs to be done either during ninjaArmy::makePointArmy() after the ninjas have been generated,
+    // or during the cleanup of ninjas[i] within ninjaArmy::startRuns(), after the kmlFileNames have been cleaned for the given run.
+    //
+    // kind of an awkward place, but this seems to be the best spot to put it for now. Seems to be working.
+    for(unsigned int i = 0; i < ninjas.size(); i++)
+    {
+        ninjas[i]->input.stations[i].stationKmlNames.clear();
+    }
 }
 
 /**

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -564,10 +564,8 @@ bool ninjaArmy::startRuns(int numProcessors)
     }
 
     // prep a clean set of kmz output filenames, to be filled before ninjas[i] gets deleted after each run
-    // stationKmlfilenames is an exception, it is filled by appending the ninjas[0] set of station files,
-    // which are shared across runs. Appends within a single run don't mess up the ordering like they do across runs.
     kmzFilenames.resize(ninjas.size());
-    stationKmlFilenames.clear();
+    stationKmlFilenames.resize(ninjas.size());
     wxModelKmzFilenames.resize(ninjas.size());
 
     if(ninjas.size() == 1)
@@ -2669,7 +2667,7 @@ std::string ninjaArmy::getOutputPath( const int nIndex, char ** papszOptions )
     return std::string("");
 }
 
-int ninjaArmy::getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::string>& stationKmlFilenamesStr,
+int ninjaArmy::getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::vector<std::string>>& stationKmlFilenamesStr,
                                    std::vector<std::string>& wxModelKmzFilenamesStr, char ** papszOptions )
 {
     kmzFilenamesStr = kmzFilenames;
@@ -2708,28 +2706,25 @@ void ninjaArmy::setCurrentRunKmzFilenames(int runNumber)
 {
     kmzFilenames[runNumber] = ninjas[runNumber]->input.kmzFile;
 
-    // assume all the other stations across all the other stations storage, are the exact same list as that of the first station
-    // SHOULD be true, seems like the idea of the storage was to make sure each station had access to the same copy of data, so a form of SHARED storage
-    // still, it's one of the quirkiest code setups that I've seen in a while
-    if(runNumber == 0)
+    std::vector<std::string> currentStationKmlFilenames;
+    if(ninjas[runNumber]->input.stations.size() == 0)
     {
-        if(ninjas[runNumber]->input.stations.size() == 0)
+        currentStationKmlFilenames.push_back( "" );
+    } else
+    {
+        if(ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size() == 0)
         {
-            stationKmlFilenames.push_back( "" );
+            currentStationKmlFilenames.push_back( "" );
         } else
         {
-            if(ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size() == 0)
+            for(int j = 0; j < ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size(); j++)
             {
-                stationKmlFilenames.push_back( "" );
-            } else
-            {
-                for(int j = 0; j < ninjas[runNumber]->input.stations[runNumber].stationKmlNames.size(); j++)
-                {
-                    stationKmlFilenames.push_back( ninjas[runNumber]->input.stations[runNumber].stationKmlNames[j] );
-                }
+                std::cout << "ninjas[" << runNumber << "]->input.stations[" << runNumber << "].stationKmlNames[" << j << "] = \"" << ninjas[runNumber]->input.stations[runNumber].stationKmlNames[j] << "\"" << std::endl;
+                currentStationKmlFilenames.push_back( ninjas[runNumber]->input.stations[runNumber].stationKmlNames[j] );
             }
         }
     }
+    stationKmlFilenames[runNumber] = currentStationKmlFilenames;
 
     // oh, this one is set to "!set" for non-wxModel runs, the storage of this filename always exists for each ninjas[i]
     if(ninjas[runNumber]->input.wxModelKmzFile == "!set")

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -244,20 +244,9 @@ Com->ninjaCom(ninjaComClass::ninjaNone, "running ninjaArmy::makePointArmy.");
         ninjas[i]->set_initializationMethod(WindNinjaInputs::pointInitializationFlag, matchPoints);
    }
 
-    // hrm, turns out clearing these static values out in the moment before adding new ones, didn't work across runs.
-    // The idea is that we need to always clear these static values out before adding new ones,
+    // need to always clear these static values out before adding new ones,
     // between each download/run, or they get kept across downloads/runs.
-    //
-    // looks like the ninjas[i]->input.stations[i].stationKmlNames get set during calls to wxStation::writeKmlFile(),
-    // which is called per ninjas[i] between calls to ninjaArmy::makePointArmy() and calls to ninjaArmy::startRuns().
-    // so clearing this data needs to be done either during ninjaArmy::makePointArmy() after the ninjas have been generated,
-    // or during the cleanup of ninjas[i] within ninjaArmy::startRuns(), after the kmlFileNames have been cleaned for the given run.
-    //
-    // kind of an awkward place, but this seems to be the best spot to put it for now. Seems to be working.
-    for(unsigned int i = 0; i < ninjas.size(); i++)
-    {
-        ninjas[i]->input.stations[i].stationKmlNames.clear();
-    }
+    wxStation::stationKmlNames.clear();
 }
 
 /**

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -104,10 +104,6 @@ int ninjaArmy::getSize()
 
 void ninjaArmy::makeDomainAverageArmy( int nSize, bool momentumFlag )
 {
-//Com->ninjaCom(ninjaComClass::ninjaFailure, "forcing an error message in ninjaArmy::makeDomainAverageArmy.");
-//throw std::runtime_error("forcing an error message in ninjaArmy::makeDomainAverageArmy.");
-Com->ninjaCom(ninjaComClass::ninjaNone, "running ninjaArmy::makeDomainAverageArmy.");
-
     if( nSize < 1 )
     {
         Com->ninjaCom(ninjaComClass::ninjaFailure, "Invalid input numNinjas '%d' in ninjaArmy::makeDomainAverageArmy()", nSize);
@@ -144,10 +140,6 @@ void ninjaArmy::makePointArmy(std::vector<boost::posix_time::ptime> timeList,
                              string timeZone, string stationFileName,
                              string demFile, bool matchPoints, bool momentumFlag)
 {
-//Com->ninjaCom(ninjaComClass::ninjaFailure, "forcing an error message in ninjaArmy::makePointArmy.");
-//throw std::runtime_error("forcing an error message in ninjaArmy::makePointArmy.");
-Com->ninjaCom(ninjaComClass::ninjaNone, "running ninjaArmy::makePointArmy.");
-
     if( timeList.size() == 0 )
     {
         Com->ninjaCom(ninjaComClass::ninjaFailure, "Invalid 'empty' input timeList in ninjaArmy::makePointArmy()");
@@ -270,10 +262,6 @@ void ninjaArmy::makeWeatherModelArmy(std::string forecastFilename, std::string t
  */
 void ninjaArmy::makeWeatherModelArmy(std::string forecastFilename, std::string timeZone, std::vector<blt::local_date_time> times, bool momentumFlag)
 {
-//Com->ninjaCom(ninjaComClass::ninjaFailure, "forcing an error message in ninjaArmy::makeWeatherModelArmy.");
-//throw std::runtime_error("forcing an error message in ninjaArmy::makeWeatherModelArmy.");
-Com->ninjaCom(ninjaComClass::ninjaNone, "running ninjaArmy::makeWeatherModelArmy.");
-
     wxModelInitialization* model;
     
     tz = timeZone;

--- a/src/ninja/ninjaArmy.h
+++ b/src/ninja/ninjaArmy.h
@@ -1368,7 +1368,7 @@ public:
     * \param weatherModelKmzFilenames The weather model kmz filenames of each ninja, to be filled. Runs without weather model kmz file output use "" for the weather model kmz filenames.
     * \return errval Returns NINJA_SUCCESS upon success.
     */
-    int getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::vector<std::string>>& stationKmlFilenamesStr,
+    int getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::string>& stationKmlFilenamesStr,
                             std::vector<std::string>& wxModelKmzFilenamesStr, char ** papszOptions=NULL );
 
     /*-----------------------------------------------------------------------------
@@ -1379,7 +1379,7 @@ public:
     void cancelAndReset();
 
     std::vector<std::string> kmzFilenames;
-    std::vector<std::vector<std::string>> stationKmlFilenames;
+    std::vector<std::string> stationKmlFilenames;
     std::vector<std::string> wxModelKmzFilenames;
 
     GDALDatasetH hSpdMemDS; //in-memory dataset for GTiff output writer

--- a/src/ninja/ninjaArmy.h
+++ b/src/ninja/ninjaArmy.h
@@ -1364,11 +1364,11 @@ public:
     *        and the weather model filenames of each ninja if they were created for the run.
     *
     * \param kmzFilenames The output kmz filenames of each ninja, to be filled.
-    * \param stationKmlFilenames The station kml filenames SHARED across each ninja, to be filled. Runs without station kml file output use "" for the station kml filenames.
+    * \param stationKmlFilenames The station kml filenames of each ninja, to be filled. Runs without station kml file output use "" for the station kml filenames.
     * \param weatherModelKmzFilenames The weather model kmz filenames of each ninja, to be filled. Runs without weather model kmz file output use "" for the weather model kmz filenames.
     * \return errval Returns NINJA_SUCCESS upon success.
     */
-    int getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::string>& stationKmlFilenamesStr,
+    int getRunKmzFilenames( std::vector<std::string>& kmzFilenamesStr, std::vector<std::vector<std::string>>& stationKmlFilenamesStr,
                             std::vector<std::string>& wxModelKmzFilenamesStr, char ** papszOptions=NULL );
 
     /*-----------------------------------------------------------------------------
@@ -1379,7 +1379,7 @@ public:
     void cancelAndReset();
 
     std::vector<std::string> kmzFilenames;
-    std::vector<std::string> stationKmlFilenames;
+    std::vector<std::vector<std::string>> stationKmlFilenames;
     std::vector<std::string> wxModelKmzFilenames;
 
     GDALDatasetH hSpdMemDS; //in-memory dataset for GTiff output writer

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -131,7 +131,7 @@ int ninjaTools::fetchDEMBBox(double *boundsBox, const char *fileName, double res
         }
         else if(result == SURF_FETCH_E_BOUNDS_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset. Please select new data source or new area.");
         }
         else if(result == SURF_FETCH_E_WARPER_ERR)
         {
@@ -155,7 +155,7 @@ int ninjaTools::fetchDEMBBox(double *boundsBox, const char *fileName, double res
         }
         else
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.\nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source.");
         }
         delete fetcher;
         return result;
@@ -217,7 +217,7 @@ int ninjaTools::fetchDEMPoint(double * adfPoint,double *adfBuff, const char* uni
         }
         else if(result == SURF_FETCH_E_BOUNDS_ERR)
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nFetch was outside the bounds of the dataset. Please select new data source or new area.");
         }
         else if(result == SURF_FETCH_E_WARPER_ERR)
         {
@@ -241,7 +241,7 @@ int ninjaTools::fetchDEMPoint(double * adfPoint,double *adfBuff, const char* uni
         }
         else
         {
-            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.");
+            Com->ninjaCom(ninjaComClass::ninjaFailure, "Failed to download elevation data.\nUnknown error occurred during fetch.\nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source.");
         }
         delete fetcher;
         return result;

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -466,7 +466,13 @@ int ninjaTools::fetchStationFromBBox( const int* yearList, const int * monthList
         if(!success)
         {
             pointInitialization::removeBadDirectory(stationPathName);
-            throw std::runtime_error("pointInitialization::fetchStationFromBbox() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
+            if(pointInitialization::error_msg.empty() || pointInitialization::error_msg == "An Error Occured, Possibly no Data Exists for request")
+            {
+                throw std::runtime_error("pointInitialization::fetchStationFromBbox() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
+            } else
+            {
+                throw std::runtime_error(pointInitialization::error_msg);
+            }
         }
         if(locationFileFlag)
         {
@@ -534,7 +540,13 @@ int ninjaTools::fetchStationByName( const int* yearList, const int * monthList, 
         if(!success)
         {
             pointInitialization::removeBadDirectory(stationPathName);
-            throw std::runtime_error("pointInitialization::fetchStationByName() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
+            if(pointInitialization::error_msg.empty() || pointInitialization::error_msg == "An Error Occured, Possibly no Data Exists for request")
+            {
+                throw std::runtime_error("pointInitialization::fetchStationByName() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
+            } else
+            {
+                throw std::runtime_error(pointInitialization::error_msg);
+            }
         }
         if(locationFileFlag)
         {

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -466,13 +466,7 @@ int ninjaTools::fetchStationFromBBox( const int* yearList, const int * monthList
         if(!success)
         {
             pointInitialization::removeBadDirectory(stationPathName);
-            if(pointInitialization::error_msg.empty() || pointInitialization::error_msg == "An Error Occured, Possibly no Data Exists for request")
-            {
-                throw std::runtime_error("pointInitialization::fetchStationFromBbox() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
-            } else
-            {
-                throw std::runtime_error(pointInitialization::error_msg);
-            }
+            throw std::runtime_error(pointInitialization::error_msg);
         }
         if(locationFileFlag)
         {
@@ -540,13 +534,7 @@ int ninjaTools::fetchStationByName( const int* yearList, const int * monthList, 
         if(!success)
         {
             pointInitialization::removeBadDirectory(stationPathName);
-            if(pointInitialization::error_msg.empty() || pointInitialization::error_msg == "An Error Occured, Possibly no Data Exists for request")
-            {
-                throw std::runtime_error("pointInitialization::fetchStationByName() failed with unknown error.\nCould not read station File: Possibly no stations exist for request.");
-            } else
-            {
-                throw std::runtime_error(pointInitialization::error_msg);
-            }
+            throw std::runtime_error(pointInitialization::error_msg);
         }
         if(locationFileFlag)
         {

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -47,7 +47,7 @@ std::string pointInitialization::tzAbbrev; // Abbreviation of the time zone
 vector<blt::local_date_time> pointInitialization::start_and_stop_times; //Storage for the start and stop time as a local obj
 //Stores the start and stop time in local time from getTimeList so that we can name the files properly
 bool pointInitialization::enforce_limits = true; //Enfore limitations on the API ->set to false if the user provides a custom key
-std::string pointInitialization::error_msg = "An Error Occured, Possibly no Data Exists for request"; //generic error message
+std::string pointInitialization::error_msg = "An error occured, Possibly no station data exists for request."; //generic error message
 //Set to whether or not we enforce the limits of 1 year and buffer range
 extern blt::tz_database globalTimeZoneDB;
 
@@ -3178,12 +3178,12 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
                 }
                 if(write_this_station==false)
                 {
+                    CPLDebug("STATION_FETCH","%s failed to return valid data...", writeID);
                     stationChecks.push_back(write_this_station);
                     if(fCount==1)
                     {
-                        CPLDebug("STATION_FETCH","%s failed to return valid data...",writeID);
-                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sensors!";
-                        //throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
+                        error_msg="ERROR: Station: Data check failed on all stations, '"+idStream.str()+"' is missing required data/sensors!";
+                        //throw std::runtime_error(error_msg);
                         return false;
                     }
                 }
@@ -3281,12 +3281,12 @@ bool pointInitialization::fetchStationData(string URL, string timeZone, bool lat
                 }
                 if(write_this_station==false)
                 {
-                    CPLDebug("STATION_FETCH","%s failed to return valid data...",writeID);
+                    CPLDebug("STATION_FETCH","%s failed to return valid data...", writeID);
                     stationChecks.push_back(write_this_station);
                     if(fCount==1)
                     {
-                        error_msg="ERROR: Station: "+idStream.str()+" is missing required data/sensors!";
-                        //throw std::runtime_error("DATA CHECK FAILED ON ALL STATIONS!");
+                        error_msg="ERROR: Station: Data check failed on all stations, '"+idStream.str()+"' is missing required data/sensors!";
+                        //throw std::runtime_error(error_msg);
                         return false;
                     }
                 }

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -728,7 +728,6 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
     OGRDataSourceH hDS;
     hDS = OGROpen( stationLoc.c_str(), FALSE, NULL );
-
     if( hDS == NULL )
     {
         oErrorString = "Cannot open csv file: ";
@@ -776,9 +775,10 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             //check for valid latitude in degrees
             dfTempValue = poFeature->GetFieldAsDouble( 3 );
 
-            if( dfTempValue > 90.0 || dfTempValue < -90.0 ) {
-                OGRFeature::DestroyFeature( poFeature );
-                GDALClose( hDS );
+            if( dfTempValue > 90.0 || dfTempValue < -90.0 )
+            {
+                OGRFeature::DestroyFeature(poFeature);
+                GDALClose(hDS);
 
                 oErrorString = "Bad latitude in weather station csv file";
                 oErrorString += " at station: ";
@@ -792,8 +792,8 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
             if( dfTempValue < -180.0 || dfTempValue > 360.0 )
             {
-                OGRFeature::DestroyFeature( poFeature );
-                GDALClose( hDS );
+                OGRFeature::DestroyFeature(poFeature);
+                GDALClose(hDS);
 
                 oErrorString = "Bad longitude in weather station csv file";
                 oErrorString += " at station: ";
@@ -805,6 +805,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             const char *pszDatum = poFeature->GetFieldAsString( 2 );
             if( !EQUAL( pszDatum, "WGS84" ) && !EQUAL( pszDatum, "NAD83" ) && !EQUAL( pszDatum, "NAD27" ) )
             {
+                OGRFeature::DestroyFeature(poFeature);
+                GDALClose(hDS);
+
                 oErrorString = "Invalid datum: ";
                 oErrorString += poFeature->GetFieldAsString( 2 );
                 oErrorString += " at station: ";
@@ -840,6 +843,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
         else
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid coordinate system: ";
             oErrorString += poFeature->GetFieldAsString( 1 );
             oErrorString += " at station: ";
@@ -854,6 +860,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         if( dfTempValue <= 0.0 )
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid height: ";
             oErrorString += poFeature->GetFieldAsString( 5 );
             oErrorString += " at station: ";
@@ -873,6 +882,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
         else
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid units for height: ";
             oErrorString += poFeature->GetFieldAsString( 6 );
             oErrorString += " at station: ";
@@ -887,6 +899,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         if( dfTempValue < 0.0 )
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid value for speed: ";
             oErrorString += poFeature->GetFieldAsString( 7 );
             oErrorString += " at station: ";
@@ -917,6 +932,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
         else
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid units for speed: ";
             oErrorString += poFeature->GetFieldAsString( 8 );
             oErrorString += " at station: ";
@@ -930,6 +948,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         if( dfTempValue > 360.0 || dfTempValue < 0.0 )
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid value for direction: ";
             oErrorString += poFeature->GetFieldAsString( 9 );
             oErrorString += " at station: ";
@@ -961,6 +982,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
         else
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid units for temperature: ";
             oErrorString += poFeature->GetFieldAsString( 11 );
             oErrorString += " at station: ";
@@ -974,6 +998,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         if( dfTempValue > 100.0 || dfTempValue < 0.0 )
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid value for cloud cover: ";
             oErrorString += poFeature->GetFieldAsString( 12 );
             oErrorString += " at station: ";
@@ -1011,6 +1038,9 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
         else
         {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid units for influence radius: ";
             oErrorString += poFeature->GetFieldAsString( 14 );
             oErrorString += " at station: ";
@@ -1033,7 +1063,11 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         //if it's not a "WindNinja NOW" type simulation and we can't detect the datetime
         bpt::ptime noTime;
-        if(datetime != "" && oStation.datetime==noTime){
+        if(datetime != "" && oStation.datetime==noTime)
+        {
+            OGRFeature::DestroyFeature(poFeature);
+            GDALClose(hDS);
+
             oErrorString = "Invalid datetime format: ";
             oErrorString += poFeature->GetFieldAsString( 15 );
             oErrorString += " at station: ";
@@ -1043,10 +1077,10 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
         }
 
         oStations.push_back(oStation);
-        OGRFeature::DestroyFeature( poFeature );
+        OGRFeature::DestroyFeature(poFeature);
     }
 
-    GDALClose( hDS );
+    GDALClose(hDS);
 
     return oStations;
 }

--- a/src/ninja/pointInitialization.cpp
+++ b/src/ninja/pointInitialization.cpp
@@ -887,7 +887,6 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
 
         if( dfTempValue < 0.0 )
         {
-            dfTempValue=0.0;
             oErrorString = "Invalid value for speed: ";
             oErrorString += poFeature->GetFieldAsString( 7 );
             oErrorString += " at station: ";
@@ -935,7 +934,8 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += poFeature->GetFieldAsString( 9 );
             oErrorString += " at station: ";
             oErrorString += oStationName;
-            dfTempValue=0.0;
+            error_msg = oErrorString;
+            throw std::runtime_error(oErrorString);
         }
 
         oStation.direction=dfTempValue;
@@ -979,7 +979,7 @@ vector<pointInitialization::preInterpolate> pointInitialization::readDiskLine(st
             oErrorString += " at station: ";
             oErrorString += oStationName;
             error_msg = oErrorString;
-            dfTempValue=0.0; //TEMPORARY UNTIL SOLRAD IS FIXED
+            throw std::runtime_error(oErrorString);
         }
 
         oStation.cloudCover=dfTempValue;

--- a/src/ninja/windninja.cpp
+++ b/src/ninja/windninja.cpp
@@ -2570,17 +2570,16 @@ WINDNINJADLL_EXPORT NinjaErr NinjaWriteBlankWxStationFile( const char * outputSt
  * \param army An opaque handle to a valid ninjaArmy.
  * \param numRuns The number of runs that were simulated, to be filled. Also the expected size of the filled filename arrays.
  * \param kmzFilenames The ninjas[i] output kmz filenames array, as a NULL char**, to be created and filled, to be created of size numRuns.
- * \param numStationKmlsPerRun An array of the number of station kmls per each run, as a NULL int*, to be created and filled, to be created of size numRuns. Also the expected inner size of the filled stationKmlFilenames array.
- * \param stationKmlFilenames The ninjas[i] station kml filenames array, as a NULL char***, to be created and filled, to be created of size numRuns by numStationKmls[runIdx]. Runs without station kml file output use "" for the station kml filenames.
+ * \param stationKmlFilenames The ninjas[i] station kml filenames array, as a NULL char**, to be created and filled, to be created of size numRuns. Runs without station kml file output use "" for the station kml filenames.
  * \param weatherModelKmzFilenames The ninjas[i] weather model kmz filenames array, as a NULL char**, to be created and filled, to be created of size numRuns. Runs without weather model kmz file output use "" for the weather model kmz filenames.
  * \param papszOptions options
  *
  * \return NINJA_SUCCESS on success, non-zero otherwise.
  */
-WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int **numStationKmlsPerRun, char**** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions)
+WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, char*** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions)
 {
     std::vector<std::string> kmzFilenameStrings;
-    std::vector<std::vector<std::string>> stationKmlFilenameStrings;
+    std::vector<std::string> stationKmlFilenameStrings;
     std::vector<std::string> wxModelKmzFilenameStrings;
 
     if( NULL != army )
@@ -2595,66 +2594,31 @@ WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *num
         *numRuns = n;
 
         *kmzFilenames = (char **)malloc(sizeof(char *) * n);
+        *stationKmlFilenames = (char **)malloc(sizeof(char *) * n);
         *weatherModelKmzFilenames = (char **)malloc(sizeof(char *) * n);
 
         for(int i = 0; i < n; i++)
         {
             std::string kmzFilenameStr = kmzFilenameStrings[i];
+            std::string stationKmlFilenameStr = stationKmlFilenameStrings[i];
             std::string wxModelKmzFilenameStr = wxModelKmzFilenameStrings[i];
 
             char *kmzFilename = (char *)malloc(kmzFilenameStr.size() + 1);
+            char *stationKmlFilename = (char *)malloc(stationKmlFilenameStr.size() + 1);
             char *wxModelKmzFilename = (char *)malloc(wxModelKmzFilenameStr.size() + 1);
 
-            if(!kmzFilename || !wxModelKmzFilename)
+            if(!kmzFilename || !stationKmlFilename || !wxModelKmzFilename)
             {
                 return NINJA_E_BAD_ALLOC;
             }
 
             memcpy(kmzFilename, kmzFilenameStr.c_str(), kmzFilenameStr.size() + 1);
+            memcpy(stationKmlFilename, stationKmlFilenameStr.c_str(), stationKmlFilenameStr.size() + 1);
             memcpy(wxModelKmzFilename, wxModelKmzFilenameStr.c_str(), wxModelKmzFilenameStr.size() + 1);
 
             (*kmzFilenames)[i] = kmzFilename;
+            (*stationKmlFilenames)[i] = stationKmlFilename;
             (*weatherModelKmzFilenames)[i] = wxModelKmzFilename;
-        }
-
-        std::cout << "stationKmlFilenameStrings.size() = " << stationKmlFilenameStrings.size() << std::endl;
-        *numStationKmlsPerRun = (int *)malloc(sizeof(int) * n);
-        for(int i = 0; i < n; i++)
-        {
-            (*numStationKmlsPerRun)[i] = (int)stationKmlFilenameStrings[i].size();
-            std::cout << "stationKmlFilenameStrings[" << i << "].size() = " << stationKmlFilenameStrings[i].size() << std::endl;
-        }
-
-        *stationKmlFilenames = (char ***)malloc(sizeof(char **) * n);
-        for(int i = 0; i < n; i++)
-        {
-            int m = (int)stationKmlFilenameStrings[i].size();
-            std::cout << "i = " << i << ", numStationKmls = " << m << std::endl;
-
-            (*stationKmlFilenames)[i] = (char **)malloc(sizeof(char *) * m);
-
-            if(!(*stationKmlFilenames)[i])
-            {
-                return NINJA_E_BAD_ALLOC;
-            }
-
-            std::vector<std::string> stationKmlFilenameStrVec = stationKmlFilenameStrings[i];
-            for(int j = 0; j < m; j++)
-            {
-                std::string stationKmlFilenameStr = stationKmlFilenameStrVec[j];
-
-                char *stationKmlFilename = (char *)malloc(stationKmlFilenameStr.size() + 1);
-
-                if(!stationKmlFilename)
-                {
-                    return NINJA_E_BAD_ALLOC;
-                }
-
-                memcpy(stationKmlFilename, stationKmlFilenameStr.c_str(), stationKmlFilenameStr.size() + 1);
-                std::cout << "stationKmlFilename[" << j << "] = \"" << stationKmlFilename << "\"" << std::endl;
-
-                (*stationKmlFilenames)[i][j] = stationKmlFilename;
-            }
         }
 
         return NINJA_SUCCESS;
@@ -2665,7 +2629,7 @@ WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *num
     }
 }
 
-WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int* numStationKmlsPerRun, char*** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions)
+WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, char** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions)
 {
     for(int i = 0; i < numRuns; i++)
     {
@@ -2674,6 +2638,14 @@ WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmz
             if(kmzFilenames[i])
             {
                 free(kmzFilenames[i]);
+            }
+        }
+
+        if(stationKmlFilenames)
+        {
+            if(stationKmlFilenames[i])
+            {
+                free(stationKmlFilenames[i]);
             }
         }
 
@@ -2686,31 +2658,6 @@ WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmz
         }
     }
 
-    for(int i = 0; i < numRuns; i++)
-    {
-        if(numStationKmlsPerRun && stationKmlFilenames)
-        {
-            if(numStationKmlsPerRun[i])
-            {
-                for(int j = 0; j < numStationKmlsPerRun[i]; j++)
-                {
-                    if(stationKmlFilenames[i])
-                    {
-                        if(stationKmlFilenames[i][j])
-                        {
-                            free(stationKmlFilenames[i][j]);
-                        }
-                    }
-                }
-
-                if(stationKmlFilenames[i])
-                {
-                    free(stationKmlFilenames[i]);
-                }
-            }
-        }
-    }
-
     if(kmzFilenames)
     {
         free(kmzFilenames);
@@ -2718,10 +2665,6 @@ WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmz
     if(stationKmlFilenames)
     {
         free(stationKmlFilenames);
-    }
-    if(numStationKmlsPerRun)
-    {
-        free(numStationKmlsPerRun);
     }
     if(weatherModelKmzFilenames)
     {

--- a/src/ninja/windninja.cpp
+++ b/src/ninja/windninja.cpp
@@ -2570,17 +2570,17 @@ WINDNINJADLL_EXPORT NinjaErr NinjaWriteBlankWxStationFile( const char * outputSt
  * \param army An opaque handle to a valid ninjaArmy.
  * \param numRuns The number of runs that were simulated, to be filled. Also the expected size of the filled filename arrays.
  * \param kmzFilenames The ninjas[i] output kmz filenames array, as a NULL char**, to be created and filled, to be created of size numRuns.
- * \param numStationKmls The number of station kmls SHARED across each run, to be filled. Also the expected size of the filled stationKmlFilenames array.
- * \param stationKmlFilenames The ninjas[i] station kml filenames array, as a NULL char**, to be created and filled, to be created of size numStationKmls. Runs without station kml file output use "" for the station kml filenames. Each run SHARES this same list of stationkmlFilenames.
+ * \param numStationKmlsPerRun An array of the number of station kmls per each run, as a NULL int*, to be created and filled, to be created of size numRuns. Also the expected inner size of the filled stationKmlFilenames array.
+ * \param stationKmlFilenames The ninjas[i] station kml filenames array, as a NULL char***, to be created and filled, to be created of size numRuns by numStationKmls[runIdx]. Runs without station kml file output use "" for the station kml filenames.
  * \param weatherModelKmzFilenames The ninjas[i] weather model kmz filenames array, as a NULL char**, to be created and filled, to be created of size numRuns. Runs without weather model kmz file output use "" for the weather model kmz filenames.
  * \param papszOptions options
  *
  * \return NINJA_SUCCESS on success, non-zero otherwise.
  */
-WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int *numStationKmls, char*** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions)
+WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int **numStationKmlsPerRun, char**** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions)
 {
     std::vector<std::string> kmzFilenameStrings;
-    std::vector<std::string> stationKmlFilenameStrings;
+    std::vector<std::vector<std::string>> stationKmlFilenameStrings;
     std::vector<std::string> wxModelKmzFilenameStrings;
 
     if( NULL != army )
@@ -2617,25 +2617,44 @@ WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *num
             (*weatherModelKmzFilenames)[i] = wxModelKmzFilename;
         }
 
-        int m = (int)stationKmlFilenameStrings.size();
-        *numStationKmls = m;
-
-        *stationKmlFilenames = (char **)malloc(sizeof(char *) * m);
-
-        for(int j = 0; j < m; j++)
+        std::cout << "stationKmlFilenameStrings.size() = " << stationKmlFilenameStrings.size() << std::endl;
+        *numStationKmlsPerRun = (int *)malloc(sizeof(int) * n);
+        for(int i = 0; i < n; i++)
         {
-            std::string stationKmlFilenameStr = stationKmlFilenameStrings[j];
+            (*numStationKmlsPerRun)[i] = (int)stationKmlFilenameStrings[i].size();
+            std::cout << "stationKmlFilenameStrings[" << i << "].size() = " << stationKmlFilenameStrings[i].size() << std::endl;
+        }
 
-            char *stationKmlFilename = (char *)malloc(stationKmlFilenameStr.size() + 1);
+        *stationKmlFilenames = (char ***)malloc(sizeof(char **) * n);
+        for(int i = 0; i < n; i++)
+        {
+            int m = (int)stationKmlFilenameStrings[i].size();
+            std::cout << "i = " << i << ", numStationKmls = " << m << std::endl;
 
-            if(!stationKmlFilename)
+            (*stationKmlFilenames)[i] = (char **)malloc(sizeof(char *) * m);
+
+            if(!(*stationKmlFilenames)[i])
             {
                 return NINJA_E_BAD_ALLOC;
             }
 
-            memcpy(stationKmlFilename, stationKmlFilenameStr.c_str(), stationKmlFilenameStr.size() + 1);
+            std::vector<std::string> stationKmlFilenameStrVec = stationKmlFilenameStrings[i];
+            for(int j = 0; j < m; j++)
+            {
+                std::string stationKmlFilenameStr = stationKmlFilenameStrVec[j];
 
-            (*stationKmlFilenames)[j] = stationKmlFilename;
+                char *stationKmlFilename = (char *)malloc(stationKmlFilenameStr.size() + 1);
+
+                if(!stationKmlFilename)
+                {
+                    return NINJA_E_BAD_ALLOC;
+                }
+
+                memcpy(stationKmlFilename, stationKmlFilenameStr.c_str(), stationKmlFilenameStr.size() + 1);
+                std::cout << "stationKmlFilename[" << j << "] = \"" << stationKmlFilename << "\"" << std::endl;
+
+                (*stationKmlFilenames)[i][j] = stationKmlFilename;
+            }
         }
 
         return NINJA_SUCCESS;
@@ -2646,7 +2665,7 @@ WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *num
     }
 }
 
-WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int numStationKmls, char** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions)
+WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int* numStationKmlsPerRun, char*** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions)
 {
     for(int i = 0; i < numRuns; i++)
     {
@@ -2667,13 +2686,27 @@ WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmz
         }
     }
 
-    for(int j = 0; j < numStationKmls; j++)
+    for(int i = 0; i < numRuns; i++)
     {
-        if(stationKmlFilenames)
+        if(numStationKmlsPerRun && stationKmlFilenames)
         {
-            if(stationKmlFilenames[j])
+            if(numStationKmlsPerRun[i])
             {
-                free(stationKmlFilenames[j]);
+                for(int j = 0; j < numStationKmlsPerRun[i]; j++)
+                {
+                    if(stationKmlFilenames[i])
+                    {
+                        if(stationKmlFilenames[i][j])
+                        {
+                            free(stationKmlFilenames[i][j]);
+                        }
+                    }
+                }
+
+                if(stationKmlFilenames[i])
+                {
+                    free(stationKmlFilenames[i]);
+                }
             }
         }
     }
@@ -2685,6 +2718,10 @@ WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmz
     if(stationKmlFilenames)
     {
         free(stationKmlFilenames);
+    }
+    if(numStationKmlsPerRun)
+    {
+        free(numStationKmlsPerRun);
     }
     if(weatherModelKmzFilenames)
     {

--- a/src/ninja/windninja.h
+++ b/src/ninja/windninja.h
@@ -422,8 +422,8 @@ typedef int  NinjaErr;
     WINDNINJADLL_EXPORT NinjaErr NinjaCheckTimeDuration
         (NinjaToolsH* tools, int* yearList, int* monthList, int * dayList, int * minuteList, int *hourList, int listSize, char ** papszOptions);
     WINDNINJADLL_EXPORT NinjaErr NinjaWriteBlankWxStationFile( const char * outputStationFilename, char ** papszOptions );
-    WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int *numStationKmls, char*** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions);
-    WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int numStationKmls, char** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions);
+    WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int **numStationKmlsPerRun, char**** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions);
+    WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int* numStationKmlsPerRun, char*** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions);
     WINDNINJADLL_EXPORT const char* NinjaFindBinDir(char ** papszOptions);
 
 WN_C_END

--- a/src/ninja/windninja.h
+++ b/src/ninja/windninja.h
@@ -422,8 +422,8 @@ typedef int  NinjaErr;
     WINDNINJADLL_EXPORT NinjaErr NinjaCheckTimeDuration
         (NinjaToolsH* tools, int* yearList, int* monthList, int * dayList, int * minuteList, int *hourList, int listSize, char ** papszOptions);
     WINDNINJADLL_EXPORT NinjaErr NinjaWriteBlankWxStationFile( const char * outputStationFilename, char ** papszOptions );
-    WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, int **numStationKmlsPerRun, char**** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions);
-    WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, int* numStationKmlsPerRun, char*** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions);
+    WINDNINJADLL_EXPORT NinjaErr NinjaGetRunKmzFilenames(NinjaArmyH * army, int *numRuns, char*** kmzFilenames, char*** stationKmlFilenames, char*** weatherModelKmzFilenames, char ** papszOptions);
+    WINDNINJADLL_EXPORT NinjaErr NinjaDestroyRunKmzFilenames(int numRuns, char** kmzFilenames, char** stationKmlFilenames, char** weatherModelKmzFilenames, char ** papszOptions);
     WINDNINJADLL_EXPORT const char* NinjaFindBinDir(char ** papszOptions);
 
 WN_C_END

--- a/src/ninja/wxModelInitialization.cpp
+++ b/src/ninja/wxModelInitialization.cpp
@@ -1503,6 +1503,23 @@ void wxModelInitialization::writeWxModelGrids(WindNinjaInputs &input)
 {
     if(input.wxModelAsciiOutFlag==true || input.wxModelShpOutFlag==true || input.wxModelGoogOutFlag == true)
     {
+        // clip the output weather model ascii grids, to the area of the dem, plus one dem cell size.
+        // actually, it looks best to use one wxModel cell size NOT one dem cell size.
+        //
+        // technically the following wxModel ascii grids all exist, but we only use SOME of them for output:
+        //  airTempGrid_wxModel, cloudCoverGrid_wxModel, uGrid_wxModel, vGrid_wxModel, wGrid_wxModel
+        double west = input.dem.get_xllCorner();
+        double east = input.dem.get_xllCorner() + input.dem.get_xDimension();
+        double south = input.dem.get_yllCorner();
+        double north = input.dem.get_yllCorner() + input.dem.get_yDimension();
+        west = west - uGrid_wxModel.get_cellSize();
+        east = east + uGrid_wxModel.get_cellSize();
+        south = south - uGrid_wxModel.get_cellSize();
+        north = north + uGrid_wxModel.get_cellSize();
+        uGrid_wxModel.clipGridInPlaceSnapToCells( west, east, south, north );
+        vGrid_wxModel.clipGridInPlaceSnapToCells( west, east, south, north );
+        cloudCoverGrid_wxModel.clipGridInPlaceSnapToCells( west, east, south, north );
+
         speedInitializationGrid_wxModel.set_headerData(uGrid_wxModel);
         dirInitializationGrid_wxModel.set_headerData(uGrid_wxModel);
 

--- a/src/ninja/wxStation.cpp
+++ b/src/ninja/wxStation.cpp
@@ -1027,7 +1027,7 @@ void wxStation::writeKmlFile( std::vector<wxStation> stations,
     fprintf( fout, "</kml>\n" );
 
     fclose( fout );
-
+std::cout << "outFileNameStamp = \"" << outFileNameStamp.c_str() << "\"" << std::endl;
     // Need to always clear these static values out before adding new ones, between each download/run, or they get kept across downloads/runs
     // Looks like this function is only ever called a single time per run, so it works to put the clear right here in the moment right before it is filled.
     stationKmlNames.clear();

--- a/src/ninja/wxStation.cpp
+++ b/src/ninja/wxStation.cpp
@@ -1027,10 +1027,7 @@ void wxStation::writeKmlFile( std::vector<wxStation> stations,
     fprintf( fout, "</kml>\n" );
 
     fclose( fout );
-std::cout << "outFileNameStamp = \"" << outFileNameStamp.c_str() << "\"" << std::endl;
-    // Need to always clear these static values out before adding new ones, between each download/run, or they get kept across downloads/runs
-    // Looks like this function is only ever called a single time per run, so it works to put the clear right here in the moment right before it is filled.
-    stationKmlNames.clear();
+
     stationKmlNames.push_back(outFileNameStamp);
 }
 


### PR DESCRIPTION
I fixed various things in this pull request, in the following rough order:

1. updated the station file checks to properly disallow negative wind direction and negative cloud cover. Fixes #633.
2. fixed the `stationKmlFilenames` storage again, fixes #726 for real this time. Fixed the `ninjaArmy::getRunKmzFilenames()` related functions, allowing the GUI kmz output plotting to have the proper `stationKmlFilenames` for real this time.
3. various improvements to the GUI surface fetch download page including:
- making the `bbox` page update the `point radius` page, and the `point radius` page update the `bbox` page, properly for `text changes` not just `draws`.
- forcing the `elevationInputFileLineEdit->setText()` to trigger the `elevationInputFileLineEditTextChanged()` `signal` even when the `dem` has the same name as what was in the `elevationInputFileLineEdit` before. So to force the `signal` when downloading a `dem` file with the same name, or opening a `dem` file with the same name from a different folder location.
- adding checks that were missing from the old qt4 GUI, plus a few new ones that were needed for a few specific cases.
4. dropping some leftover `ninjaCom` `messages` and debugging `throws`, from back when I was still testing out `ninjaCom`.
5. changed the `wxModel` outputs, `kmz` and otherwise, to clip to the `dem` bounds plus one `wxModel` cell size. Also improved the `ascii_grid` clipping method, to more properly `round` to the desired clipping area. Fixes #752, at least for plotting the kmz files on the `map`.
6. some small cleanup to `error messages` methods and `messages`, for `station_fetch` when downloading `station data` from an area without available or valid `station data`, or when using an invalid or bogus `stationID`. Related to #749.
7. cleanup to the `ninjaCom` methods in the GUI, specifically to make the `ninjaComMessageHandler` functions be uniform in method across the various parts of the GUI code. Involved a small fix to improve how `"\n"` characters are used in the `messages`. Related to #666.