### PR TITLE
fix #763: ensure bands are explicitly allocated for warp, tidy

### DIFF
--- a/src/ninja/genericSurfInitialization.cpp
+++ b/src/ninja/genericSurfInitialization.cpp
@@ -426,26 +426,66 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
             dfNoData = -9999.0;
         }
 
-        // Setup warp options
+        // Setup warp options.
+        // Only warp the requested forecast-time band.
         psWarpOptions = GDALCreateWarpOptions();
 
-        psWarpOptions->nBandCount = nBandCount;
-
-        psWarpOptions->padfDstNoDataReal =
-            (double*) CPLMalloc( sizeof( double ) * nBandCount );
-        psWarpOptions->padfDstNoDataImag =
-            (double*) CPLMalloc( sizeof( double ) * nBandCount );
-
-        for( int b = 0;b < srcDS->GetRasterCount();b++ ) {
-            psWarpOptions->padfDstNoDataReal[b] = dfNoData;
-            psWarpOptions->padfDstNoDataImag[b] = dfNoData;
-        }
-
-        psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", "NO_DATA");
-        if(pbSuccess == false)  // if GDALGetRasterNoDataValue() fails to return that a NO_DATA value is in the source dataset
+        if( nBandCount <= 0 )
         {
-            psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions, "INIT_DEST", boost::lexical_cast<std::string>(dfNoData).c_str());
+            GDALClose((GDALDatasetH) srcDS);
+            GDALDestroyWarpOptions(psWarpOptions);
+            throw std::runtime_error("Forecast variable has zero raster bands.");
         }
+
+        if( bandNum < 1 || bandNum > nBandCount )
+        {
+            GDALClose((GDALDatasetH) srcDS);
+            GDALDestroyWarpOptions(psWarpOptions);
+            throw std::runtime_error("Requested forecast band is outside raster band range.");
+        }
+
+        if( pbSuccess == false || std::isnan(dfNoData) )
+        {
+            dfNoData = -9999.0;
+        }
+
+        psWarpOptions->nBandCount = 1;
+
+        psWarpOptions->panSrcBands =
+            (int*) CPLMalloc( sizeof( int ) );
+        psWarpOptions->panDstBands =
+            (int*) CPLMalloc( sizeof( int ) );
+
+        psWarpOptions->panSrcBands[0] = bandNum;
+        psWarpOptions->panDstBands[0] = 1;
+
+        psWarpOptions->padfSrcNoDataReal =
+            (double*) CPLMalloc( sizeof( double ) );
+        psWarpOptions->padfSrcNoDataImag =
+            (double*) CPLMalloc( sizeof( double ) );
+        psWarpOptions->padfDstNoDataReal =
+            (double*) CPLMalloc( sizeof( double ) );
+        psWarpOptions->padfDstNoDataImag =
+            (double*) CPLMalloc( sizeof( double ) );
+
+        psWarpOptions->padfSrcNoDataReal[0] = dfNoData;
+        psWarpOptions->padfSrcNoDataImag[0] = 0.0;
+        psWarpOptions->padfDstNoDataReal[0] = dfNoData;
+        psWarpOptions->padfDstNoDataImag[0] = 0.0;
+
+        psWarpOptions->papszWarpOptions =
+            CSLSetNameValue(
+                psWarpOptions->papszWarpOptions,
+                "INIT_DEST",
+                boost::lexical_cast<std::string>(dfNoData).c_str()
+            );
+
+        psWarpOptions->papszWarpOptions =
+            CSLSetNameValue(
+                psWarpOptions->papszWarpOptions,
+                "SKIP_NOSOURCE",
+                "NO"
+            );
 
         // compute the coordinateTransformationAngle, the angle between the y coordinate grid lines of the pre-warped and warped datasets,
         // going FROM the y coordinate grid line of the pre-warped dataset TO the y coordinate grid line of the warped dataset
@@ -472,28 +512,28 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
         }
 
         if( varList[i] == "Temperature_height_above_ground" ) {
-            GDAL2AsciiGrid( wrpDS, bandNum, airGrid );
+            GDAL2AsciiGrid( wrpDS, 1, airGrid );
         if( std::isnan( dfNoData ) ) {
         airGrid.set_noDataValue(-9999.0);
         airGrid.replaceNan( -9999.0 );
         }
     }
         else if( varList[i] == "V-component_of_wind_height_above_ground" ) {
-            GDAL2AsciiGrid( wrpDS, bandNum, vGrid );
+            GDAL2AsciiGrid( wrpDS, 1, vGrid );
         if( std::isnan( dfNoData ) ) {
         vGrid.set_noDataValue(-9999.0);
         vGrid.replaceNan( -9999.0 );
         }
     }
         else if( varList[i] == "U-component_of_wind_height_above_ground" ) {
-            GDAL2AsciiGrid( wrpDS, bandNum, uGrid );
+            GDAL2AsciiGrid( wrpDS, 1, uGrid );
         if( std::isnan( dfNoData ) ) {
         uGrid.set_noDataValue(-9999.0);
         uGrid.replaceNan( -9999.0 );
         }
     }
         else if( varList[i] == "Total_cloud_cover" ) {
-            GDAL2AsciiGrid( wrpDS, bandNum, cloudGrid );
+            GDAL2AsciiGrid( wrpDS, 1, cloudGrid );
         if( std::isnan( dfNoData ) ) {
         cloudGrid.set_noDataValue(-9999.0);
         cloudGrid.replaceNan( -9999.0 );
@@ -501,8 +541,8 @@ void genericSurfInitialization::setSurfaceGrids( WindNinjaInputs &input,
     }
 
         GDALDestroyWarpOptions( psWarpOptions );
-        GDALClose((GDALDatasetH) srcDS );
         GDALClose((GDALDatasetH) wrpDS );
+        GDALClose((GDALDatasetH) srcDS );
     }
     cloudGrid /= 100.0;
 


### PR DESCRIPTION
This fixes issues #763. 

This PR code was partially in conjunction with codex to try to sus out exactly what of this structure needs to be allocated in new GDALs to avoid the segfault.

This ensures that the bands are explicitly allocated as per the docs (only when band=0 does gdal guess and allocate). The docs and gpt suggest that: GDAL only auto-populates panSrcBands / panDstBands when nBandCount == 0. If nBandCount is nonzero, the band mapping arrays must be populated explicitly.

Once the memory is explicitly allocated and the bands are put in the right place, the memory consistency is correct.