### PR TITLE
ensure shapelib is found on linux and macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,9 @@ set(WINDNINJA_VERSION_NAME WindNinja-${VER_STR})
 message(STATUS "VERSION: ${VER_STR}")
 message(STATUS "PKG VERSION: ${WINDNINJA_VERSION_NAME}")
 
+find_package(shapelib CONFIG REQUIRED)
 # Find Dependencies: VCPKG for Windows and ATP for Linux
 if(MSVC)
-    find_package(shapelib CONFIG REQUIRED)
     find_package(GDAL CONFIG REQUIRED)
     find_package(netCDF CONFIG REQUIRED)
     find_package(Boost REQUIRED COMPONENTS date_time program_options unit_test_framework)

--- a/src/ninja/CMakeLists.txt
+++ b/src/ninja/CMakeLists.txt
@@ -134,7 +134,8 @@ endif(WITH_NOMADS_SUPPORT)
 set(LINK_LIBS ${NETCDF_LIBRARIES_C} 
               ${GDAL_LIBRARY} 
               ${CURL_LIBRARIES}
-              ${Boost_LIBRARIES})
+              ${Boost_LIBRARIES}
+              shapelib::shp)
 
 
 include_directories(${NINJA_INCLUDES})
@@ -142,7 +143,7 @@ include_directories(${NINJA_INCLUDES})
 if(WIN32)
     add_library(ninja STATIC ${NINJA_SOURCES})
     add_library(WindNinjadll SHARED ${NINJA_SOURCES})
-    target_link_libraries(WindNinjadll  PRIVATE shapelib::shp GDAL::GDAL ${LINK_LIBS})
+    target_link_libraries(WindNinjadll PRIVATE GDAL::GDAL ${LINK_LIBS})
     target_compile_definitions(WindNinjadll
         PUBLIC 
             WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
This ensure that shapelib is found on macos and linux. Without there are a bunch of link time errors:
```
src/ninja/./libninja.so: undefined reference to DBFOpen'
ninja/./libninja.so: undefined reference to DBFWriteIntegerAttribute'
[snip]
```