### PR TITLE
Removed GUI test cases from GUI, cleaned up the C-API autotest scripts

### DIFF
--- a/autotest/api/test_capi_domain_average_wind.c
+++ b/autotest/api/test_capi_domain_average_wind.c
@@ -27,9 +27,32 @@
  *
  *****************************************************************************/
 #include "windninja.h"
-#include <stdio.h> //for printf
+#include <stdio.h> //for printf, FILE, fopen, fclose
+#include <stdlib.h> //for malloc, free
+#include <string.h> //for strcat, strlen, used in concat() function
 #include <stdbool.h>
 
+// used for combining const char* "strings"
+// returns a newly allocated char* that the function caller must free().
+char* concat(const char *s1, const char *s2)
+{
+    if(s1 == NULL || s2 == NULL)
+    {
+        printf("an input to concat() is NULL\n");
+        return NULL;
+    }
+
+    char *result = malloc(strlen(s1) + strlen(s2) + 1); // +1 for the null-terminator
+    if (result == NULL)
+    {
+        printf("concat() failed (out of memory)\n");
+        return NULL;
+    }
+
+    strcpy(result, s1);
+    strcat(result, s2);
+    return result;
+}
 
 
 int main()
@@ -48,21 +71,35 @@ int main()
         printf("NinjaInit: err = %d\n", err);
     }
 
+    // manually set your wnDataPath (makes it easier for setting paths and testing)
+    // must replace the "~/" part with your exact path
+    //const char* wnDataPath = "~/src/wind/windninja/data";
+    const char* wnDataPath = "/home/atw09001/src/wind/windninja/data";
+
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
+    char* multiStreamFilename = concat(wnDataPath, "/../autotest/api/data/ninja.log");
+    if(multiStreamFilename == NULL)
+    {
+        printf("concat failed\n");
+        return 1;
+    }
+
     FILE* multiStream = NULL;
-    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
+        //free(multiStreamFilename);
         printf("error opening log file\n");
+        //return 1;
     }
 
     /*
      * Set up domain average run
      */
     /* inputs that do not vary among ninjas in an army */
-    const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    char * demFile = concat(wnDataPath, "/../autotest/api/data/missoula_valley.tif");
     const char * initializationMethod = "domain_average";
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
@@ -82,7 +119,7 @@ int main()
     const char * units = "m";
     const double width = 1.0;
     const char * scaling = "equal_color";
-    const char * outputPath  = "/home/atw09001/src/wind/windninja/autotest/api/data/output";
+    char * outputPath  = concat(wnDataPath, "/../autotest/api/data/output");
     const bool outputFlag = 1;
 
     /* inputs that can vary among ninjas in an army */
@@ -278,6 +315,10 @@ int main()
     {
         printf("NinjaFinalize: err = %d\n", err);
     }
+
+    free(outputPath);
+    free(demFile);
+    free(multiStreamFilename);
 
     return NINJA_SUCCESS;
 }

--- a/autotest/api/test_capi_domain_average_wind.c
+++ b/autotest/api/test_capi_domain_average_wind.c
@@ -29,7 +29,7 @@
 #include "windninja.h"
 #include <stdio.h> //for printf, FILE, fopen, fclose
 #include <stdlib.h> //for malloc, free
-#include <string.h> //for strcat, strlen, used in concat() function
+#include <string.h> //for strlen, memcpy, used in concat() function
 #include <stdbool.h>
 
 // used for combining const char* "strings"
@@ -42,15 +42,18 @@ char* concat(const char *s1, const char *s2)
         return NULL;
     }
 
-    char *result = malloc(strlen(s1) + strlen(s2) + 1); // +1 for the null-terminator
-    if (result == NULL)
+    size_t len1 = strlen(s1);
+    size_t len2 = strlen(s2);
+    char *result = malloc(len1 + len2 + 1); // +1 for '\0', the null-terminator
+    if(result == NULL)
     {
         printf("concat() failed (out of memory)\n");
         return NULL;
     }
 
-    strcpy(result, s1);
-    strcat(result, s2);
+    memcpy(result, s1, len1);
+    memcpy(result + len1, s2, len2 + 1);  // includes '\0', the null-terminator
+
     return result;
 }
 

--- a/autotest/api/test_capi_domain_average_wind.c
+++ b/autotest/api/test_capi_domain_average_wind.c
@@ -28,34 +28,9 @@
  *****************************************************************************/
 #include "windninja.h"
 #include <stdio.h> //for printf, FILE, fopen, fclose
-#include <stdlib.h> //for malloc, free
-#include <string.h> //for strlen, memcpy, used in concat() function
 #include <stdbool.h>
 
-// used for combining const char* "strings"
-// returns a newly allocated char* that the function caller must free().
-char* concat(const char *s1, const char *s2)
-{
-    if(s1 == NULL || s2 == NULL)
-    {
-        printf("an input to concat() is NULL\n");
-        return NULL;
-    }
-
-    size_t len1 = strlen(s1);
-    size_t len2 = strlen(s2);
-    char *result = malloc(len1 + len2 + 1); // +1 for '\0', the null-terminator
-    if(result == NULL)
-    {
-        printf("concat() failed (out of memory)\n");
-        return NULL;
-    }
-
-    memcpy(result, s1, len1);
-    memcpy(result + len1, s2, len2 + 1);  // includes '\0', the null-terminator
-
-    return result;
-}
+#define MAX_PATH_LEN 512
 
 
 int main()
@@ -82,27 +57,20 @@ int main()
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
-    char* multiStreamFilename = concat(wnDataPath, "/../autotest/api/data/ninja.log");
-    if(multiStreamFilename == NULL)
-    {
-        printf("concat failed\n");
-        return 1;
-    }
-
-    FILE* multiStream = NULL;
-    multiStream = fopen(multiStreamFilename, "w+");
+    char multiStreamFilename[MAX_PATH_LEN];
+    snprintf(multiStreamFilename, sizeof(multiStreamFilename), "%s%s", wnDataPath, "/../autotest/api/data/ninja.log");
+    FILE* multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
-        //free(multiStreamFilename);
         printf("error opening log file\n");
-        //return 1;
     }
 
     /*
      * Set up domain average run
      */
     /* inputs that do not vary among ninjas in an army */
-    char * demFile = concat(wnDataPath, "/../autotest/api/data/missoula_valley.tif");
+    char demFile[MAX_PATH_LEN];
+    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
     const char * initializationMethod = "domain_average";
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
@@ -122,7 +90,8 @@ int main()
     const char * units = "m";
     const double width = 1.0;
     const char * scaling = "equal_color";
-    char * outputPath  = concat(wnDataPath, "/../autotest/api/data/output");
+    char outputPath[MAX_PATH_LEN];
+    snprintf(outputPath, sizeof(outputPath), "%s%s", wnDataPath, "/../autotest/api/data/output");
     const bool outputFlag = 1;
 
     /* inputs that can vary among ninjas in an army */
@@ -318,10 +287,6 @@ int main()
     {
         printf("NinjaFinalize: err = %d\n", err);
     }
-
-    free(outputPath);
-    free(demFile);
-    free(multiStreamFilename);
 
     return NINJA_SUCCESS;
 }

--- a/autotest/api/test_capi_domain_average_wind.c
+++ b/autotest/api/test_capi_domain_average_wind.c
@@ -34,10 +34,10 @@
 
 int main()
 {
-    /* 
+    /*
      * Setting up the simulation
      */
-    NinjaArmyH* ninjaArmy = NULL; 
+    NinjaArmyH* ninjaArmy = NULL;
     const int nCPUs = 3;
     const char * runType = "C-API autotest";
     char ** papszOptions = NULL;
@@ -58,8 +58,8 @@ int main()
         printf("error opening log file\n");
     }
 
-    /* 
-     * Set up domain average run 
+    /*
+     * Set up domain average run
      */
     /* inputs that do not vary among ninjas in an army */
     const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
@@ -67,14 +67,15 @@ int main()
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
     const int nLayers = 20; //layers in the mesh
-    const int diurnalFlag = 1; //diurnal slope wind parameterization not used
+    const int diurnalFlag = 1; //set to 1 to use the diurnal slope wind parameterization inputs
+    const int stabilityFlag = 0; //set to 1 to use the stability wind parameterization inputs. NOT to be used with a momentum solver run.
     const double height = 10.0;
     const char * heightUnits = "m";
     //bool momentumFlag = 0; //we're using the conservation of mass solver
     bool momentumFlag = 1; //we're using the conservation of momentum solver
     unsigned int numNinjas = 2; //two ninjas in the ninjaArmy - must be equal to array sizes
 
-    /* inputs specific to output 
+    /* inputs specific to output
      * Note: Outputs have default values if inputs are not specified (like resolution)
      */
     const double outputResolution = 100.0;
@@ -88,6 +89,8 @@ int main()
     const double speedList[] = {5.5, 5.5}; // matches the size of numNinjas
     const char * speedUnits = "mps";
     const double directionList[2] = {220.0, 300.0};
+
+    // thermal parameterization inputs (diurnal and stability)
     const int year[2] = {2023, 2023};
     const int month[2] = {10, 11};
     const int day[2] = {10, 11};
@@ -127,20 +130,27 @@ int main()
     }
 
     /*
-     * Create the army
+     * Make the army
      */
-    err = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speedList, speedUnits, directionList, year, month, day, hour, minute, timezone, air, airUnits, cloud, cloudUnits, papszOptions);
-    if( err != NINJA_SUCCESS)
+    if(diurnalFlag == 1 || stabilityFlag == 1)
+    {
+        err = NinjaMakeDomainAverageArmyThermalParameterization(ninjaArmy, numNinjas, momentumFlag, speedList, speedUnits, directionList, year, month, day, hour, minute, timezone, air, airUnits, cloud, cloudUnits, papszOptions);
+    }
+    else
+    {
+        err = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speedList, speedUnits, directionList, papszOptions);
+    }
+    if(err != NINJA_SUCCESS)
     {
         printf("NinjaMakeDomainAverageArmy: err = %d\n", err);
     }
 
-    /* 
+    /*
      * Prepare the army
      */
     for(unsigned int i=0; i<numNinjas; i++)
     {
-      /* 
+      /*
        * Sets Simulation Variables
        */
       err = NinjaSetNumberCPUs(ninjaArmy, i, nCPUs, papszOptions);
@@ -190,7 +200,13 @@ int main()
       {
         printf("NinjaSetDiurnalWinds: err = %d\n", err);
       }
-    
+
+      err = NinjaSetStabilityFlag(ninjaArmy, i, stabilityFlag, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+        printf("NinjaSetStabilityFlag: err = %d\n", err);
+      }
+
       err = NinjaSetUniVegetation(ninjaArmy, i, vegetation, papszOptions);
       if(err != NINJA_SUCCESS)
       {
@@ -230,7 +246,7 @@ int main()
       }
     }
 
-    /* 
+    /*
      * Start the simulations
      */
     err = NinjaStartRuns(ninjaArmy, nCPUs, papszOptions);
@@ -239,7 +255,7 @@ int main()
         printf("NinjaStartRuns: err = %d\n", err);
     }
     
-    /* 
+    /*
      * Clean up
      */
     err = NinjaDestroyArmy(ninjaArmy, papszOptions);
@@ -254,6 +270,13 @@ int main()
         {
             printf("error closing log file\n");
         }
+    }
+
+    // must be called to cleanup ninjaInit();
+    err = NinjaFinalize(papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFinalize: err = %d\n", err);
     }
 
     return NINJA_SUCCESS;

--- a/autotest/api/test_capi_domain_average_wind.c
+++ b/autotest/api/test_capi_domain_average_wind.c
@@ -32,7 +32,6 @@
 
 #define MAX_PATH_LEN 512
 
-
 int main()
 {
     /*
@@ -51,8 +50,7 @@ int main()
 
     // manually set your wnDataPath (makes it easier for setting paths and testing)
     // must replace the "~/" part with your exact path
-    //const char* wnDataPath = "~/src/wind/windninja/data";
-    const char* wnDataPath = "/home/atw09001/src/wind/windninja/data";
+    const char* wnDataPath = "~/src/wind/windninja/data";
 
     /*
      * Setting up a log file, for ninjaCom, if desired

--- a/autotest/api/test_capi_fetching.c
+++ b/autotest/api/test_capi_fetching.c
@@ -83,6 +83,7 @@ int main()
 
     /*
      * Testing fetching from a DEM bounding box
+     * TODO: implement nan filling of the result, if needed.
      */
     char demFileBBox[MAX_PATH_LEN];
     snprintf(demFileBBox, sizeof(demFileBBox), "%s%s", wnDataPath, "/../autotest/api/data/fetch/DEMBBox.tif"); // output file name
@@ -141,14 +142,38 @@ int main()
     }
 
     /*
+     * Testing fetching for a Pastcast file
+     */
+    const char* wx_model_type_pastcast = "PASTCAST-GCP-HRRR-CONUS-3-KM";
+    const char* osTimeZone_pastcast = "UTC";
+    int startYear = 2024;
+    int startMonth = 2;
+    int startDay = 2;  // UTC time
+    int startHour = 2;  // UTC time
+    int endYear = 2024;
+    int endMonth = 2;
+    int endDay = 2;  // UTC time
+    int endHour = 2;  // UTC time
+    err = NinjaFetchArchiveWeatherData(ninjaTools, wx_model_type_pastcast, demFileForecast, osTimeZone_pastcast, startYear, startMonth, startDay, startHour, endYear, endMonth, endDay, endHour);//, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFetchArchiveWeatherData: err = %d\n", err);
+    } else
+    {
+        printf("NinjaFetchArchiveWeatherData: success\n");
+    }
+
+    /*
      * Testing fetching station data from a geotiff file.
      */
+    // always lists of size 2 for these methods
+    // if doing a latestTime fetch, the fetch just ignores the later times in the list
+    int size = 2;
     int year[2] = {2024, 2024};
     int month[2] = {2, 2};
-    int day[2] = {2, 2};
-    int hour[2] = {2, 2};
+    int day[2] = {2, 2};  // UTC time
+    int hour[2] = {2, 2};  // UTC time
     int minute[2] = {2, 2};
-    int size = 2;
     char output_path[MAX_PATH_LEN];
     char elevation_file[MAX_PATH_LEN];
     snprintf(output_path, sizeof(output_path), "%s%s", wnDataPath, "/../autotest/api/data/fetch/");
@@ -169,7 +194,54 @@ int main()
     }
 
     /*
+     * Testing fetching station data from a list of station IDs.
+     * use the helper functions to generate the desired list of times for this fetching method
+     * so convert from local time to UTC time
+     *
+     * hrm, I like that it comes out with the same times as above
+     * but I DON'T like that the filenames come out different, for UTC vs local time. a future TODO in sorting this out.
+     */
+    // always lists of size 2 for these methods
+    // if doing a latestTime fetch, the fetch just ignores the later times in the list
+    const char* stationIds = "KMSO,BLMM8,PNTM8,FINM8";
+    ////const char* osTimeZone_fromId = "UTC";
+    const char* osTimeZone_fromId = "America/Denver";
+    //int inSize = 2;
+    int inYear[2] = {2024, 2024};
+    int inMonth[2] = {2, 2};
+    int inDay[2] = {1, 1};  // local time
+    int inHour[2] = {19, 19};  // local time, 7 hrs earlier
+    //int inDay[2] = {2, 2};  // UTC time
+    //int inHour[2] = {2, 2};  // UTC time
+    int inMinute[2] = {2, 2};
+    int outSize = 2;
+    // make sure the outputs have the same size as outSize.
+    int outYear[2], outMonth[2], outDay[2], outHour[2], outMinute[2];
+    err = NinjaGetTimeList(ninjaTools, inYear, inMonth, inDay, inHour, inMinute, outYear, outMonth, outDay, outHour, outMinute, outSize, osTimeZone_fromId);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaGetTimeList: err = %d\n", err);
+    }
+    if(fetchLatestFlag == 0)
+    {
+        err = NinjaCheckTimeDuration(ninjaTools, outYear, outMonth, outDay, outHour, outMinute, outSize, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+            printf("NinjaCheckTimeDuration: err = %d\n", err);
+        }
+    }
+    err = NinjaFetchStationByName(ninjaTools, outYear, outMonth, outDay, outHour, outMinute, outSize, elevation_file, stationIds, osTimeZone_fromId, fetchLatestFlag, output_path, locationFileFlag, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFetchStationByName: err = %d\n", err);
+    } else
+    {
+        printf("NinjaFetchStationByName: success\n");
+    }
+
+    /*
      * Testing fetching from a DEM point
+     * TODO: implement nan filling of the result, if needed.
      */
     double adfPoint[] = {-104.0, 40.07}; // Point coordinates (longitude, latitude)
     double adfBuff[] = {1.5, 1.5}; // Buffer to store the elevation value

--- a/autotest/api/test_capi_fetching.c
+++ b/autotest/api/test_capi_fetching.c
@@ -27,9 +27,10 @@
  *
  *****************************************************************************/
 #include "windninja.h"
-#include <stdio.h> //for printf and strcmp
-#include <string.h>
+#include <stdio.h> //for printf, FILE, fopen, fclose
 #include <stdbool.h>
+
+#define MAX_PATH_LEN 512
 
 /*TODO: 
  * Implement exhaustive tests for all wx_model_types for NinjaFetchForecast
@@ -51,11 +52,16 @@ int main()
         printf("NinjaInit: err = %d\n", err);
     }
 
+    // manually set your wnDataPath (makes it easier for setting paths and testing)
+    // must replace the "~/" part with your exact path
+    const char* wnDataPath = "~/src/wind/windninja/data";
+
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
-    FILE* multiStream = NULL;
-    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    char multiStreamFilename[MAX_PATH_LEN];
+    snprintf(multiStreamFilename, sizeof(multiStreamFilename), "%s%s", wnDataPath, "/../autotest/api/data/ninja.log");
+    FILE* multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
         printf("error opening log file\n");
@@ -78,7 +84,8 @@ int main()
     /*
      * Testing fetching from a DEM bounding box
      */
-    const char * demFileBBox = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMBBox.tif"; // output file name
+    char demFileBBox[MAX_PATH_LEN];
+    snprintf(demFileBBox, sizeof(demFileBBox), "%s%s", wnDataPath, "/../autotest/api/data/fetch/DEMBBox.tif"); // output file name
     char * fetch_type = "lcp"; // can be srtm, gmted, relief
     double resolution = 30.0; // 30 m resolution
     double boundsBox [] = {40.07, -104.0, 40.0, -104.07}; // Bounding box (north, east, south, west)
@@ -142,8 +149,10 @@ int main()
     int hour[2] = {2, 2};
     int minute[2] = {2, 2};
     int size = 2;
-    const char* output_path = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/";
-    const char* elevation_file = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    char output_path[MAX_PATH_LEN];
+    char elevation_file[MAX_PATH_LEN];
+    snprintf(output_path, sizeof(output_path), "%s%s", wnDataPath, "/../autotest/api/data/fetch/");
+    snprintf(elevation_file, sizeof(elevation_file), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
     const char* osTimeZone = "UTC";
     bool fetchLatestFlag = 0;  // set to 1 if you want the latestTime instead of the above time list
     double buffer = 10;  // distance around elevation file
@@ -165,7 +174,8 @@ int main()
     double adfPoint[] = {-104.0, 40.07}; // Point coordinates (longitude, latitude)
     double adfBuff[] = {1.5, 1.5}; // Buffer to store the elevation value
     double dfCellSize = 30.0; // Cell size in meters
-    char* pszDstFile = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMpoint.tif";
+    char pszDstFile[MAX_PATH_LEN];
+    snprintf(pszDstFile, sizeof(pszDstFile), "%s%s", wnDataPath, "/../autotest/api/data/fetch/DEMpoint.tif");
     char* fetchType = "lcp";
     err = NinjaFetchDEMPoint(ninjaTools, adfPoint, adfBuff, units, dfCellSize, pszDstFile, fetchType, papszOptions);
     if(err != NINJA_SUCCESS)

--- a/autotest/api/test_capi_fetching.c
+++ b/autotest/api/test_capi_fetching.c
@@ -38,34 +38,63 @@
 
 int main()
 {
-    /* 
-     * Setting up NinjaArmy
+    /*
+     * Setting up NinjaTools
      */
-    NinjaArmyH* ninjaArmy = NULL; 
+    NinjaToolsH* ninjaTools = NULL;
+    const char * runType = "C-API autotest";
     char ** papszOptions = NULL;
     NinjaErr err = 0; 
-    err = NinjaInit(papszOptions); // must be called for fetching and simulations 
+    err = NinjaInit(runType, papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
     if(err != NINJA_SUCCESS)
     {
-      printf("NinjaInit: err = %d\n", err);
+        printf("NinjaInit: err = %d\n", err);
     }
 
     /*
-     * Testing fetching from a DEM bounding box  
+     * Setting up a log file, for ninjaCom, if desired
+     */
+    FILE* multiStream = NULL;
+    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    if(multiStream == NULL)
+    {
+        printf("error opening log file\n");
+    }
+
+    /*
+     * Initialize ninjaTools
+     */
+    ninjaTools = NinjaMakeTools();
+
+    /*
+     * Customize the ninja communication
+     */
+    err = NinjaSetToolsMultiComStream(ninjaTools, multiStream, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaSetToolsMultiComStream: err = %d\n", err);
+    }
+
+    /*
+     * Testing fetching from a DEM bounding box
      */
     const char * demFileBBox = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMBBox.tif"; // output file name
     char * fetch_type = "lcp"; // can be srtm, gmted, relief
     double resolution = 30.0; // 30 m resolution
     double boundsBox [] = {40.07, -104.0, 40.0, -104.07}; // Bounding box (north, east, south, west)
-    err = NinjaFetchDEMBBox(ninjaArmy, boundsBox, demFileBBox, resolution, fetch_type, papszOptions);
-    if (err != NINJA_SUCCESS){
+    err = NinjaFetchDEMBBox(ninjaTools, boundsBox, demFileBBox, resolution, fetch_type, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
         printf("NinjaFetchDEMBBox: err = %d\n", err);
+    } else
+    {
+        printf("NinjaFetchDEMBBox: success\n");
     }
     
     /*
-     * Testing fetching for a Forecast file 
+     * Testing fetching for a Forecast file
      */
-    const char*wx_model_type = "NOMADS-HRRR-CONUS-3-KM"; //  follow the cli argument output UCAR-NAM-CONUS-12-KM, 
+    const char* wx_model_type = "NOMADS-HRRR-CONUS-3-KM";  // follow the cli argument output UCAR-NAM-CONUS-12-KM,
     /* All Possible inputs for wx_model_type
      * UCAR-NAM-ALASKA-11-KM, 
      * UCAR-NDFD-CONUS-2.5-KM, 
@@ -94,17 +123,18 @@ int main()
      * NOMADS-RAP-NORTH-AMERICA-32-KM
     */
     const char * demFileForecast = demFileBBox; // input DEM file
-    int numNinjas = 1;
-    const char* forecastFilename = NinjaFetchForecast(ninjaArmy, wx_model_type, numNinjas, demFileForecast, papszOptions);
-    if (strcmp(forecastFilename, "exception") == 0){
-        printf("NinjaFetchForecast: err = %s\n", forecastFilename);
-    }
-    else{
-        printf("NinjaFetchForecast: forecastFilename = %s\n", forecastFilename);
+    int numForecastHours = 1;
+    err = NinjaFetchWeatherData(ninjaTools, wx_model_type, demFileForecast, numForecastHours);//, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFetchWeatherData: err = %d\n", err);
+    } else
+    {
+        printf("NinjaFetchWeatherData: success\n");
     }
 
     /*
-     * Testing fetching station data from a geotiff file.  
+     * Testing fetching station data from a geotiff file.
      */
     int year[2] = {2024, 2024};
     int month[2] = {2, 2};
@@ -115,15 +145,18 @@ int main()
     const char* output_path = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/";
     const char* elevation_file = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
     const char* osTimeZone = "UTC";
-    bool fetchLatestFlag = 1;
-    double buffer = 10;
+    bool fetchLatestFlag = 0;  // set to 1 if you want the latestTime instead of the above time list
+    double buffer = 10;  // distance around elevation file
     const char* units = "mi";
+    bool locationFileFlag = 1; //set to 1 if you want the location file for the station data to be output
 
-    err = NinjaFetchStation(year, month, day, hour, minute, size, elevation_file, buffer, units, osTimeZone, fetchLatestFlag, output_path, papszOptions);
-    if (err != NINJA_SUCCESS) {
-        printf("NinjaFetchStation: err = %d\n", err);
-    } else {
-        printf("NinjaFetchStation: success\n");
+    err = NinjaFetchStationFromBBox(ninjaTools, year, month, day, hour, minute, size, elevation_file, buffer, units, osTimeZone, fetchLatestFlag, output_path, locationFileFlag, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFetchStationFromBBox: err = %d\n", err);
+    } else
+    {
+        printf("NinjaFetchStationFromBBox: success\n");
     }
 
     /*
@@ -134,11 +167,39 @@ int main()
     double dfCellSize = 30.0; // Cell size in meters
     char* pszDstFile = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMpoint.tif";
     char* fetchType = "lcp";
-    err = NinjaFetchDEMPoint(ninjaArmy, adfPoint, adfBuff, units, dfCellSize, pszDstFile, fetchType, papszOptions);
-    if (err != NINJA_SUCCESS) {
+    err = NinjaFetchDEMPoint(ninjaTools, adfPoint, adfBuff, units, dfCellSize, pszDstFile, fetchType, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
         printf("NinjaFetchDemPoint: err = %d\n", err);
-    } else {
+    } else
+    {
         printf("NinjaFetchDemPoint: elevation = %f\n", adfBuff[0]);
+    }
+
+    /*
+     * Clean up
+     */
+
+    // not yet needed/implemented in the code, but it should be.
+    //err = NinjaDestroyTools(ninjaTools, papszOptions);
+    //if(err != NINJA_SUCCESS)
+    //{
+    //    printf("NinjaDestroyTools: err = %d\n", ninjaErr);
+    //}
+
+    if(multiStream != NULL)
+    {
+        if(fclose(multiStream) != 0)
+        {
+            printf("error closing log file\n");
+        }
+    }
+
+    // must be called to cleanup ninjaInit();
+    err = NinjaFinalize(papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFinalize: err = %d\n", err);
     }
 
     return NINJA_SUCCESS;

--- a/autotest/api/test_capi_output.c
+++ b/autotest/api/test_capi_output.c
@@ -125,8 +125,20 @@ int main()
      */
     const double outputResolution = 100.0;
     const char * units = "m";
-    const double width = 1.0;
-    const char * scaling = "equal_color";
+    const double clipAmount = 0.0;  // use values between 0.0 and 50.0
+    //const double clipAmount = 20.0;
+    const double lineWidth = 1.0;
+    //// some google earth specific variables
+    const char * scaling = "equal_interval";  // equivalent to "Uniform Range" in the gui
+    //const char * scaling = "equal_color";  // equivalent to "Equal Count" in the gui, the default
+    const char * colorScheme = "default";  // default (ROYGB), oranges, blues, greens, pinks, magic_beans, pink_to_green, ROPGW
+    const bool scaleVectors = false;  // enable vector scaling based on wind speed
+    const bool useConsistentColorScale = false;  // google earth, use the same color scale across multi-runs
+    //// some pdf specific variables
+    const int baseMap = 0; // 0 is "topofire", 1 is "hillshade". the connection goes down a lot for topofire, though it looks a lot better
+    const double pdfHeight = 8.5;  // inches
+    const double pdfWidth = 11.0;  // inches
+    const double pdfDpi = 150;
     char outputPath[MAX_PATH_LEN];
     snprintf(outputPath, sizeof(outputPath), "%s%s", wnDataPath, "/../autotest/api/data/output");
     const bool outputFlag = 1;
@@ -168,6 +180,12 @@ int main()
     /*
      * Prepare the army
      */
+    // farsite atm file only works if very specific units. outputs in mph at 20 feet, or outputs in kph at 10 meters.
+    //err = NinjaSetAsciiAtmFile(ninjaArmy, outputFlag, papszOptions);
+    //if(err != NINJA_SUCCESS)
+    //{
+    //    printf("NinjaSetAsciiAtmFile: err = %d\n", err);
+    //}
     for(unsigned int i=0; i<numNinjas; i++)
     {
       /*
@@ -196,25 +214,13 @@ int main()
       {
         printf("NinjaSetPosition: err = %d\n", err);
       }
-    
+
       err = NinjaSetInputWindHeight(ninjaArmy, i, height, heightUnits, papszOptions);
       if(err != NINJA_SUCCESS)
       {
         printf("NinjaSetInputWindHeight: err = %d\n", err);
       }
-    
-      err = NinjaSetOutputWindHeight(ninjaArmy, i, height, heightUnits, papszOptions);
-      if(err != NINJA_SUCCESS)
-      {
-        printf("NinjaSetOutputWindHeight: err = %d\n", err);
-      }
-    
-      err = NinjaSetOutputSpeedUnits(ninjaArmy, i, speedUnits, papszOptions);
-      if(err != NINJA_SUCCESS)
-      {
-        printf("NinjaSetOutputSpeedUnits: err = %d\n", err);
-      }
-    
+
       err = NinjaSetDiurnalWinds(ninjaArmy, i, diurnalFlag, papszOptions);
       if(err != NINJA_SUCCESS)
       {
@@ -274,6 +280,24 @@ int main()
           printf("NinjaSetOutputPath: err = %d\n", err);
       }
 
+      err = NinjaSetOutputWindHeight(ninjaArmy, i, height, heightUnits, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+        printf("NinjaSetOutputWindHeight: err = %d\n", err);
+      }
+
+      err = NinjaSetOutputSpeedUnits(ninjaArmy, i, speedUnits, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+        printf("NinjaSetOutputSpeedUnits: err = %d\n", err);
+      }
+
+      err = NinjaSetOutputBufferClipping(ninjaArmy, i, clipAmount, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+        printf("NinjaSetOutputBufferClipping: err = %d\n", err);
+      }
+
       /* Google output (.kmz) */
       err = NinjaSetGoogOutFlag(ninjaArmy, i, outputFlag, papszOptions);
       if(err != NINJA_SUCCESS)
@@ -281,22 +305,34 @@ int main()
           printf("NinjaSetGoogOutFlag: err = %d\n", err);
       }
 
-      err = NinjaSetGoogResolution (ninjaArmy, i, outputResolution, units, papszOptions);
+      err = NinjaSetGoogResolution(ninjaArmy, i, outputResolution, units, papszOptions);
       if(err != NINJA_SUCCESS)
       {
           printf("NinjaSetGoogResolution: err = %d\n", err);
       }
 
-      err = NinjaSetGoogSpeedScaling (ninjaArmy, i, scaling, papszOptions);
+      err = NinjaSetGoogSpeedScaling(ninjaArmy, i, scaling, papszOptions);
       if(err != NINJA_SUCCESS)
       {
           printf("NinjaSetGoogSpeedScaling: err = %d\n", err);
       }
 
-      err = NinjaSetGoogLineWidth (ninjaArmy, i, width, papszOptions);
+      err = NinjaSetGoogLineWidth(ninjaArmy, i, lineWidth, papszOptions);
       if(err != NINJA_SUCCESS)
       {
           printf("NinjaSetGoogLineWidth: err = %d\n", err);
+      }
+
+      err = NinjaSetGoogColor(ninjaArmy, i, colorScheme, scaleVectors, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetGoogColor: err = %d\n", err);
+      }
+
+      err = NinjaSetGoogConsistentColorScale(ninjaArmy, i, useConsistentColorScale, numNinjas, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetGoogConsistentColorScale: err = %d\n", err);
       }
 
       /* Shapefile output (.shp) */
@@ -319,12 +355,61 @@ int main()
           printf("NinjaSetAsciiOutFlag: err = %d\n", err);
       }
 
+      err = NinjaSetAsciiAaigridOutFlag(ninjaArmy, i, outputFlag, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetAsciiAaigridOutFlag: err = %d\n", err);
+      }
+
+      err = NinjaSetAsciiProjOutFlag(ninjaArmy, i, outputFlag, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetAsciiProjOutFlag: err = %d\n", err);
+      }
+
       err = NinjaSetAsciiResolution(ninjaArmy, i, outputResolution, units, papszOptions);
       if(err != NINJA_SUCCESS)
       {
           printf("NinjaSetAsciiResolution: err = %d\n", err);
       }
-      
+
+      /* pdf output (.pdf) */
+      err = NinjaSetPDFOutFlag(ninjaArmy, i, outputFlag, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFOutFlag: err = %d\n", err);
+      }
+
+      err = NinjaSetPDFLineWidth(ninjaArmy, i, lineWidth, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFLineWidth: err = %d\n", err);
+      }
+
+      err = NinjaSetPDFBaseMap(ninjaArmy, i, baseMap, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFBaseMap: err = %d\n", err);
+      }
+
+      err = NinjaSetPDFDEM(ninjaArmy, i, demFile, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFDEM: err = %d\n", err);
+      }
+
+      err = NinjaSetPDFSize(ninjaArmy, i, pdfHeight, pdfWidth, pdfDpi, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFSize: err = %d\n", err);
+      }
+
+      err = NinjaSetPDFResolution(ninjaArmy, i, outputResolution, units, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+          printf("NinjaSetPDFResolution: err = %d\n", err);
+      }
+
       /* VKT output (.vkt) */
       err = NinjaSetVtkOutFlag(ninjaArmy, i, outputFlag, papszOptions);
       if(err != NINJA_SUCCESS)

--- a/autotest/api/test_capi_output.c
+++ b/autotest/api/test_capi_output.c
@@ -27,8 +27,10 @@
  *
  *****************************************************************************/
 #include "windninja.h"
-#include <stdio.h> //for printf
+#include <stdio.h> //for printf, FILE, fopen, fclose
 #include <stdbool.h>
+
+#define MAX_PATH_LEN 512
 
 void printArray(const double* array, int size, const char* label) {
     if (array == NULL) {
@@ -59,11 +61,16 @@ int main()
         printf("NinjaInit: err = %d\n", err);
     }
 
+    // manually set your wnDataPath (makes it easier for setting paths and testing)
+    // must replace the "~/" part with your exact path
+    const char* wnDataPath = "~/src/wind/windninja/data";
+
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
-    FILE* multiStream = NULL;
-    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    char multiStreamFilename[MAX_PATH_LEN];
+    snprintf(multiStreamFilename, sizeof(multiStreamFilename), "%s%s", wnDataPath, "/../autotest/api/data/ninja.log");
+    FILE* multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
         printf("error opening log file\n");
@@ -73,7 +80,8 @@ int main()
      * Set up domain average run
      */
     /* inputs that do not vary among ninjas in an army */
-    const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    char demFile[MAX_PATH_LEN];
+    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
     const char * initializationMethod = "domain_average";
     const char * meshChoice = "coarse";
     const char * vegetation = "brush";
@@ -119,7 +127,8 @@ int main()
     const char * units = "m";
     const double width = 1.0;
     const char * scaling = "equal_color";
-    const char * outputPath  = "/home/atw09001/src/wind/windninja/autotest/api/data/output";
+    char outputPath[MAX_PATH_LEN];
+    snprintf(outputPath, sizeof(outputPath), "%s%s", wnDataPath, "/../autotest/api/data/output");
     const bool outputFlag = 1;
 
     /*

--- a/autotest/api/test_capi_output.c
+++ b/autotest/api/test_capi_output.c
@@ -45,79 +45,132 @@ void printArray(const double* array, int size, const char* label) {
 
 int main()
 {
-    /* 
+    /*
      * Setting up the simulation
      */
-    NinjaArmyH* ninjaArmy = NULL; 
-    const char * comType = "cli"; //communication type is always set to "cli"
+    NinjaArmyH* ninjaArmy = NULL;
     const int nCPUs = 1;
+    const char * runType = "C-API autotest";
     char ** papszOptions = NULL;
-    NinjaErr err = 0; 
-    err = NinjaInit(papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
+    NinjaErr err = 0;
+    err = NinjaInit(runType, papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
     if(err != NINJA_SUCCESS)
     {
-      printf("NinjaInit: err = %d\n", err);
+        printf("NinjaInit: err = %d\n", err);
     }
 
-    /* 
-     * Set up domain average run 
+    /*
+     * Setting up a log file, for ninjaCom, if desired
+     */
+    FILE* multiStream = NULL;
+    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    if(multiStream == NULL)
+    {
+        printf("error opening log file\n");
+    }
+
+    /*
+     * Set up domain average run
      */
     /* inputs that do not vary among ninjas in an army */
-    const char * demFile = "/home/mason/Documents/Git/WindNinja/windninja/autotest/api/data/missoula_valley.tif"; 
+    const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
     const char * initializationMethod = "domain_average";
     const char * meshChoice = "coarse";
-    const char * vegetation = "grass";
+    const char * vegetation = "brush";
     const int nLayers = 20; //layers in the mesh
-    const int diurnalFlag = 0; //diurnal slope wind parameterization not used
+    const int diurnalFlag = 0; //set to 1 to use the diurnal slope wind parameterization inputs
+    const int stabilityFlag = 0; //set to 1 to use the stability wind parameterization inputs. NOT to be used with a momentum solver run.
     const double height = 10.0;
     const char * heightUnits = "m";
     bool momentumFlag = 0; //we're using the conservation of mass solver
-    unsigned int numNinjas = 3; //two ninjas in the ninjaArmy
+    //bool momentumFlag = 1; //we're using the conservation of momentum solver
+    unsigned int numNinjas = 2; //two ninjas in the ninjaArmy - must be equal to array sizes
+
+    //const int nIters = -1.0;  //set to value > 0.0 to override the default value of 1000. Used only by the conservation of momentum solver.
+    const int nIters = 300;  // the cli and the GUI use a value of 300 instead of the default value of 1000.
+
+    const double meshResolution = -1.0;  //set to value > 0.0 to override meshChoice with meshResolution value. Used only by the conservation of momentum solver.
+    //const double meshResolution = 300.0;
+    const char * meshResolutionUnits = "m";
+
+    bool matchedPoints = true;  // for point initialization, but currently required as an input to SetInitializationMethod(). Should the match points pointInitialization algorythm be run, or should it just run as a domainAvgRun on the input wind field. ALWAYS set to true unless you know what you are doing.
 
     /* inputs that can vary among ninjas in an army */
     const double speedList[] = {5.5, 5.5};
     const char * speedUnits = "mps";
     const double directionList[] = {220, 300};
 
-    /* inputs specific to output 
+    // thermal parameterization inputs (diurnal and stability)
+    const int year[2] = {2023, 2023};
+    const int month[2] = {10, 11};
+    const int day[2] = {10, 11};
+    const int hour[2] = {12, 13};
+    const int minute[2] = {30, 31};
+    const char * timezone = "UTC";
+    const double air[2] = {50.0, 50.0};
+    const char * airUnits = "F";
+    const double cloud[2] = {10.0, 10.0};
+    const char * cloudUnits = "percent";
+
+    /* inputs specific to output
      * Note: Outputs have default values if inputs are not specified (For example, resolution will default to the mesh resolution)
      */
     const double outputResolution = 100.0;
     const char * units = "m";
     const double width = 1.0;
     const char * scaling = "equal_color";
-    const char * outputPath  = "/home/mason/Documents/Git/WindNinja/windninja/autotest/api/data/output";
+    const char * outputPath  = "/home/atw09001/src/wind/windninja/autotest/api/data/output";
     const bool outputFlag = 1;
-    /* 
-     * Create the army
+
+    /*
+     * Initialize the army
      */
-    ninjaArmy = NinjaMakeDomainAverageArmy(numNinjas, momentumFlag, speedList, speedUnits, directionList, papszOptions);
+    ninjaArmy = NinjaInitializeArmy();
     if( NULL == ninjaArmy )
     {
-        printf("NinjaCreateArmy: ninjaArmy = NULL\n");
+        printf("NinjaInitializeArmy: ninjaArmy = NULL\n");
     }
 
-    /* 
+    /*
+     * Customize the ninja communication
+     */
+    err = NinjaSetArmyMultiComStream(ninjaArmy, multiStream, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaSetArmyMultiComStream: err = %d\n", err);
+    }
+
+    /*
+     * Make the army
+     */
+    if(diurnalFlag == 1 || stabilityFlag == 1)
+    {
+        err = NinjaMakeDomainAverageArmyThermalParameterization(ninjaArmy, numNinjas, momentumFlag, speedList, speedUnits, directionList, year, month, day, hour, minute, timezone, air, airUnits, cloud, cloudUnits, papszOptions);
+    }
+    else
+    {
+        err = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speedList, speedUnits, directionList, papszOptions);
+    }
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaMakeDomainAverageArmy: err = %d\n", err);
+    }
+
+    /*
      * Prepare the army
      */
     for(unsigned int i=0; i<numNinjas; i++)
     {
-      /* 
+      /*
        * Sets Simulation Variables
        */
-      err = NinjaSetCommunication(ninjaArmy, i, comType, papszOptions);
-      if(err != NINJA_SUCCESS)
-      {
-        printf("NinjaSetCommunication: err = %d\n", err);
-      }
-    
       err = NinjaSetNumberCPUs(ninjaArmy, i, nCPUs, papszOptions);
       if(err != NINJA_SUCCESS)
       {
         printf("NinjaSetNumberCPUs: err = %d\n", err);
       }
     
-      err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, papszOptions);
+      err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, matchedPoints, papszOptions);
       if(err != NINJA_SUCCESS)
       {
         printf("NinjaSetInitializationMethod: err = %d\n", err);
@@ -158,26 +211,52 @@ int main()
       {
         printf("NinjaSetDiurnalWinds: err = %d\n", err);
       }
-    
+
+      err = NinjaSetStabilityFlag(ninjaArmy, i, stabilityFlag, papszOptions);
+      if(err != NINJA_SUCCESS)
+      {
+        printf("NinjaSetStabilityFlag: err = %d\n", err);
+      }
+
       err = NinjaSetUniVegetation(ninjaArmy, i, vegetation, papszOptions);
       if(err != NINJA_SUCCESS)
       {
         printf("NinjaSetUniVegetation: err = %d\n", err);
       }
-    
-      err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
-      if(err != NINJA_SUCCESS)
+
+      if(nIters > 0.0)
       {
-          printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+        err = NinjaSetNumberOfIterations(ninjaArmy, i, nIters, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+          printf("NinjaSetNumberOfIterations: err = %d\n", err);
+        }
       }
-    
+
+      if(meshResolution > 0.0)
+      {
+        err = NinjaSetMeshResolution(ninjaArmy, i, meshResolution, meshResolutionUnits, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+          printf("NinjaSetMeshResolution: err = %d\n", err);
+        }
+      }
+      else  // meshResolution not set, use meshChoice
+      {
+        err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+          printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+        }
+      }
+
       err = NinjaSetNumVertLayers(ninjaArmy, i, nLayers, papszOptions);
       if(err != NINJA_SUCCESS)
       {
           printf("NinjaSetNumVertLayers: err = %d\n", err);
       }
 
-      /* 
+      /*
        * Sets Output Variables
        */
       err = NinjaSetOutputPath(ninjaArmy, i, outputPath, papszOptions);
@@ -243,10 +322,9 @@ int main()
       {
           printf("NinjaSetVtkOutFlag: err = %d\n", err);
       }
-
     }
 
-    /* 
+    /*
      * Start the simulations
      */
     err = NinjaStartRuns(ninjaArmy, nCPUs, papszOptions);
@@ -255,7 +333,7 @@ int main()
         printf("NinjaStartRuns: err = %d\n", err);
     }
 
-    /* 
+    /*
      * Get the outputs
      */
     const double* outputSpeedGrid = NULL;
@@ -302,7 +380,7 @@ int main()
     printf("Grid Rows: %d\n", outputGridnRows);
     printf("Grid Projection: %s\n", outputGridProjection);
 
-    /* 
+    /*
      * Clean up
      */
     err = NinjaDestroyArmy(ninjaArmy, papszOptions);
@@ -310,6 +388,21 @@ int main()
     {
         printf("NinjaDestroyRuns: err = %d\n", err);
     }
- 
+
+    if(multiStream != NULL)
+    {
+        if(fclose(multiStream) != 0)
+        {
+            printf("error closing log file\n");
+        }
+    }
+
+    // must be called to cleanup ninjaInit();
+    err = NinjaFinalize(papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFinalize: err = %d\n", err);
+    }
+
     return NINJA_SUCCESS;
 }

--- a/autotest/api/test_capi_point_initialization_wind.c
+++ b/autotest/api/test_capi_point_initialization_wind.c
@@ -87,41 +87,23 @@ int main()
     //const double meshResolution = 300.0;
     const char * meshResolutionUnits = "m";
 
-    /* timeListSize is technically used instead of the number of ninjas */
-    /* but timeListSize is technically used more like a numTimeSteps, it can be less than or equal to the size of the time arrays */
-    //int timeListSize = numNinjas;
-    int timeListSize = 2;
-    //int timeListSize = 1;  // make sure to only use 1 if doing latestTime data, or it tries to converge on some kind of NO_DATA situation or something.
+    char demFile[MAX_PATH_LEN];
+    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
+    //char* osTimeZone = "UTC";
+    char* osTimeZone = "America/Denver";
+    bool matchPointsFlag = 1;  // needed to match the station data, or else you only get a domainAverageRun of the initial wind field constructed from the station data
 
-    //// the fetched data times, hrm the run seems to be way stricter than the fetch for building the times
-    //// will need to run fetch test to get station data
-    /// so update the folder path accordingly for the fresh data.
-    /// the time list seems to stay pretty stable, latestTime just affects folder paths/names.
-    //int year[2] = {2024, 2024};
-    //int month[2] = {2, 2};
-    //int day[2] = {2, 2};
-    //int hour[2] = {2, 2};  // local time
-    ////int hour[2] = {8, 8};  // UTC time
-    //int minute[2] = {0, 59};
 
-    //// the /windninja/data/ times, predownloaded data.
-    int year[2] = {2018, 2018};
-    int month[2] = {6, 6};
-    //int day[2] = {20, 21};  // local time
-    //int hour[2] = {21, 21};  // local time
-    int day[2] = {21, 22}; // UTC time
-    int hour[2] = {3, 3};  // UTC time
-    int minute[2] = {28, 28};
-
-    ////// will need to run fetch test to get wxstation data, or grab the data from the windninja/data folder (that seems easier)
-    //// hrm, doesn't seem to like the station location files, like the cli does
+    /* set the number and names of the station files to use */
+    ////// use predownloaded WINDNINJA_DATA files
+    //// try the station location files
+    //// hrm, the C-API doesn't seem to like the station location files, like the cli does
     ////int numStationFiles = 1;
     ////char station_path0[MAX_PATH_LEN];
-    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/missoula_valley_stations_6.csv.csv");  // latestTime
-    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/missoula_valley_stations_6.csv.csv");  // timeSeries
     ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/missoula_valley_stations_4.csv");  // latestTime
     ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/missoula_valley_stations_4.csv");  // timeSeries
     ////const char* station_paths[1] = {station_path0};
+    //// standard setup for a latestTime or timeSeries
     int numStationFiles = 4;
     char station_path0[MAX_PATH_LEN];
     char station_path1[MAX_PATH_LEN];
@@ -138,7 +120,27 @@ int main()
     //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/PNTM8-2018-06-25_1237-2.csv");
     //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/TR266-2018-06-25_1237-3.csv");
     const char* station_paths[4] = {station_path0, station_path1, station_path2, station_path3};
-    /// the fetched data
+
+    ////// use files fetched from test_capi_fetching.c
+    ////// will need to run test_capi_fetching.c to get wxstation data, and adjust the path names accordingly
+    //// hrm, the C-API doesn't seem to like the station location files, like the cli does
+    ////int numStationFiles = 1;
+    ////char station_path0[MAX_PATH_LEN];
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1840-missoula_valley/missoula_valley_stations_6.csv.csv");  // latestTime
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/missoula_valley_stations_6.csv.csv");  // timeSeries
+    ////const char* station_paths[1] = {station_path0};
+    /// latestTime
+    //int numStationFiles = 4;
+    //char station_path0[MAX_PATH_LEN];
+    //char station_path1[MAX_PATH_LEN];
+    //char station_path2[MAX_PATH_LEN];
+    //char station_path3[MAX_PATH_LEN];
+    //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1840-missoula_valley/KMSO-2026-05-04_1840-0.csv");
+    //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1840-missoula_valley/BLMM8-2026-05-04_1840-1.csv");
+    //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1840-missoula_valley/PNTM8-2026-05-04_1840-2.csv");
+    //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1840-missoula_valley/FINM8-2026-05-04_1840-3.csv");
+    //const char* station_paths[4] = {station_path0, station_path1, station_path2, station_path3};
+    /// timeSeries
     //int numStationFiles = 6;
     //char station_path0[MAX_PATH_LEN];
     //char station_path1[MAX_PATH_LEN];
@@ -146,14 +148,6 @@ int main()
     //char station_path3[MAX_PATH_LEN];
     //char station_path4[MAX_PATH_LEN];
     //char station_path5[MAX_PATH_LEN];
-    /// latestTime
-    //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/KMSO-2026-05-04_1530-0.csv");
-    //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/BLMM8-2026-05-04_1530-1.csv");
-    //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/PNTM8-2026-05-04_1530-2.csv");
-    //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/FINM8-2026-05-04_1530-3.csv");
-    //snprintf(station_path4, sizeof(station_path4), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/NINM8-2026-05-04_1530-4.csv");
-    //snprintf(station_path5, sizeof(station_path5), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/TT350-2026-05-04_1530-5.csv");
-    /// timeSeries
     //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/KMSO-2024-02-02_0202-2024-02-02_0202-0.csv");
     //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/BLMM8-2024-02-02_0202-2024-02-02_0202-1.csv");
     //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/PNTM8-2024-02-02_0202-2024-02-02_0202-2.csv");
@@ -162,11 +156,137 @@ int main()
     //snprintf(station_path5, sizeof(station_path5), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/MOMM8-2024-02-02_0202-2024-02-02_0202-5.csv");
     //const char* station_paths[6] = {station_path0, station_path1, station_path2, station_path3, station_path4, station_path5};
 
-    char demFile[MAX_PATH_LEN];
-    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
-    //char* osTimeZone = "UTC";
-    char* osTimeZone = "America/Denver";
-    bool matchPointsFlag = 1;  // needed to match the station data, or else you only get a domainAverageRun of the initial wind field constructed from the station data
+
+    /* set the times to be used from/with the station files */
+    /* timeListSize is technically used instead of the number of ninjas */
+    /* but timeListSize is technically used more like a numTimeSteps, it can be less than or equal to the size of the time arrays */
+    /* to do a latestTime simulation, instead of a timeSeries, use a timeListSize of 1. */
+    ////int timeListSize = numNinjas;
+    int timeListSize = 2;
+    //int timeListSize = 1;  // make sure to only use 1 if doing latestTime data, or it tries to converge on some kind of NO_DATA situation or something.
+
+    //// use predownloaded WINDNINJA_DATA files and times
+    //int year[2] = {2018, 2018};
+    //int month[2] = {6, 6};
+    ////int day[2] = {20, 21};  // local time
+    ////int hour[2] = {21, 21};  // local time
+    //int day[2] = {21, 22}; // UTC time
+    //int hour[2] = {3, 3};  // UTC time, 6 hrs later
+    //int minute[2] = {28, 28};
+
+    //// use fetched data times
+    //// will need to run test_capi_fetching.c to get station data
+    //// so update the folder path accordingly for the fresh data.
+    ////
+    //// hrm the run seems to be way stricter than the fetch for building the times
+    //// have to use a narrower set of times than the download
+    ////
+    //// the time list seems to stay pretty stable, latestTime just affects folder paths/names
+    //// so probably don't need to edit this list of times after all.
+    //int year[2] = {2024, 2024};
+    //int month[2] = {2, 2};
+    ////int day[2] = {1, 1};  // local time
+    ////int hour[2] = {19, 19};  // local time, 7 hrs earlier
+    //int day[2] = {2, 2};  // UTC time
+    //int hour[2] = {2, 2};  // UTC time
+    //int minute[2] = {0, 59};
+
+
+    //// or even better, generate your own list of times, using the helper functions
+    //// this involves setting up a ninjaTools instance
+    /// use predownloaded WINDNINJA_DATA files and times
+    int startYear = 2018;
+    int startMonth = 6;
+    int startDay = 20;  // local time
+    int startHour = 21;  // local time
+    //int startDay = 21;  // UTC time
+    //int startHour = 3;  // UTC time, 6 hrs later
+    int startMinute = 28;
+    int stopYear = 2018;
+    int stopMonth = 6;
+    int stopDay = 21;  // local time
+    int stopHour = 21;  // local time
+    //int stopDay = 22;  // UTC time
+    //int stopHour = 3;  // UTC time, 6 hrs later
+    int stopMinute = 28;
+    /// use fetched data times (for files fetched from test_capi_fetching.c)
+    /// looks like the fetch was in UTC time, but these helper functions require local time as input
+    //int startYear = 2024;
+    //int startMonth = 2;
+    //int startDay = 1;  // local time
+    //int startHour = 19;  // local time, 7 hrs earlier
+    ////int startDay = 2;  // UTC time
+    ////int startHour = 2;  // UTC time
+    //int startMinute = 0;
+    //int stopYear = 2024;
+    //int stopMonth = 2;
+    //int stopDay = 1;  // local time
+    //int stopHour = 19;  // local time, 7 hrs earlier
+    ////int stopDay = 2;  // UTC time
+    ////int stopHour = 2;  // UTC time
+    //int stopMinute = 59;
+
+    NinjaToolsH* ninjaTools = NULL;
+    /*
+     * Initialize ninjaTools
+     */
+    ninjaTools = NinjaMakeTools();
+    /*
+     * Customize the ninja communication
+     */
+    err = NinjaSetToolsMultiComStream(ninjaTools, multiStream, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaSetToolsMultiComStream: err = %d\n", err);
+    }
+
+    // MUST USE THE SAME or smaller SIZE AS timeListSize, or you get ERRORS
+    int year[2];
+    int month[2];
+    int day[2];
+    int hour[2];
+    int minute[2];
+    if(timeListSize == 1)
+    {
+        int outYear;
+        int outMonth;
+        int outDay;
+        int outHour;
+        int outMinute;
+        err = NinjaGenerateSingleTimeObject(ninjaTools, startYear, startMonth, startDay, startHour, startMinute, osTimeZone, &outYear, &outMonth, &outDay, &outHour, &outMinute);
+        if(err != NINJA_SUCCESS)
+        {
+            printf("NinjaGenerateSingleTimeObject: err = %d\n", err);
+        }
+
+        year[0] = outYear;
+        month[0] = outMonth;
+        day[0] = outDay;
+        hour[0] = outHour;
+        minute[0] = outMinute;
+    }
+    else
+    {
+        int inYears[2] = {startYear, stopYear};
+        int inMonths[2] = {startMonth, stopMonth};
+        int inDays[2] = {startDay, stopDay};
+        int inHours[2] = {startHour, stopHour};
+        int inMinutes[2] = {startMinute, stopMinute};
+        err = NinjaGetTimeList(ninjaTools, inYears, inMonths, inDays, inHours, inMinutes, year, month, day, hour, minute, timeListSize, osTimeZone);
+        if(err != NINJA_SUCCESS)
+        {
+            printf("NinjaGetTimeList: err = %d\n", err);
+        }
+    }
+
+    // not yet needed/implemented in the code, but it should be.
+    // if ninjaTools was used/generated, clean it up afterwards
+    //err = NinjaDestroyTools(ninjaTools, papszOptions);
+    //if(err != NINJA_SUCCESS)
+    //{
+    //    printf("NinjaDestroyTools: err = %d\n", ninjaErr);
+    //}
+
 
     /*
      * Initialize the army

--- a/autotest/api/test_capi_point_initialization_wind.c
+++ b/autotest/api/test_capi_point_initialization_wind.c
@@ -27,8 +27,10 @@
  *
  *****************************************************************************/
 #include "windninja.h"
-#include <stdio.h> //for printf
+#include <stdio.h> //for printf, FILE, fopen, fclose
 #include <stdbool.h>
+
+#define MAX_PATH_LEN 512
 
 int main()
 {
@@ -46,11 +48,16 @@ int main()
         printf("NinjaInit: err = %d\n", err);
     }
 
+    // manually set your wnDataPath (makes it easier for setting paths and testing)
+    // must replace the "~/" part with your exact path
+    const char* wnDataPath = "~/src/wind/windninja/data";
+
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
-    FILE* multiStream = NULL;
-    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    char multiStreamFilename[MAX_PATH_LEN];
+    snprintf(multiStreamFilename, sizeof(multiStreamFilename), "%s%s", wnDataPath, "/../autotest/api/data/ninja.log");
+    FILE* multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
         printf("error opening log file\n");
@@ -85,14 +92,19 @@ int main()
     //int timeListSize = numNinjas;
     int timeListSize = 2;
     //int timeListSize = 1;  // make sure to only use 1 if doing latestTime data, or it tries to converge on some kind of NO_DATA situation or something.
+
     //// the fetched data times, hrm the run seems to be way stricter than the fetch for building the times
+    //// will need to run fetch test to get station data
+    /// so update the folder path accordingly for the fresh data.
+    /// the time list seems to stay pretty stable, latestTime just affects folder paths/names.
     //int year[2] = {2024, 2024};
     //int month[2] = {2, 2};
     //int day[2] = {2, 2};
     //int hour[2] = {2, 2};  // local time
     ////int hour[2] = {8, 8};  // UTC time
     //int minute[2] = {0, 59};
-    //// the /windninja/data/ times
+
+    //// the /windninja/data/ times, predownloaded data.
     int year[2] = {2018, 2018};
     int month[2] = {6, 6};
     //int day[2] = {20, 21};  // local time
@@ -100,21 +112,58 @@ int main()
     int day[2] = {21, 22}; // UTC time
     int hour[2] = {3, 3};  // UTC time
     int minute[2] = {28, 28};
+
     ////// will need to run fetch test to get wxstation data, or grab the data from the windninja/data folder (that seems easier)
     //// hrm, doesn't seem to like the station location files, like the cli does
     ////int numStationFiles = 1;
-    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/missoula_valley_stations_6.csv.csv"};  // latestTime
-    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/missoula_valley_stations_6.csv.csv"};  // timeSeries
-    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/missoula_valley_stations_4.csv"};  // timeSeries
-    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/missoula_valley_stations_4.csv"};  // latestTime
+    ////char station_path0[MAX_PATH_LEN];
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/missoula_valley_stations_6.csv.csv");  // latestTime
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/missoula_valley_stations_6.csv.csv");  // timeSeries
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/missoula_valley_stations_4.csv");  // latestTime
+    ////snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/missoula_valley_stations_4.csv");  // timeSeries
+    ////const char* station_paths[1] = {station_path0};
     int numStationFiles = 4;
-    const char* station_paths[4] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/KMSO-MDT-2018-06-20_2128-2018-06-21_2128-0.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TS934-MDT-2018-06-20_2128-2018-06-21_2128-1.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/PNTM8-MDT-2018-06-20_2128-2018-06-21_2128-2.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TR266-MDT-2018-06-20_2128-2018-06-21_2128-3.csv"};  // timeSeries
-    //const char* station_paths[4] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/KMSO-2018-06-25_1237-0.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/TS934-2018-06-25_1237-1.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/PNTM8-2018-06-25_1237-2.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/TR266-2018-06-25_1237-3.csv"};  // latestTime
-    // the fetched data
+    char station_path0[MAX_PATH_LEN];
+    char station_path1[MAX_PATH_LEN];
+    char station_path2[MAX_PATH_LEN];
+    char station_path3[MAX_PATH_LEN];
+    /// timeSeries
+    snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/KMSO-MDT-2018-06-20_2128-2018-06-21_2128-0.csv");
+    snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TS934-MDT-2018-06-20_2128-2018-06-21_2128-1.csv");
+    snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/PNTM8-MDT-2018-06-20_2128-2018-06-21_2128-2.csv");
+    snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TR266-MDT-2018-06-20_2128-2018-06-21_2128-3.csv");
+    /// latestTime
+    //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/KMSO-2018-06-25_1237-0.csv");
+    //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/TS934-2018-06-25_1237-1.csv");
+    //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/PNTM8-2018-06-25_1237-2.csv");
+    //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/WXSTATIONS-2018-06-25-1237-missoula_valley/TR266-2018-06-25_1237-3.csv");
+    const char* station_paths[4] = {station_path0, station_path1, station_path2, station_path3};
+    /// the fetched data
     //int numStationFiles = 6;
-    //const char* station_paths[6] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/KMSO-2026-04-29_1331-0.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/BLMM8-2026-04-29_1331-1.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/PNTM8-2026-04-29_1331-2.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/FINM8-2026-04-29_1331-3.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/NINM8-2026-04-29_1331-4.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/TT350-2026-04-29_1331-5.csv"};  // latestTime
-    //const char* station_paths[6] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/KMSO-2024-02-02_0202-2024-02-02_0202-0.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/BLMM8-2024-02-02_0202-2024-02-02_0202-1.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/PNTM8-2024-02-02_0202-2024-02-02_0202-2.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/FINM8-2024-02-02_0202-2024-02-02_0202-3.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/NINM8-2024-02-02_0202-2024-02-02_0202-4.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/MOMM8-2024-02-02_0202-2024-02-02_0202-5.csv"};  // timeSeries
-    char* demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    //char station_path0[MAX_PATH_LEN];
+    //char station_path1[MAX_PATH_LEN];
+    //char station_path2[MAX_PATH_LEN];
+    //char station_path3[MAX_PATH_LEN];
+    //char station_path4[MAX_PATH_LEN];
+    //char station_path5[MAX_PATH_LEN];
+    /// latestTime
+    //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/KMSO-2026-05-04_1530-0.csv");
+    //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/BLMM8-2026-05-04_1530-1.csv");
+    //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/PNTM8-2026-05-04_1530-2.csv");
+    //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/FINM8-2026-05-04_1530-3.csv");
+    //snprintf(station_path4, sizeof(station_path4), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/NINM8-2026-05-04_1530-4.csv");
+    //snprintf(station_path5, sizeof(station_path5), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2026-05-04-1530-missoula_valley/TT350-2026-05-04_1530-5.csv");
+    /// timeSeries
+    //snprintf(station_path0, sizeof(station_path0), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/KMSO-2024-02-02_0202-2024-02-02_0202-0.csv");
+    //snprintf(station_path1, sizeof(station_path1), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/BLMM8-2024-02-02_0202-2024-02-02_0202-1.csv");
+    //snprintf(station_path2, sizeof(station_path2), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/PNTM8-2024-02-02_0202-2024-02-02_0202-2.csv");
+    //snprintf(station_path3, sizeof(station_path3), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/FINM8-2024-02-02_0202-2024-02-02_0202-3.csv");
+    //snprintf(station_path4, sizeof(station_path4), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/NINM8-2024-02-02_0202-2024-02-02_0202-4.csv");
+    //snprintf(station_path5, sizeof(station_path5), "%s%s", wnDataPath, "/../autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/MOMM8-2024-02-02_0202-2024-02-02_0202-5.csv");
+    //const char* station_paths[6] = {station_path0, station_path1, station_path2, station_path3, station_path4, station_path5};
+
+    char demFile[MAX_PATH_LEN];
+    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
     //char* osTimeZone = "UTC";
     char* osTimeZone = "America/Denver";
     bool matchPointsFlag = 1;  // needed to match the station data, or else you only get a domainAverageRun of the initial wind field constructed from the station data

--- a/autotest/api/test_capi_point_initialization_wind.c
+++ b/autotest/api/test_capi_point_initialization_wind.c
@@ -4,7 +4,7 @@
  * Purpose:  C API testing
  * Author:   Mason Willman <mason.willman
  *
- * gcc -g -Wall -o test_capi_point_initialization_wind.c test_capi_point_initialization_wind.c -lninja
+ * gcc -g -Wall -o test_capi_point_initialization_wind test_capi_point_initialization_wind.c -lninja
  *
  ******************************************************************************
  *
@@ -32,75 +32,135 @@
 
 int main()
 {
-    /* 
+    /*
      * Setting up the simulation
      */
-    NinjaArmyH* ninjaArmy = NULL; 
-    const char * comType = "cli"; //communication type is always set to "cli"
-    const int nCPUs = 1;
+    NinjaArmyH* ninjaArmy = NULL;
+    const int nCPUs = 3;
+    const char * runType = "C-API autotest";
     char ** papszOptions = NULL;
-    NinjaErr err = 0; 
-    err = NinjaInit(papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
+    NinjaErr err = 0;
+    err = NinjaInit(runType, papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
     if(err != NINJA_SUCCESS)
     {
-      printf("NinjaInit: err = %d\n", err);
+        printf("NinjaInit: err = %d\n", err);
     }
 
-    /* 
-     * Set up point initialization run 
+    /*
+     * Setting up a log file, for ninjaCom, if desired
+     */
+    FILE* multiStream = NULL;
+    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    if(multiStream == NULL)
+    {
+        printf("error opening log file\n");
+    }
+
+    /*
+     * Set up point initialization run
      */
     /* inputs that can vary among ninjas in an army */
-    //double outputResolution = 100; 
     const char * initializationMethod = "point";
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
     const int nLayers = 20; //layers in the mesh
-    const int diurnalFlag = 0; //diurnal slope wind parameterization not used
+    const int diurnalFlag = 0; //set to 1 to use the diurnal slope wind parameterization inputs
+    const int stabilityFlag = 0; //set to 1 to use the stability wind parameterization inputs. NOT to be used with a momentum solver run.
     const double height = 10.0;
     const char * heightUnits = "m";
     const char * speedUnits = "mps";
     bool momentumFlag = 0; //we're using the conservation of mass solver
-    unsigned int numNinjas = 2; //two ninjas in the ninjaArmy
-    
-    /* Size must match the number of ninjas */
-    int size = numNinjas;
-    int year[2] = {2024, 2024}; 
-    int month[2] = {2, 2};
-    int day[2] = {2, 2};
-    int hour[2] = {2, 2};
-    int minute[2] = {2, 2};
-    char* station_path = "data/WXSTATION"; // will need to run fetch test to get wxstation data
-    char* demFile = "data/missoula_valley.tif";
-    char* osTimeZone = "UTC";
-    bool matchPointFlag = 1;
+    ////bool momentumFlag = 1; //we're using the conservation of momentum solver. NOTE: CANNOT DO POINT INITIALIZATION WITH A MOMENTUM SOLVER RUN.
+    ////unsigned int numNinjas = 2; //two ninjas in the ninjaArmy - this will eventually be equal to the number of times in the timeList to be run on the set of station files
 
-    /* 
-     * Create the army
+    //const int nIters = -1.0;  //set to value > 0.0 to override the default value of 1000. Used only by the conservation of momentum solver.
+    const int nIters = 300;  // the cli and the GUI use a value of 300 instead of the default value of 1000.
+
+    const double meshResolution = -1.0;  //set to value > 0.0 to override meshChoice with meshResolution value. Used only by the conservation of momentum solver.
+    //const double meshResolution = 300.0;
+    const char * meshResolutionUnits = "m";
+
+    /* timeListSize is technically used instead of the number of ninjas */
+    /* but timeListSize is technically used more like a numTimeSteps, it can be less than or equal to the size of the time arrays */
+    //int timeListSize = numNinjas;
+    int timeListSize = 2;
+    //int timeListSize = 1;  // make sure to only use 1 if doing latestTime data, or it tries to converge on some kind of NO_DATA situation or something.
+    //// the fetched data times, hrm the run seems to be way stricter than the fetch for building the times
+    //int year[2] = {2024, 2024};
+    //int month[2] = {2, 2};
+    //int day[2] = {2, 2};
+    //int hour[2] = {2, 2};  // local time
+    ////int hour[2] = {8, 8};  // UTC time
+    //int minute[2] = {0, 59};
+    //// the /windninja/data/ times
+    int year[2] = {2018, 2018};
+    int month[2] = {6, 6};
+    //int day[2] = {20, 21};  // local time
+    //int hour[2] = {21, 21};  // local time
+    int day[2] = {21, 22}; // UTC time
+    int hour[2] = {3, 3};  // UTC time
+    int minute[2] = {28, 28};
+    ////// will need to run fetch test to get wxstation data, or grab the data from the windninja/data folder (that seems easier)
+    //// hrm, doesn't seem to like the station location files, like the cli does
+    ////int numStationFiles = 1;
+    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/missoula_valley_stations_6.csv.csv"};  // latestTime
+    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/missoula_valley_stations_6.csv.csv"};  // timeSeries
+    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/missoula_valley_stations_4.csv"};  // timeSeries
+    ////const char* station_paths[1] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/missoula_valley_stations_4.csv"};  // latestTime
+    int numStationFiles = 4;
+    const char* station_paths[4] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/KMSO-MDT-2018-06-20_2128-2018-06-21_2128-0.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TS934-MDT-2018-06-20_2128-2018-06-21_2128-1.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/PNTM8-MDT-2018-06-20_2128-2018-06-21_2128-2.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-MDT-2018-06-20-2128-2018-06-21-2128-missoula_valley/TR266-MDT-2018-06-20_2128-2018-06-21_2128-3.csv"};  // timeSeries
+    //const char* station_paths[4] = {"/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/KMSO-2018-06-25_1237-0.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/TS934-2018-06-25_1237-1.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/PNTM8-2018-06-25_1237-2.csv", "/home/atw09001/src/wind/windninja/data/WXSTATIONS-2018-06-25-1237-missoula_valley/TR266-2018-06-25_1237-3.csv"};  // latestTime
+    // the fetched data
+    //int numStationFiles = 6;
+    //const char* station_paths[6] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/KMSO-2026-04-29_1331-0.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/BLMM8-2026-04-29_1331-1.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/PNTM8-2026-04-29_1331-2.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/FINM8-2026-04-29_1331-3.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/NINM8-2026-04-29_1331-4.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2026-04-29-1331-missoula_valley/TT350-2026-04-29_1331-5.csv"};  // latestTime
+    //const char* station_paths[6] = {"/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/KMSO-2024-02-02_0202-2024-02-02_0202-0.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/BLMM8-2024-02-02_0202-2024-02-02_0202-1.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/PNTM8-2024-02-02_0202-2024-02-02_0202-2.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/FINM8-2024-02-02_0202-2024-02-02_0202-3.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/NINM8-2024-02-02_0202-2024-02-02_0202-4.csv", "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/WXSTATIONS-2024-02-02-0202-2024-02-02-0202-missoula_valley/MOMM8-2024-02-02_0202-2024-02-02_0202-5.csv"};  // timeSeries
+    char* demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    //char* osTimeZone = "UTC";
+    char* osTimeZone = "America/Denver";
+    bool matchPointsFlag = 1;  // needed to match the station data, or else you only get a domainAverageRun of the initial wind field constructed from the station data
+
+    /*
+     * Initialize the army
      */
-    ninjaArmy = NinjaMakePointArmy(year, month, day, hour, minute, size, osTimeZone, station_path, demFile, matchPointFlag, momentumFlag, papszOptions);
+    ninjaArmy = NinjaInitializeArmy();
     if( NULL == ninjaArmy )
     {
-        printf("NinjaCreateArmy: ninjaArmy = NULL\n");
+        printf("NinjaInitializeArmy: ninjaArmy = NULL\n");
     }
-    
-    /* 
+
+    /*
+     * Customize the ninja communication
+     */
+    err = NinjaSetArmyMultiComStream(ninjaArmy, multiStream, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaSetArmyMultiComStream: err = %d\n", err);
+    }
+
+    /*
+     * Make the army
+     */
+    err = NinjaMakePointArmy(ninjaArmy, year, month, day, hour, minute, timeListSize, osTimeZone, station_paths, numStationFiles, demFile, matchPointsFlag, momentumFlag, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaMakePointArmy: err = %d\n", err);
+    }
+
+    /*
      * Prepare the army
      */
-    for(unsigned int i=0; i<numNinjas; i++)
+    for(unsigned int i=0; i<timeListSize; i++)
     {
-        err = NinjaSetCommunication(ninjaArmy, i, comType, papszOptions);
-        if(err != NINJA_SUCCESS)
-        {
-          printf("NinjaSetCommunication: err = %d\n", err);
-        }
-     
+        /*
+        * Sets Simulation Variables
+        */
         err = NinjaSetNumberCPUs(ninjaArmy, i, nCPUs, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetNumberCPUs: err = %d\n", err);
         }
-     
-        err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, papszOptions);
+
+        err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, matchPointsFlag, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetInitializationMethod: err = %d\n", err);
@@ -141,19 +201,45 @@ int main()
         {
           printf("NinjaSetDiurnalWinds: err = %d\n", err);
         }
-     
+
+        err = NinjaSetStabilityFlag(ninjaArmy, i, stabilityFlag, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+          printf("NinjaSetStabilityFlag: err = %d\n", err);
+        }
+
         err = NinjaSetUniVegetation(ninjaArmy, i, vegetation, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetUniVegetation: err = %d\n", err);
         }
-     
-        err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
-        if(err != NINJA_SUCCESS)
+
+        if(nIters > 0.0)
         {
-            printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+          err = NinjaSetNumberOfIterations(ninjaArmy, i, nIters, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetNumberOfIterations: err = %d\n", err);
+          }
         }
-     
+
+        if(meshResolution > 0.0)
+        {
+          err = NinjaSetMeshResolution(ninjaArmy, i, meshResolution, meshResolutionUnits, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetMeshResolution: err = %d\n", err);
+          }
+        }
+        else  // meshResolution not set, use meshChoice
+        {
+          err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+          }
+        }
+
         err = NinjaSetNumVertLayers(ninjaArmy, i, nLayers, papszOptions);
         if(err != NINJA_SUCCESS)
         {
@@ -161,7 +247,7 @@ int main()
         }
     }
 
-    /* 
+    /*
      * Start the simulations
      */
     err = NinjaStartRuns(ninjaArmy, nCPUs, papszOptions);
@@ -169,8 +255,8 @@ int main()
     {
         printf("NinjaStartRuns: err = %d\n", err);
     }
-    
-    /* 
+
+    /*
      * Clean up
      */
     err = NinjaDestroyArmy(ninjaArmy, papszOptions);
@@ -178,6 +264,21 @@ int main()
     {
         printf("NinjaDestroyRuns: err = %d\n", err);
     }
- 
+
+    if(multiStream != NULL)
+    {
+        if(fclose(multiStream) != 0)
+        {
+            printf("error closing log file\n");
+        }
+    }
+
+    // must be called to cleanup ninjaInit();
+    err = NinjaFinalize(papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFinalize: err = %d\n", err);
+    }
+
     return NINJA_SUCCESS;
 }

--- a/autotest/api/test_capi_weather_model_initialization_wind.c
+++ b/autotest/api/test_capi_weather_model_initialization_wind.c
@@ -30,77 +30,113 @@
 #include <stdio.h> //for printf
 #include <stdbool.h>
 
-
-
 int main()
 {
-    /* 
+    /*
      * Setting up the simulation
      */
-    NinjaArmyH* ninjaArmy = NULL; 
-    const char * comType = "cli"; //communication type is always set to "cli"
+    NinjaArmyH* ninjaArmy = NULL;
     const int nCPUs = 1;
+    const char * runType = "C-API autotest";
     char ** papszOptions = NULL;
     NinjaErr err = 0; 
-    err = NinjaInit(papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
+    err = NinjaInit(runType, papszOptions); //initialize global singletons and environments (GDAL_DATA, etc.)
     if(err != NINJA_SUCCESS)
     {
-      printf("NinjaInit: err = %d\n", err);
+        printf("NinjaInit: err = %d\n", err);
     }
 
-    /* 
-     * Set up Weather Model Initialization run 
+    /*
+     * Setting up a log file, for ninjaCom, if desired
      */
-    const char * demFile = "/data/missoula_valley.tif"; 
-    //double outputResolution = 100; 
+    FILE* multiStream = NULL;
+    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    if(multiStream == NULL)
+    {
+        printf("error opening log file\n");
+    }
+
+    /*
+     * Set up Weather Model Initialization run
+     */
+    //const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
+    const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMBBox.tif";
     const char * initializationMethod = "wxmodel";
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
     const int nLayers = 20; //layers in the mesh
-    const int diurnalFlag = 0; //diurnal slope wind parameterization not used
+    const int diurnalFlag = 0; //set to 1 to use the diurnal slope wind parameterization inputs
+    const int stabilityFlag = 0; //set to 1 to use the stability wind parameterization inputs. NOT to be used with a momentum solver run.
     const double height = 10.0;
     const char * heightUnits = "m";
     bool momentumFlag = 0; //we're using the conservation of mass solver
-    unsigned int numNinjas = 2; //two ninjas in the ninjaArmy - this will eventually be equal to the number of weather stations files
-    
+    //bool momentumFlag = 1; //we're using the conservation of momentum solver
+    ////unsigned int numNinjas = 2; //two ninjas in the ninjaArmy - this will eventually be equal to the number of times in the weather stations files
+
+    //const int nIters = -1.0;  //set to value > 0.0 to override the default value of 1000. Used only by the conservation of momentum solver.
+    const int nIters = 300;  // the cli and the GUI use a value of 300 instead of the default value of 1000.
+
+    const double meshResolution = -1.0;  //set to value > 0.0 to override meshChoice with meshResolution value. Used only by the conservation of momentum solver.
+    //const double meshResolution = 300.0;
+    const char * meshResolutionUnits = "m";
+
     /* inputs that can vary among ninjas in an army */
     const char * speedUnits = "mps";
 
-    /* 
-     * Create the army
+    /* timeListSize is technically used instead of the number of ninjas */
+    //// will need to run fetch test to get wxstation data, there is no predownloaded data in the windninja/data folder for this case
+    const char * forecast = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/NOMADS-HRRR-CONUS-3-KM-DEMBBox.tif/20260429T2000/20260429T2000.zip";
+    int timeListSize = 1;
+    ////const char* inputTimeList[1] = {"20260429T2000"};  // apparently wrong format
+    const char* inputTimeList[1] = {"2026-Apr-29 14:00:00 MDT"};
+
+    //const char * osTimeZone = "UTC";
+    const char * osTimeZone = "America/Denver";
+
+    bool matchedPoints = true;  // for point initialization, but currently required as an input to SetInitializationMethod(). Should the match points pointInitialization algorythm be run, or should it just run as a domainAvgRun on the input wind field. ALWAYS set to true unless you know what you are doing.
+
+    /*
+     * Initialize the army
      */
-    const char * forecast = "/data/NOMADS-HRRR-CONUS-3-KM-missoula_valley.tif/20250310T1400/20250310T1400.zip"; // should run fetch test to get data
-    const char * osTimeZone = "UTC";
-    ninjaArmy = NinjaMakeWeatherModelArmy(forecast, osTimeZone, momentumFlag, papszOptions);
+    ninjaArmy = NinjaInitializeArmy();
     if( NULL == ninjaArmy )
     {
-        printf("NinjaCreateArmy: ninjaArmy = NULL\n");
+        printf("NinjaInitializeArmy: ninjaArmy = NULL\n");
     }
 
-    err = NinjaInit(papszOptions); //must be called for any simulation
+    /*
+     * Customize the ninja communication
+     */
+    err = NinjaSetArmyMultiComStream(ninjaArmy, multiStream, papszOptions);
     if(err != NINJA_SUCCESS)
     {
-      printf("NinjaInit: err = %d\n", err);
+        printf("NinjaSetArmyMultiComStream: err = %d\n", err);
     }
-    
-    /* 
+
+    /*
+     * Make the army
+     */
+    err = NinjaMakeWeatherModelArmy(ninjaArmy, forecast, osTimeZone, inputTimeList, timeListSize, momentumFlag, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaMakeWeatherModelArmy: err = %d\n", err);
+    }
+
+    /*
      * Prepare the army
      */
-    for(unsigned int i=0; i<numNinjas; i++)
+    for(unsigned int i=0; i<timeListSize; i++)
     {
-        err = NinjaSetCommunication(ninjaArmy, i, comType, papszOptions);
-        if(err != NINJA_SUCCESS)
-        {
-          printf("NinjaSetCommunication: err = %d\n", err);
-        }
-     
+        /*
+        * Sets Simulation Variables
+        */
         err = NinjaSetNumberCPUs(ninjaArmy, i, nCPUs, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetNumberCPUs: err = %d\n", err);
         }
      
-        err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, papszOptions);
+        err = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, matchedPoints, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetInitializationMethod: err = %d\n", err);
@@ -135,25 +171,51 @@ int main()
         {
           printf("NinjaSetOutputSpeedUnits: err = %d\n", err);
         }
-     
+
         err = NinjaSetDiurnalWinds(ninjaArmy, i, diurnalFlag, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetDiurnalWinds: err = %d\n", err);
         }
-     
+
+        err = NinjaSetStabilityFlag(ninjaArmy, i, stabilityFlag, papszOptions);
+        if(err != NINJA_SUCCESS)
+        {
+          printf("NinjaSetStabilityFlag: err = %d\n", err);
+        }
+
         err = NinjaSetUniVegetation(ninjaArmy, i, vegetation, papszOptions);
         if(err != NINJA_SUCCESS)
         {
           printf("NinjaSetUniVegetation: err = %d\n", err);
         }
-     
-        err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
-        if(err != NINJA_SUCCESS)
+
+        if(nIters > 0.0)
         {
-            printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+          err = NinjaSetNumberOfIterations(ninjaArmy, i, nIters, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetNumberOfIterations: err = %d\n", err);
+          }
         }
-     
+
+        if(meshResolution > 0.0)
+        {
+          err = NinjaSetMeshResolution(ninjaArmy, i, meshResolution, meshResolutionUnits, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetMeshResolution: err = %d\n", err);
+          }
+        }
+        else  // meshResolution not set, use meshChoice
+        {
+          err = NinjaSetMeshResolutionChoice(ninjaArmy, i, meshChoice, papszOptions);
+          if(err != NINJA_SUCCESS)
+          {
+            printf("NinjaSetMeshResolutionChoice: err = %d\n", err);
+          }
+        }
+
         err = NinjaSetNumVertLayers(ninjaArmy, i, nLayers, papszOptions);
         if(err != NINJA_SUCCESS)
         {
@@ -161,7 +223,7 @@ int main()
         }
     }
 
-    /* 
+    /*
      * Start the simulations
      */
     err = NinjaStartRuns(ninjaArmy, nCPUs, papszOptions);
@@ -170,13 +232,14 @@ int main()
         printf("NinjaStartRuns: err = %d\n", err);
     }
 
-    /* 
+    /*
      * Get the outputs
      */
     const double* outputSpeedGrid = NULL;
     const double* outputDirectionGrid = NULL;
     const char* outputGridProjection = NULL;
     const int nIndex = 0;
+
     outputSpeedGrid = NinjaGetOutputSpeedGrid(ninjaArmy, nIndex, papszOptions);
     if( NULL == outputSpeedGrid )
     {
@@ -194,8 +257,8 @@ int main()
     {
         printf("Error in NinjaGetOutputGridProjection");
     }
-    
-    /* 
+
+    /*
      * Clean up
      */
     err = NinjaDestroyArmy(ninjaArmy, papszOptions);
@@ -203,6 +266,21 @@ int main()
     {
         printf("NinjaDestroyRuns: err = %d\n", err);
     }
- 
+
+    if(multiStream != NULL)
+    {
+        if(fclose(multiStream) != 0)
+        {
+            printf("error closing log file\n");
+        }
+    }
+
+    // must be called to cleanup ninjaInit();
+    err = NinjaFinalize(papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaFinalize: err = %d\n", err);
+    }
+
     return NINJA_SUCCESS;
 }

--- a/autotest/api/test_capi_weather_model_initialization_wind.c
+++ b/autotest/api/test_capi_weather_model_initialization_wind.c
@@ -27,8 +27,10 @@
  *
  *****************************************************************************/
 #include "windninja.h"
-#include <stdio.h> //for printf
+#include <stdio.h> //for printf, FILE, fopen, fclose
 #include <stdbool.h>
+
+#define MAX_PATH_LEN 512
 
 int main()
 {
@@ -46,11 +48,16 @@ int main()
         printf("NinjaInit: err = %d\n", err);
     }
 
+    // manually set your wnDataPath (makes it easier for setting paths and testing)
+    // must replace the "~/" part with your exact path
+    const char* wnDataPath = "~/src/wind/windninja/data";
+
     /*
      * Setting up a log file, for ninjaCom, if desired
      */
-    FILE* multiStream = NULL;
-    multiStream = fopen("/home/atw09001/src/wind/windninja/autotest/api/data/ninja.log", "w+");
+    char multiStreamFilename[MAX_PATH_LEN];
+    snprintf(multiStreamFilename, sizeof(multiStreamFilename), "%s%s", wnDataPath, "/../autotest/api/data/ninja.log");
+    FILE* multiStream = fopen(multiStreamFilename, "w+");
     if(multiStream == NULL)
     {
         printf("error opening log file\n");
@@ -59,8 +66,9 @@ int main()
     /*
      * Set up Weather Model Initialization run
      */
-    //const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/missoula_valley.tif";
-    const char * demFile = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/DEMBBox.tif";
+    char demFile[MAX_PATH_LEN];
+    //snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/missoula_valley.tif");
+    snprintf(demFile, sizeof(demFile), "%s%s", wnDataPath, "/../autotest/api/data/fetch/DEMBBox.tif");
     const char * initializationMethod = "wxmodel";
     const char * meshChoice = "coarse";
     const char * vegetation = "grass";
@@ -85,10 +93,13 @@ int main()
 
     /* timeListSize is technically used instead of the number of ninjas */
     //// will need to run fetch test to get wxstation data, there is no predownloaded data in the windninja/data folder for this case
-    const char * forecast = "/home/atw09001/src/wind/windninja/autotest/api/data/fetch/NOMADS-HRRR-CONUS-3-KM-DEMBBox.tif/20260429T2000/20260429T2000.zip";
+    /// so update the folder path accordingly for the fresh data.
+    /// will have to update the time list accordingly as well.
+    char forecast[MAX_PATH_LEN];
+    snprintf(forecast, sizeof(forecast), "%s%s", wnDataPath, "/../autotest/api/data/fetch/NOMADS-HRRR-CONUS-3-KM-DEMBBox.tif/20260504T2000/20260504T2000.zip");
     int timeListSize = 1;
-    ////const char* inputTimeList[1] = {"20260429T2000"};  // apparently wrong format
-    const char* inputTimeList[1] = {"2026-Apr-29 14:00:00 MDT"};
+    ////const char* inputTimeList[1] = {"20260504T2000"};  // apparently wrong format
+    const char* inputTimeList[1] = {"2026-May-04 14:00:00 MDT"};  // convert from UTC to MDT, 6 hrs back
 
     //const char * osTimeZone = "UTC";
     const char * osTimeZone = "America/Denver";

--- a/autotest/api/test_capi_weather_model_initialization_wind.c
+++ b/autotest/api/test_capi_weather_model_initialization_wind.c
@@ -88,21 +88,61 @@ int main()
     //const double meshResolution = 300.0;
     const char * meshResolutionUnits = "m";
 
+    //const char * osTimeZone = "UTC";
+    const char * osTimeZone = "America/Denver";
+
     /* inputs that can vary among ninjas in an army */
     const char * speedUnits = "mps";
 
+
     /* timeListSize is technically used instead of the number of ninjas */
-    //// will need to run fetch test to get wxstation data, there is no predownloaded data in the windninja/data folder for this case
+    //// will need to run test_capi_fetching.c to get wxstation data, there is no predownloaded data in the windninja/data folder for this case
     /// so update the folder path accordingly for the fresh data.
     /// will have to update the time list accordingly as well.
     char forecast[MAX_PATH_LEN];
-    snprintf(forecast, sizeof(forecast), "%s%s", wnDataPath, "/../autotest/api/data/fetch/NOMADS-HRRR-CONUS-3-KM-DEMBBox.tif/20260504T2000/20260504T2000.zip");
-    int timeListSize = 1;
-    ////const char* inputTimeList[1] = {"20260504T2000"};  // apparently wrong format
-    const char* inputTimeList[1] = {"2026-May-04 14:00:00 MDT"};  // convert from UTC to MDT, 6 hrs back
+    snprintf(forecast, sizeof(forecast), "%s%s", wnDataPath, "/../autotest/api/data/fetch/NOMADS-HRRR-CONUS-3-KM-DEMBBox.tif/20260504T2300/20260504T2300.zip");
+    //snprintf(forecast, sizeof(forecast), "%s%s", wnDataPath, "/../autotest/api/data/fetch/PASTCAST-GCP-HRRR-CONUS-3-KM-DEMBBox.tif/20240202T0200/20240202T0200.zip");
 
-    //const char * osTimeZone = "UTC";
-    const char * osTimeZone = "America/Denver";
+    /*//// manually set a time from the file (needs updated each time)
+    int timeListSize = 1;
+    ////const char* inputTimeList[1] = {"20260504T2300"};  // apparently wrong format
+    const char* inputTimeList[1] = {"2026-May-04 17:00:00 MDT"};  // convert from UTC to MDT, 6 hrs back*/
+
+    //// or get the full time list read from the file, and pick indices
+    //// yeah, picking indices can be a pain without printing out the list, making a new list from specific times is also a pain
+    //// so this is meant more to just use the whole time list, with a debug option to print out the full list
+    //// this involves setting up a ninjaTools instance
+    // Initialize ninjaTools
+    NinjaToolsH* ninjaTools = NinjaMakeTools();
+    // Customize the ninja communication
+    err = NinjaSetToolsMultiComStream(ninjaTools, multiStream, papszOptions);
+    if(err != NINJA_SUCCESS)
+    {
+        printf("NinjaSetToolsMultiComStream: err = %d\n", err);
+    }
+    // now get the list of times
+    int timeListSize = 0;
+    const char **inputTimeList = NinjaGetWeatherModelTimeList(ninjaTools, &timeListSize, forecast, osTimeZone);
+    if(inputTimeList == NULL)
+    {
+        printf("NinjaGetWeatherModelTimeList: Failed to fill timeList\n");
+    }
+    if(timeListSize == 0)
+    {
+        printf("NinjaGetWeatherModelTimeList: returned empty timeList\n");
+    }
+    for(unsigned int i = 0; i < timeListSize; i++)
+    {
+        printf("timeList[%d] = '%s'\n", i, inputTimeList[i]);
+    }
+    // not yet needed/implemented in the code, but it should be.
+    // if ninjaTools was used/generated, clean it up afterwards
+    //err = NinjaDestroyTools(ninjaTools, papszOptions);
+    //if(err != NINJA_SUCCESS)
+    //{
+    //    printf("NinjaDestroyTools: err = %d\n", ninjaErr);
+    //}
+
 
     bool matchedPoints = true;  // for point initialization, but currently required as an input to SetInitializationMethod(). Should the match points pointInitialization algorythm be run, or should it just run as a domainAvgRun on the input wind field. ALWAYS set to true unless you know what you are doing.
 

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -528,9 +528,6 @@ void MainWindow::solveButtonClicked()
             {
                 ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), papszOptions);
             }
-            //ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, -1, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeDomainAverageArmy() single messaging error, instead of the double messaging makeDomainAverageArmy() error.
-            //ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, 0, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), DEMTimeZone.toUtf8().data(), airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeDomainAverageArmy() single messaging error, instead of the double messaging makeDomainAverageArmy() error.
-            //ninjaErr = NinjaMakeDomainAverageArmy(ninjaArmy, numNinjas, momentumFlag, speeds.data(), speedUnits.toUtf8().constData(), directions.data(), years.data(), months.data(), days.data(), hours.data(), minutes.data(), "fudge", airTemps.data(), airTempUnits.toUtf8().constData(), cloudCovers.data(), cloudCoverUnits.toUtf8().constData(), papszOptions);  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h, but then catches error as expected, well it technically throws two separate error messages, but both are caught properly
             if(ninjaErr != NINJA_SUCCESS)
             {
                 qDebug() << "NinjaMakeDomainAverageArmy: ninjaErr =" << ninjaErr;
@@ -579,59 +576,7 @@ void MainWindow::solveButtonClicked()
             QVector<int> hour   = { start.time().hour(),   end.time().hour() };
             QVector<int> minute = { start.time().minute(), end.time().minute() };
 
-            // runs fine for the single time run, as expected,
-            // and, errors and is properly caught for the multi-time run
-            /*QVector<int> year   = {start.date().year(),   start.date().year()};
-            QVector<int> month  = {start.date().month(),  start.date().month()};
-            QVector<int> day    = {start.date().day(),    start.date().day()};
-            QVector<int> hour   = {start.time().hour(),   start.time().hour()};
-            QVector<int> minute = {start.time().minute(), start.time().minute()};*/
-
-            // runs fine for the single time run, as expected,
-            // and, errors and is properly caught for the multi-time run
-            /*QVector<int> year   = {end.date().year(),   end.date().year()};
-            QVector<int> month  = {end.date().month(),  end.date().month()};
-            QVector<int> day    = {end.date().day(),    end.date().day()};
-            QVector<int> hour   = {end.time().hour(),   end.time().hour()};
-            QVector<int> minute = {end.time().minute(), end.time().minute()};*/
-
-            // runs fine for the single time run, as expected,
-            // and, errors and is properly caught for the multi-time run
-            /*QVector<int> year   = {start.date().year(),   start.date().year()-1};
-            QVector<int> month  = {start.date().month(),  start.date().month()};
-            QVector<int> day    = {start.date().day(),    start.date().day()};
-            QVector<int> hour   = {start.time().hour(),   start.time().hour()};
-            QVector<int> minute = {start.time().minute(), start.time().minute()};*/
-
-            // runs fine for the single time run, as expected,
-            // and, errors and is properly caught for the multi-time run
-            //  which is interesting because the download without an additional hour time difference should also error but does not always error,
-            //  so this implies the time checking for the run from this, is more strict, and better
-            /*QVector<int> year   = {start.date().year(),   start.date().year()};
-            QVector<int> month  = {start.date().month(),  start.date().month()};
-            QVector<int> day    = {start.date().day(),    start.date().day()};
-            QVector<int> hour   = {start.time().hour(),   start.time().hour()-1};
-            QVector<int> minute = {start.time().minute(), start.time().minute()};*/
-
-            // errors for both the single time run AND the multi-time run,
-            // and errors are properly caught for both cases
-            /*QVector<int> year   = {end.date().year()+1,   end.date().year()};
-            QVector<int> month  = {end.date().month(),  end.date().month()};
-            QVector<int> day    = {end.date().day(),    end.date().day()};
-            QVector<int> hour   = {end.time().hour(),   end.time().hour()};
-            QVector<int> minute = {end.time().minute(), end.time().minute()};*/
-
-            // errors for both the single time run AND the multi-time run,
-            // and errors are properly caught for both cases
-            /*QVector<int> year   = {end.date().year(),   end.date().year()};
-            QVector<int> month  = {end.date().month(),  end.date().month()};
-            QVector<int> day    = {end.date().day(),    end.date().day()};
-            QVector<int> hour   = {end.time().hour()+1,   end.time().hour()};
-            QVector<int> minute = {end.time().minute(), end.time().minute()};*/
-
             int nTimeSteps = ui->weatherStationDataTimestepsSpinBox->value();
-            //int nTimeSteps = 1;  // runs fine for the single time, properly throws an error for multi-times, well the error implies out of index but maybe not at the proper step ("NinjaSetNumberCPUS", "Run 0: ERROR: Exception caught: invalid index 1". But the error is at least properly caught.
-            //int nTimeSteps = 2;   // runs fine for 2 timestep multi-times, but for 1 timestep multi-times, an error is getting thrown, but apparently the solver isn't stopping because it is an error on just one single thread???? Quirky behavior that is not good. "ERROR 4: : No such file or directory, Run 1: ERROR: Exception caught: Cannot open input file for reading in ninja::readInputFile()." but then it continues with the run0 info to completion, then it ends hanging because it didn't stop at the error message and it finds it DID have some kind of error at the end. Ugh. I do see that it printed red, so it SAW that it was an error message, but I guess it wasn't a THROWN error message or something? So it didn't properly stop the solver?? Not sure what is going on here.
 
             QVector<int> outYear(nTimeSteps);
             QVector<int> outMonth(nTimeSteps);
@@ -657,12 +602,6 @@ void MainWindow::solveButtonClicked()
                     timeZoneBytes.constData(),
                     &endYear, &endMonth, &endDay, &endHour, &endMinute
                     );
-                //ninjaErr = NinjaGenerateSingleTimeObject(
-                //    ninjaTools,
-                //    startYear, startMonth, startDay, startHour, startMinute,
-                //    "fudge",
-                //    &endYear, &endMonth, &endDay, &endHour, &endMinute
-                //    );  // breaks HARD, a smart pointer failing on assert somewhere along the pipeline, not sure if that occurs here, or later down the pipeline. And it gets past the try/catch error handling stuff, hrm.
                 if(ninjaErr != NINJA_SUCCESS)
                 {
                     qDebug() << "NinjaGenerateSingleTimeObject: ninjaErr =" << ninjaErr;
@@ -686,22 +625,6 @@ void MainWindow::solveButtonClicked()
                     outHour.data(), outMinute.data(),
                     nTimeSteps, timeZoneBytes.data()
                 );
-                //ninjaErr = NinjaGetTimeList(
-                //    ninjaTools,
-                //    year.data(), month.data(), day.data(),
-                //    hour.data(), minute.data(),
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(),
-                //    1, timeZoneBytes.data()
-                //    );  // catches error as expected, though month or date out of range wasn't quite the error I was expecting
-                //ninjaErr = NinjaGetTimeList(
-                //    ninjaTools,
-                //    year.data(), month.data(), day.data(),
-                //    hour.data(), minute.data(),
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(),
-                //    nTimeSteps, "fudge"
-                //    );  // breaks HARD, a smart pointer failing on assert somewhere along the pipeline, not sure if that occurs here, or later down the pipeline. And it gets past the try/catch error handling stuff, hrm.
                 if(ninjaErr != NINJA_SUCCESS)
                 {
                     qDebug() << "NinjaGetTimeList: ninjaErr =" << ninjaErr;
@@ -721,55 +644,6 @@ void MainWindow::solveButtonClicked()
                     stationFileNames.size(), DEMPath.toUtf8().data(),
                     true, momentumFlag, papszOptions
                     );
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), -1,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    stationFileNames.size(), DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //    );  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error, and instead of the single unexpected month or date out of range error that was seen for this case.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), 0,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    stationFileNames.size(), DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //    );  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    -1, DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //    );  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    0, DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //    );  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    stationFileNames.size(), "fudge",
-                //    true, momentumFlag, papszOptions
-                //    );  // um, it warns that the dem doesn't exist, but then continues on without throwing an error or a ninjaCom, so the solver continues as if everything is normal. The warning is "ERROR 4: fudge: No such file or directory" four times, yet still it continues as if nothing went wrong.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), nTimeSteps,
-                //    "fudge", stationFileNames.data(),
-                //    stationFileNames.size(), DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //    );  // no error or warning messages are thrown, just runs as if the dem timezone is good enough
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    outYear.data(), outMonth.data(), outDay.data(),
-                //    outHour.data(), outMinute.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(), stationFileNames.data(),
-                //    stationFileNames.size(), DEMPath.toUtf8().data(),
-                //    true, true, papszOptions
-                //    );  // catches error as expected
                 if(ninjaErr != NINJA_SUCCESS)
                 {
                     qDebug() << "NinjaMakePointArmy: ninjaErr =" << ninjaErr;
@@ -799,25 +673,6 @@ void MainWindow::solveButtonClicked()
             hour = date.time().hour();
             minute = date.time().minute();
 
-            //year = -1;  // catches error as expected
-            //year = 0;  // catches error as expected
-            //year = 1235;  // catches error as expected
-            //year = 2035;  // um, apparently this one is an allowable year, it runs like normal without an error thrown, even though it probably shouldn't
-
-            //month = -1;  // catches error as expected
-            //month = 0;  // catches error as expected
-            //month = 14;  // catches error as expected
-
-            //day = -1;  // catches error as expected
-            //day = 0;  // catches error as expected
-            //day = 33;  // catches error as expected
-
-            //hour = -1;  // this one SHOULD error, but runs fine somehow, no errors thrown. Probably wraps around or sets it to a value of 0 or something.
-            //hour = 26;  // this one SHOULD error, but runs fine somehow, no errors thrown. Probably wraps around or sets it to a value of 0 or something.
-
-            //minute = -1;  // this one SHOULD error, but runs fine somehow, no errors thrown. Probably wraps around or sets it to a value of 0 or something.
-            //minute = 78;  // this one SHOULD error, but runs fine somehow, no errors thrown. Probably wraps around or sets it to a value of 0 or something.
-
             int outYear, outMonth, outDay, outHour, outMinute;
 
             ninjaErr = NinjaGenerateSingleTimeObject(
@@ -826,12 +681,6 @@ void MainWindow::solveButtonClicked()
                 timeZoneBytes.constData(),
                 &outYear, &outMonth, &outDay, &outHour, &outMinute
                 );
-            //ninjaErr = NinjaGenerateSingleTimeObject(
-            //    ninjaTools,
-            //    year, month, day, hour, minute,
-            //    "fudge",
-            //    &outYear, &outMonth, &outDay, &outHour, &outMinute
-            //    );  // breaks HARD, a smart pointer failing on assert somewhere along the pipeline, not sure if that occurs here, or later down the pipeline. And it gets past the try/catch error handling stuff, hrm.
             if (ninjaErr != NINJA_SUCCESS)
             {
                 qDebug() << "NinjaGenerateSingleTimeObject: ninjaErr =" << ninjaErr;
@@ -859,69 +708,6 @@ void MainWindow::solveButtonClicked()
                     DEMPath.toUtf8().data(),
                     true, momentumFlag, papszOptions
                 );
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), -1,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    static_cast<int>(stationFileNames.size()),
-                //    DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //);  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error, and instead of the single unexpected month or date out of range error that was seen for this case.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), 0,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    static_cast<int>(stationFileNames.size()),
-                //    DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //);  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    -1,
-                //    DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //);  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    0,
-                //    DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //);  // catches error as expected, now it triggers the NinjaMakePointArmy() single messaging error, instead of the double messaging makePointArmy() error.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    static_cast<int>(stationFileNames.size()),
-                //    "fudge",
-                //    true, momentumFlag, papszOptions
-                //);  // um, it warns that the dem doesn't exist, but then continues on without throwing an error or a ninjaCom, so the solver continues as if everything is normal. The warning is "ERROR 4: fudge: No such file or directory" four times, yet still it continues as if nothing went wrong.
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), nTimeSteps,
-                //    "fudge",
-                //    stationFileNames.data(),
-                //    static_cast<int>(stationFileNames.size()),
-                //    DEMPath.toUtf8().data(),
-                //    true, momentumFlag, papszOptions
-                //);  // no error or warning messages are thrown, just runs as if the dem timezone is good enough
-                //ninjaErr = NinjaMakePointArmy( ninjaArmy,
-                //    yearVec.data(), monthVec.data(), dayVec.data(),
-                //    hourVec.data(), minuteVec.data(), nTimeSteps,
-                //    DEMTimeZone.toUtf8().data(),
-                //    stationFileNames.data(),
-                //    static_cast<int>(stationFileNames.size()),
-                //    DEMPath.toUtf8().data(),
-                //    true, true, papszOptions
-                //);  // catches error as expected
                 if(ninjaErr != NINJA_SUCCESS)
                 {
                     qDebug() << "NinjaMakePointArmy ninjaErr =" << ninjaErr;
@@ -952,10 +738,6 @@ void MainWindow::solveButtonClicked()
         }
 
         ninjaErr = NinjaMakeWeatherModelArmy(ninjaArmy, filePath.c_str(), timeZone.c_str(), inputTimeList, timeListSize, ui->momentumSolverCheckBox->isChecked(), papszOptions);
-        //ninjaErr = NinjaMakeWeatherModelArmy(ninjaArmy, filePath.c_str(), timeZone.c_str(), inputTimeList, -1, ui->momentumSolverCheckBox->isChecked(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeWeatherModelArmy() single messaging error, instead of the double messaging makeWeatherArmy() error.  // need to make a better error check for this than to disallow an empty inputTimeList. Need to setup a check to compare inputTimeList size to the input timeListSize.
-        //ninjaErr = NinjaMakeWeatherModelArmy(ninjaArmy, filePath.c_str(), timeZone.c_str(), inputTimeList, 0, ui->momentumSolverCheckBox->isChecked(), papszOptions);  // catches error as expected, now it triggers the NinjaMakeWeatherModelArmy() single messaging error, instead of the double messaging makeWeatherArmy() error.  // need to make a better error check for this than to disallow an empty inputTimeList. Need to setup a check to compare inputTimeList size to the input timeListSize.
-        //ninjaErr = NinjaMakeWeatherModelArmy(ninjaArmy, "fudge", timeZone.c_str(), inputTimeList, timeListSize, ui->momentumSolverCheckBox->isChecked(), papszOptions);  // catches error as expected
-        //ninjaErr = NinjaMakeWeatherModelArmy(ninjaArmy, filePath.c_str(), "fudge", inputTimeList, timeListSize, ui->momentumSolverCheckBox->isChecked(), papszOptions);  // catches error as expected
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaMakeWeatherModelArmy ninjaErr =" << ninjaErr;
@@ -1128,7 +910,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
 
     char **papszOptions = nullptr;
 
-    // can this one even be tested?? The way it is organized also makes it tough to setup a ninjaCom message
     ninjaErr = NinjaSetAsciiAtmFile(ninjaArmy, ui->fireBehaviorResolutionCheckBox->isChecked(), papszOptions);
     if(ninjaErr != NINJA_SUCCESS)
     {
@@ -1149,12 +930,7 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
                 {
                     writeToConsole("Writing Weather Station .kml");
                 }
-                // function needs MAJOR rework to get the testing to work, direct call to non-ninjaArmy function makes this process tougher
                 ninjaErr = NinjaSetStationKML(ninjaArmy, i, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), ui->outputDirectoryLineEdit->text().toUtf8().constData(), ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);
-                //ninjaErr = NinjaSetStationKML(ninjaArmy, i+10, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), ui->outputDirectoryLineEdit->text().toUtf8().constData(), ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);  // test error handling  // function needs reorganized to handle this test
-                //ninjaErr = NinjaSetStationKML(ninjaArmy, i, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), ui->outputDirectoryLineEdit->text().toUtf8().constData(), "fudge", papszOptions);  // test error handling  // ran, but the functions need reorganized for proper messaging
-                //ninjaErr = NinjaSetStationKML(ninjaArmy, i, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), "fudge", ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);  // test error handling  // function needs reorganized to handle this test
-                //ninjaErr = NinjaSetStationKML(ninjaArmy, i, "fudge", ui->outputDirectoryLineEdit->text().toUtf8().constData(), ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);  // test error handling  // function needs reorganized to handle this test
                 if(ninjaErr != NINJA_SUCCESS)
                 {
                     printf("NinjaSetStationKML: ninjaErr = %d\n", ninjaErr);
@@ -1164,8 +940,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetNumberCPUs(ninjaArmy, i, ui->numberOfProcessorsSpinBox->value(), papszOptions);
-        //ninjaErr = NinjaSetNumberCPUs(ninjaArmy, i+10, ui->numberOfProcessorsSpinBox->value(), papszOptions);  // test error handling
-        //ninjaErr = NinjaSetNumberCPUs(ninjaArmy, i, -1, papszOptions);  // test error handling  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetNumberCPUs: ninjaErr =" << ninjaErr;
@@ -1173,8 +947,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetInitializationMethod(ninjaArmy, i, initializationMethod, ui->pointInitializationGroupBox->isChecked(), papszOptions);
-        //ninjaErr = NinjaSetInitializationMethod(ninjaArmy, i+10, initializationMethod, ui->pointInitializationGroupBox->isChecked(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-        //ninjaErr = NinjaSetInitializationMethod(ninjaArmy, i, "fudge", ui->pointInitializationGroupBox->isChecked(), papszOptions);  // test error handling
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetInitializationMethod: ninjaErr =" << ninjaErr;
@@ -1182,8 +954,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetDem(ninjaArmy, i, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), papszOptions);
-        //ninjaErr = NinjaSetDem(ninjaArmy, i+10, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), papszOptions);
-        //ninjaErr = NinjaSetDem(ninjaArmy, i, "fudge", papszOptions);  // test error handling  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetDem: ninjaErr =" << ninjaErr;
@@ -1200,8 +970,7 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
             }
         }
 
-        ninjaErr = NinjaSetPosition(ninjaArmy, i, papszOptions);  // if setting up ninja.cpp function call to simply throw, this breaks, this requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
-        //ninjaErr = NinjaSetPosition(ninjaArmy, i+10, papszOptions);  // test error handling
+        ninjaErr = NinjaSetPosition(ninjaArmy, i, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetPosition: ninjaErr =" << ninjaErr;
@@ -1209,9 +978,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetInputWindHeight(ninjaArmy, i, ui->inputWindHeightSpinBox->value(), ui->inputWindHeightUnitsComboBox->itemData(ui->inputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-        //ninjaErr = NinjaSetInputWindHeight(ninjaArmy, i+10, ui->inputWindHeightSpinBox->value(), ui->inputWindHeightUnitsComboBox->itemData(ui->inputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-        //ninjaErr = NinjaSetInputWindHeight(ninjaArmy, i, ui->inputWindHeightSpinBox->value(), "fudge", papszOptions);  // test error handling
-        //ninjaErr = NinjaSetInputWindHeight(ninjaArmy, i, -1, ui->inputWindHeightUnitsComboBox->itemData(ui->inputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetInputWindHeight: ninjaErr =" << ninjaErr;
@@ -1219,7 +985,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetDiurnalWinds(ninjaArmy, i, ui->diurnalCheckBox->isChecked(), papszOptions);
-        //ninjaErr = NinjaSetDiurnalWinds(ninjaArmy, i+10, ui->diurnalCheckBox->isChecked(), papszOptions);  // test error handling
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetDiurnalWinds: ninjaErr =" << ninjaErr;
@@ -1227,7 +992,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetStabilityFlag(ninjaArmy, i, ui->stabilityCheckBox->isChecked(), papszOptions);
-        //ninjaErr = NinjaSetStabilityFlag(ninjaArmy, i+10, ui->stabilityCheckBox->isChecked(), papszOptions);  // test error handling
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetStabilityFlag: ninjaErr =" << ninjaErr;
@@ -1237,8 +1001,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         if(ui->vegetationStackedWidget->currentIndex() == 0)
         {
             ninjaErr = NinjaSetUniVegetation(ninjaArmy, i, ui->vegetationComboBox->currentText().toLower().toUtf8().constData(), papszOptions);
-            //ninjaErr = NinjaSetUniVegetation(ninjaArmy, i+10, ui->vegetationComboBox->currentText().toLower().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-            //ninjaErr = NinjaSetUniVegetation(ninjaArmy, i, "fudge", papszOptions);  // test error handling
             if(ninjaErr != NINJA_SUCCESS)
             {
                 qDebug() << "NinjaSetUniVegetation: ninjaErr =" << ninjaErr;
@@ -1249,9 +1011,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         #ifdef NINJAFOAM
         // the cli and the GUI use a value of 300 instead of the default value of 1000.
         ninjaErr = NinjaSetNumberOfIterations(ninjaArmy, i, 300, papszOptions);
-        //ninjaErr = NinjaSetNumberOfIterations(ninjaArmy, i+10, 300, papszOptions);  // catches the error, as expected, but only when using the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
-        //ninjaErr = NinjaSetNumberOfIterations(ninjaArmy, i, -1, papszOptions);  // the code still needs a check against this, OpenFOAM itself is throwing the error right now, which is not an easy one to properly try/catch.
-        //ninjaErr = NinjaSetNumberOfIterations(ninjaArmy, i, 0, papszOptions);  // the code still needs a check against this, OpenFOAM itself is throwing the error right now, which is not an easy one to properly try/catch.
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetNumberOfIterations: ninjaErr =" << ninjaErr;
@@ -1270,8 +1029,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         } else
         {
             ninjaErr = NinjaSetMeshResolutionChoice(ninjaArmy, i, ui->meshResolutionComboBox->currentText().toLower().toUtf8().constData(), papszOptions);
-            //ninjaErr = NinjaSetMeshResolutionChoice(ninjaArmy, i+10, ui->meshResolutionComboBox->currentText().toLower().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-            //ninjaErr = NinjaSetMeshResolutionChoice(ninjaArmy, i, "fudge", papszOptions);  // test error handling
             if(ninjaErr != NINJA_SUCCESS)
             {
                 qDebug() << "NinjaSetMeshResolutionChoice: ninjaErr =" << ninjaErr;
@@ -1280,8 +1037,6 @@ bool MainWindow::prepareArmy(NinjaArmyH *ninjaArmy, int numNinjas, const char* i
         }
 
         ninjaErr = NinjaSetNumVertLayers(ninjaArmy, i, 20, papszOptions);
-        //ninjaErr = NinjaSetNumVertLayers(ninjaArmy, i+10, 20, papszOptions);  // test error handling
-        //ninjaErr = NinjaSetNumVertLayers(ninjaArmy, i, -1, papszOptions);  // test error handling  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
         if(ninjaErr != NINJA_SUCCESS)
         {
             qDebug() << "NinjaSetNumVertLayers: ninjaErr =" << ninjaErr;
@@ -1307,7 +1062,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     int ninjaErr;
 
     ninjaErr = NinjaSetOutputPath(ninjaArmy, i, ui->outputDirectoryLineEdit->text().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetOutputPath(ninjaArmy, i+10, ui->outputDirectoryLineEdit->text().toUtf8().constData(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetOutputPath: ninjaErr =" << ninjaErr;
@@ -1315,9 +1069,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetOutputWindHeight(ninjaArmy, i, ui->outputWindHeightSpinBox->value(), ui->outputWindHeightUnitsComboBox->itemData(ui->outputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetOutputWindHeight(ninjaArmy, i+10, ui->outputWindHeightSpinBox->value(), ui->outputWindHeightUnitsComboBox->itemData(ui->outputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetOutputWindHeight(ninjaArmy, i, ui->outputWindHeightSpinBox->value(), "fudge", papszOptions);  // test error handling
-    //ninjaErr = NinjaSetOutputWindHeight(ninjaArmy, i, -1, ui->outputWindHeightUnitsComboBox->itemData(ui->outputWindHeightUnitsComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetOutputWindHeight: ninjaErr =" << ninjaErr;
@@ -1325,8 +1076,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetOutputSpeedUnits(ninjaArmy, i, ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetOutputSpeedUnits(ninjaArmy, i+10, ui->outputSpeedUnitsComboBox->currentText().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetOutputSpeedUnits(ninjaArmy, i, "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetOutputSpeedUnits: ninjaErr =" << ninjaErr;
@@ -1334,9 +1083,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetOutputBufferClipping(ninjaArmy, i, ui->clipOutputSpinBox->value(), papszOptions);
-    //ninjaErr = NinjaSetOutputBufferClipping(ninjaArmy, i+10, ui->clipOutputSpinBox->value(), papszOptions);  // test error handling, looks good
-    //ninjaErr = NinjaSetOutputBufferClipping(ninjaArmy, i, -1, papszOptions);  // test error handling
-    //ninjaErr = NinjaSetOutputBufferClipping(ninjaArmy, i, 50, papszOptions);  // test error handling, message might need improved, but it IS an error, as it should be
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetOutputBufferClipping: ninjaErr =" << ninjaErr;
@@ -1344,7 +1090,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogOutFlag(ninjaArmy, i, ui->googleEarthCheckBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetGoogOutFlag(ninjaArmy, i+10, ui->googleEarthCheckBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogOutFlag: ninjaErr =" << ninjaErr;
@@ -1352,8 +1097,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogResolution(ninjaArmy, i, ui->googleEarthMeshResolutionSpinBox->value(), ui->googleEarthMeshResolutionComboBox->itemData(ui->googleEarthMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetGoogResolution(ninjaArmy, i+10, ui->googleEarthMeshResolutionSpinBox->value(), ui->googleEarthMeshResolutionComboBox->itemData(ui->googleEarthMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetGoogResolution(ninjaArmy, i, ui->googleEarthMeshResolutionSpinBox->value(), "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogResolution: ninjaErr =" << ninjaErr;
@@ -1361,8 +1104,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogSpeedScaling(ninjaArmy, i, ui->legendComboBox->itemData(ui->legendComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetGoogSpeedScaling(ninjaArmy, i+10, ui->legendComboBox->itemData(ui->legendComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetGoogSpeedScaling(ninjaArmy, i, "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogSpeedScaling: ninjaErr =" << ninjaErr;
@@ -1370,9 +1111,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogLineWidth(ninjaArmy, i, ui->googleEarthVectorsSpinBox->value(), papszOptions);
-    //ninjaErr = NinjaSetGoogLineWidth(ninjaArmy, i+10, ui->googleEarthVectorsSpinBox->value(), papszOptions);  // test error handling
-    //ninjaErr = NinjaSetGoogLineWidth(ninjaArmy, i, -1, papszOptions);  // test error handling  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h
-    //ninjaErr = NinjaSetGoogLineWidth(ninjaArmy, i, 101, papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogLineWidth: ninjaErr =" << ninjaErr;
@@ -1380,8 +1118,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogColor(ninjaArmy, i, ui->alternativeColorSchemeComboBox->itemData(ui->alternativeColorSchemeComboBox->currentIndex()).toString().toUtf8().constData(), ui->googleEarthVectorScalingCheckBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetGoogColor(ninjaArmy, i+10, ui->alternativeColorSchemeComboBox->itemData(ui->alternativeColorSchemeComboBox->currentIndex()).toString().toUtf8().constData(), ui->googleEarthVectorScalingCheckBox->isChecked(), papszOptions);  // test error handling
-    ////ninjaErr = NinjaSetGoogColor(ninjaArmy, i, "fudge", ui->googleEarthVectorScalingCheckBox->isChecked(), papszOptions);  // test error handling  // requires the try/catch form of IF_VALID_INDEX_TRY in ninjaArmy.h  // actually, the colorScheme string appears to not even be checked
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogColor: ninjaErr =" << ninjaErr;
@@ -1389,7 +1125,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetGoogConsistentColorScale(ninjaArmy, i, ui->legendCheckBox->isChecked(), numNinjas, papszOptions);
-    //ninjaErr = NinjaSetGoogConsistentColorScale(ninjaArmy, i+10, ui->legendCheckBox->isChecked(), numNinjas, papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetGoogConsistentColorScale: ninjaErr =" << ninjaErr;
@@ -1397,7 +1132,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetAsciiOutFlag(ninjaArmy, i, ui->fireBehaviorGroupBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetAsciiOutFlag(ninjaArmy, i+10, ui->fireBehaviorGroupBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetAsciiOutFlag: ninjaErr =" << ninjaErr;
@@ -1405,7 +1139,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetAsciiAaigridOutFlag(ninjaArmy, i, ui->fireBehaviorGroupBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetAsciiAaigridOutFlag(ninjaArmy, i+10, ui->fireBehaviorGroupBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetAsciiAaigridOutFlag: ninjaErr =" << ninjaErr;
@@ -1413,7 +1146,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetAsciiProjOutFlag(ninjaArmy, i, ui->fireBehaviorGroupBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetAsciiProjOutFlag(ninjaArmy, i+10, ui->fireBehaviorGroupBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetAsciiProjOutFlag: ninjaErr =" << ninjaErr;
@@ -1421,8 +1153,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetAsciiResolution(ninjaArmy, i, ui->fireBehaviorMeshResolutionSpinBox->value(), ui->fireBehaviorMeshResolutionComboBox->itemData(ui->fireBehaviorMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetAsciiResolution(ninjaArmy, i+10, ui->fireBehaviorMeshResolutionSpinBox->value(), ui->fireBehaviorMeshResolutionComboBox->itemData(ui->fireBehaviorMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetAsciiResolution(ninjaArmy, i, ui->fireBehaviorMeshResolutionSpinBox->value(), "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetAsciiResolution: ninjaErr =" << ninjaErr;
@@ -1430,7 +1160,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetShpOutFlag(ninjaArmy, i, ui->shapeFilesGroupBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetShpOutFlag(ninjaArmy, i+10, ui->shapeFilesGroupBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetShpOutFlag: ninjaErr =" << ninjaErr;
@@ -1438,8 +1167,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetShpResolution(ninjaArmy, i, ui->shapeFilesMeshResolutionSpinBox->value(), ui->shapeFilesMeshResolutionComboBox->itemData(ui->shapeFilesMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetShpResolution(ninjaArmy, i+10, ui->shapeFilesMeshResolutionSpinBox->value(), ui->shapeFilesMeshResolutionComboBox->itemData(ui->shapeFilesMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetShpResolution(ninjaArmy, i, ui->shapeFilesMeshResolutionSpinBox->value(), "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetShpResolution: ninjaErr =" << ninjaErr;
@@ -1447,7 +1174,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFOutFlag(ninjaArmy, i, ui->geospatialPDFFilesGroupBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetPDFOutFlag(ninjaArmy, i+10, ui->geospatialPDFFilesGroupBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFOutFlag: ninjaErr =" << ninjaErr;
@@ -1455,7 +1181,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFLineWidth(ninjaArmy, i, ui->geospatialPDFFilesVectorsSpinBox->value(), papszOptions);
-    //ninjaErr = NinjaSetPDFLineWidth(ninjaArmy, i+10, ui->geospatialPDFFilesVectorsSpinBox->value(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFLineWidth: ninjaErr =" << ninjaErr;
@@ -1463,7 +1188,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFBaseMap(ninjaArmy, i, ui->basemapComboBox->currentIndex(), papszOptions);
-    //ninjaErr = NinjaSetPDFBaseMap(ninjaArmy, i+10, ui->basemapComboBox->currentIndex(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFBaseMap: ninjaErr =" << ninjaErr;
@@ -1471,8 +1195,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFDEM(ninjaArmy, i, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetPDFDEM(ninjaArmy, i+10, ui->elevationInputFileLineEdit->property("fullpath").toString().toUtf8().constData(), papszOptions);  // test error handling
-    ////ninjaErr = NinjaSetPDFDEM(ninjaArmy, i, "fudge", papszOptions);  // test error handling  // the dem string is not even checked
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFDEM: ninjaErr =" << ninjaErr;
@@ -1480,7 +1202,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFSize(ninjaArmy, i, PDFSize.PDFHeight, PDFSize.PDFWidth, PDFSize.PDFDpi, papszOptions);
-    //ninjaErr = NinjaSetPDFSize(ninjaArmy, i+10, PDFSize.PDFHeight, PDFSize.PDFWidth, PDFSize.PDFDpi, papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFSize: ninjaErr =" << ninjaErr;
@@ -1488,8 +1209,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetPDFResolution(ninjaArmy, i, ui->geospatialPDFFilesMeshResolutionSpinBox->value(), ui->geospatialPDFFilesMeshResolutionComboBox->itemData(ui->geospatialPDFFilesMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);
-    //ninjaErr = NinjaSetPDFResolution(ninjaArmy, i+10, ui->geospatialPDFFilesMeshResolutionSpinBox->value(), ui->geospatialPDFFilesMeshResolutionComboBox->itemData(ui->geospatialPDFFilesMeshResolutionComboBox->currentIndex()).toString().toUtf8().constData(), papszOptions);  // test error handling  // hrm, ninjaCom isn't triggering for this one, though the error returns, leading to it hanging without a proper message.
-    //ninjaErr = NinjaSetPDFResolution(ninjaArmy, i, ui->geospatialPDFFilesMeshResolutionSpinBox->value(), "fudge", papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetPDFResolution: ninjaErr =" << ninjaErr;
@@ -1497,7 +1216,6 @@ bool MainWindow::setOutputFlags(NinjaArmyH* ninjaArmy,
     }
 
     ninjaErr = NinjaSetVtkOutFlag(ninjaArmy, i, ui->VTKFilesCheckBox->isChecked(), papszOptions);
-    //ninjaErr = NinjaSetVtkOutFlag(ninjaArmy, i+10, ui->VTKFilesCheckBox->isChecked(), papszOptions);  // test error handling
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetVtkOutFlag: ninjaErr =" << ninjaErr;

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -248,84 +248,6 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
     QVector<int> minute = {start.time().minute(), end.time().minute()};
     QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);
 
-    // this one should break so hard, the code won't even know what happened
-    // yeah, a qt error this time, "ASSERT failure in QList::operator[]: "index out of range""
-    // well, that's confusing. This breaking only happens if doing "qDebug() << outTime[1];" rather than just [0],
-    // comment that out and it runs to completion fine for everything, it just uses the first time for everything.
-    // looks like it just uses the single time, as either a latestTime or a time-series file format,
-    //  depending on the choice of the input download type, latestTime or time-series
-    /*QVector<int> year   = {start.date().year(),   end.date().year()};
-    QVector<int> month  = {start.date().month(),  end.date().month()};
-    QVector<int> day    = {start.date().day(),    end.date().day()};
-    QVector<int> hour   = {start.time().hour(),   end.time().hour()};
-    QVector<int> minute = {start.time().minute(), end.time().minute()};
-    QVector<int> outYear(1), outMonth(1), outDay(1), outHour(1), outMinute(1);*/
-
-    // this set will probably work fine
-    // yup, worked fine. The time-series became a time-series from and to the same exact time
-    /*QVector<int> year   = {start.date().year(),   start.date().year()};
-    QVector<int> month  = {start.date().month(),  start.date().month()};
-    QVector<int> day    = {start.date().day(),    start.date().day()};
-    QVector<int> hour   = {start.time().hour(),   start.time().hour()};
-    QVector<int> minute = {start.time().minute(), start.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // this set will probably work fine
-    // yup, worked fine. The time-series became a time-series from and to the same exact time
-    /*QVector<int> year   = {end.date().year(),   end.date().year()};
-    QVector<int> month  = {end.date().month(),  end.date().month()};
-    QVector<int> day    = {end.date().day(),    end.date().day()};
-    QVector<int> hour   = {end.time().hour(),   end.time().hour()};
-    QVector<int> minute = {end.time().minute(), end.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // the latestTime fetch just uses the first time from the list
-    // the time-series fetch throws an error as expected, but the message seems to drop what is going on to cause the error
-    // looks like we don't have a proper start time > stop time check yet, so it just fails with the generic error
-    /*QVector<int> year   = {start.date().year(),   start.date().year()-1};
-    QVector<int> month  = {start.date().month(),  start.date().month()};
-    QVector<int> day    = {start.date().day(),    start.date().day()};
-    QVector<int> hour   = {start.time().hour(),   start.time().hour()};
-    QVector<int> minute = {start.time().minute(), start.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // should die pretty hard
-    // well, it runs this part fine, just runs normally when run by the later fetch (because the fetch SHOULD die, but does not right now for this case),
-    // unless it is a latestTime fetch in which case it just uses the first time from the list
-    /*QVector<int> year   = {start.date().year(),   start.date().year()};
-    QVector<int> month  = {start.date().month(),  start.date().month()};
-    QVector<int> day    = {start.date().day(),    start.date().day()};
-    QVector<int> hour   = {start.time().hour(),   start.time().hour()-1};
-    QVector<int> minute = {start.time().minute(), start.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // the latestTime fetch just uses the first time from the list
-    // the time-series fetch throws an error as expected, but the message seems to drop what is going on to cause the error
-    /*QVector<int> year   = {start.date().year(),   start.date().year()};
-    QVector<int> month  = {start.date().month(),  start.date().month()};
-    QVector<int> day    = {start.date().day(),    start.date().day()};
-    QVector<int> hour   = {start.time().hour(),   start.time().hour()-2};  // had to use 3 instead of 2 for this to work, when I was right at and close to the hour
-    QVector<int> minute = {start.time().minute(), start.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // the latestTime fetch just uses the first time from the list
-    // the time-series fetch throws an error as expected, but the message seems to drop what is going on to cause the error
-    /*QVector<int> year   = {end.date().year()+1,   end.date().year()};
-    QVector<int> month  = {end.date().month(),  end.date().month()};
-    QVector<int> day    = {end.date().day(),    end.date().day()};
-    QVector<int> hour   = {end.time().hour(),   end.time().hour()};
-    QVector<int> minute = {end.time().minute(), end.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
-    // the latestTime fetch just uses the first time from the list
-    // the time-series fetch throws an error as expected, but the message seems to drop what is going on to cause the error
-    /*QVector<int> year   = {end.date().year(),   end.date().year()};
-    QVector<int> month  = {end.date().month(),  end.date().month()};
-    QVector<int> day    = {end.date().day(),    end.date().day()};
-    QVector<int> hour   = {end.time().hour()+1,   end.time().hour()};
-    QVector<int> minute = {end.time().minute(), end.time().minute()};
-    QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);*/
-
     ninjaErr = NinjaGetTimeList(
         ninjaTools,
         year.data(), month.data(), day.data(),
@@ -334,22 +256,6 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
         outHour.data(), outMinute.data(),
         2, DEMTimeZoneBytes.data()
         );
-    //ninjaErr = NinjaGetTimeList(
-    //    ninjaTools,
-    //    year.data(), month.data(), day.data(),
-    //    hour.data(), minute.data(),
-    //    outYear.data(), outMonth.data(), outDay.data(),
-    //    outHour.data(), outMinute.data(),
-    //    1, DEMTimeZoneBytes.data()
-    //    );  // this one shouldn't hurt anything, but want to see what happens  // gives an error, for both latestTime and time-series: "Day of month value is out of range 1..31".
-    //ninjaErr = NinjaGetTimeList(
-    //    ninjaTools,
-    //    year.data(), month.data(), day.data(),
-    //    hour.data(), minute.data(),
-    //    outYear.data(), outMonth.data(), outDay.data(),
-    //    outHour.data(), outMinute.data(),
-    //    2, "fudge"
-    //    );  // should break, but probably won't, will probably be treated like the dem timezone  // turns out it breaks HARD, a smart pointer failing on assert somewhere along the pipeline, not sure if that occurs here, or later down the pipeline. Definitely a break not necessarily related directly with the dem, breaks probably because of something sized wrong because of the dem being off, or it breaks because it IS trying to read the dem even though it shouldn't. And it gets past the try/catch error handling stuff, hrm.
     if(ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaGetTimeList: ninjaErr =" << ninjaErr;
@@ -374,10 +280,8 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
         return;
     }
 
-    if(ui->weatherStationDataTimeComboBox->currentIndex() == 1) // TODO: Add proper error handling for a bad time duration (someone downloads too much data)
+    if(ui->weatherStationDataTimeComboBox->currentIndex() == 1)
     {
-        //outYear[0] = outYear[1]-2;  // doing more than a year worth of time SHOULD be what triggers it, this is NOT a check on the times themselves  // hrm, it returns an error code of 8, but no ninjaCom seems to be sent so it leaves it hanging without a proper message. runs fine for a latestTime simulation. // updated ninja code and the error message is WAY better now, has a proper error message.
-        //outYear[1] = outYear[0]+2;  // not sure if it can even handle when the endYear goes past the current year  // same result as the above test.
         ninjaErr = NinjaCheckTimeDuration(ninjaTools, outYear.data(), outMonth.data(), outDay.data(), outHour.data(), outMinute.data(), 2, papszOptions);
         if(ninjaErr != NINJA_SUCCESS)
         {
@@ -464,42 +368,6 @@ int PointInitializationInput::fetchStationFromBbox(NinjaToolsH* ninjaTools,
                                                    bool fetchLatestFlag,
                                                    QString outputPath)
 {
-    // apparently if it is a latestTime run, changing the times means nothing, they get ignored
-    // though looks like the values that find themselves in there before editing for a latestTime run,
-    // are   endDateTime of current time         , in UTC
-    // and startDateTime of current time - 1 hour, in UTC
-    // meaning that setting a latestTime run to a multi-time series, just runs fine and acts like a multi-time series
-    // hrm, when redownloading of the same type, multi-time series, but differing times, the same folder and sometimes filenames end up getting used, from the first download attempt. Seems like badly defined behavior, might be related to the stations info being a set of static variables? I'm not sure what is going on there, the inputs to the function ARE the proper updated set of times.
-    // hrm, in all cases, failing or otherwise, the wxStation folder ends up still getting written, does not end up getting cleaned up after the failing of the run.
-
-    //fetchLatestFlag = TRUE;  // on a single-time series, what will happen?  // Turns out it runs fine, just uses the start time of the multi-time series. So kind of a useless test.
-    //fetchLatestFlag = FALSE;  // try on a multi-time series, with good inputs or no, what will happen?  // Turns out it runs fine, because the default values are a time series that is normally ignored. kind of behaves like a useful test, though that depends on how the inputs could change.
-
-    //year[1] = year[0]-1;  // throws an error as expected, though the message seems to drop what is going on to cause the error. The folder is still created, doesn't get cleaned up after the download fails.
-    //hour[1] = hour[0]-1;  // need to carefully set the date to the same date for both times for this test to properly work. apparently this test SHOULD break, but something must be up in how it is handled within the ninja code because it ends up just downloading a single dateTime, of the earliest of the two sets of times.
-    //hour[1] = hour[0]-2;  // throws an error as expected, though the message seems to drop what is going on to cause the error, but had to use 3 instead of 2 for this to work, when I was right at and close to the hour. need to carefully set the date to the same date for both times for this test to properly work.
-    //year[0] = year[1]+1;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[0] = hour[1]+1;  // need to carefully set the date to the same date for both times for this test to properly work. apparently this test SHOULD break, but something must be up in how it is handled within the ninja code because it ends up just downloading a single dateTime, of the earliest of the two sets of times. Seems to work better when not close to the hour.
-    //hour[0] = hour[1]+2;  // throws an error as expected. need to carefully set the date to the same date for both times for this test to properly work.
-    //elevationFile = "fudge";  // after adding in the check to the raw ninja code, for if the file exists BEFORE opening, it now properly throws the error "demFile 'fudge' does not exist."
-    //buffer = -1;  // runs fine, no error messages, just downloads the data within the area of the dem
-    //units = "fudge";  // runs fine, no error messages, just downloads the data within the area of the dem
-    //osTimeZone = "fudge";  // runs fine, no error messages, seems to just download the data assuming the timezone of the dem
-
-    //year[0] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[0] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //year[1] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[1] = 9999;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the endTime was the same thing as the startTime
-    //year[0] = -1;  // throws an error as expected, and actually a good informative error this time
-    //hour[0] = -1;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the startHour was the same thing as the endHour
-    //year[1] = -1;  // throws an error as expected, and actually a good informative error this time
-    //hour[1] = -1;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the endHour was the same thing as the startHour
-    //year[0] = 0;  // throws an error as expected, and actually a good informative error this time
-    //year[1] = 0;  // throws an error as expected, and actually a good informative error this time
-
-    //qDebug() << "year[0] month[0] day[0] hour[0] minute[0] =" << year[0] << month[0] << day[0] << hour[0] << minute[0];
-    //qDebug() << "year[1] month[1] day[1] hour[1] minute[1] =" << year[1] << month[1] << day[1] << hour[1] << minute[1];
-
     char ** options = NULL;
     NinjaErr ninjaErr = NinjaFetchStationFromBBox(
         ninjaTools,
@@ -531,44 +399,6 @@ int PointInitializationInput::fetchStationByName(NinjaToolsH* ninjaTools,
                                                  bool fetchLatestFlag,
                                                  QString outputPath)
 {
-    //stationList = "KMSO,PNTM8";  // this is a working list, what the list SHOULD be, and it works great. But apparently doing so with a SPACE between the commas of the stations, even though that is what is shown in the GUI as an example, DOES break the code.
-    //stationList = "KMSO, PNTM8";  // um, this should NOT thrown an error, but it does. So I guess something is wrong with how the files are parsed. Runs fine for a single station. The error message also drops telling what is going on, so annoying.
-
-    // apparently if it is a latestTime run, changing the times means nothing, they get ignored
-    // though looks like the values that find themselves in there before editing for a latestTime run,
-    // are   endDateTime of current time         , in UTC
-    // and startDateTime of current time - 1 hour, in UTC
-    // meaning that setting a latestTime run to a multi-time series, just runs fine and acts like a multi-time series
-    // hrm, when redownloading of the same type, multi-time series, but differing times, the same folder and sometimes filenames end up getting used, from the first download attempt. Seems like badly defined behavior, might be related to the stations info being a set of static variables? I'm not sure what is going on there, the inputs to the function ARE the proper updated set of times.
-    // hrm, in all cases, failing or otherwise, the wxStation folder ends up still getting written, does not end up getting cleaned up after the failing of the run.
-
-    //fetchLatestFlag = TRUE;  // on a single-time series, what will happen?  // Turns out it runs fine, just uses the start time of the multi-time series. So kind of a useless test.
-    //fetchLatestFlag = FALSE;  // try on a multi-time series, with good inputs or no, what will happen?  // Turns out it runs fine, because the default values are a time series that is normally ignored. kind of behaves like a useful test, though that depends on how the inputs could change.
-
-    //year[1] = year[0]-1;  // throws an error as expected, though the message seems to drop what is going on to cause the error. The folder is still created, doesn't get cleaned up after the download fails.
-    //hour[1] = hour[0]-1;  // need to carefully set the date to the same date for both times for this test to properly work. apparently this test SHOULD break, but something must be up in how it is handled within the ninja code because it ends up just downloading a single dateTime, of the earliest of the two sets of times.
-    //hour[1] = hour[0]-2;  // throws an error as expected, though the message seems to drop what is going on to cause the error, but had to use 3 instead of 2 for this to work, when I was right at and close to the hour. need to carefully set the date to the same date for both times for this test to properly work.
-    //year[0] = year[1]+1;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[0] = hour[1]+1;  // need to carefully set the date to the same date for both times for this test to properly work. apparently this test SHOULD break, but something must be up in how it is handled within the ninja code because it ends up just downloading a single dateTime, of the earliest of the two sets of times. Seems to work better when not close to the hour.
-    //hour[0] = hour[1]+2;  // throws an error as expected. need to carefully set the date to the same date for both times for this test to properly work.
-    //elevationFile = "fudge";  // um, this is supposed to have thrown an error, but it didn't, data somehow downloaded fine with fudge in the name. Oh I see, it just uses the stations that are chosen to be downloaded.
-    //stationList = "fudge";  // throws error as expected, though the message seems to drop what is going on to cause the error.
-    //osTimeZone = "fudge";  // runs fine, no error messages, seems to just download the data assuming the timezone of the dem
-
-    //year[0] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[0] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //year[1] = 9999;  // throws an error as expected, though the message seems to drop what is going on to cause the error
-    //hour[1] = 9999;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the endTime was the same thing as the startTime
-    //year[0] = -1;  // throws an error as expected, and actually a good informative error this time
-    //hour[0] = -1;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the startHour was the same thing as the endHour
-    //year[1] = -1;  // throws an error as expected, and actually a good informative error this time
-    //hour[1] = -1;  // um, this one did NOT throw an error, but actually ran successfully, creating data as if the endHour was the same thing as the startHour
-    //year[0] = 0;  // throws an error as expected, and actually a good informative error this time
-    //year[1] = 0;  // throws an error as expected, and actually a good informative error this time
-
-    //qDebug() << "year[0] month[0] day[0] hour[0] minute[0] =" << year[0] << month[0] << day[0] << hour[0] << minute[0];
-    //qDebug() << "year[1] month[1] day[1] hour[1] minute[1] =" << year[1] << month[1] << day[1] << hour[1] << minute[1];
-
     char ** options = NULL;
     NinjaErr ninjaErr = NinjaFetchStationByName(
         ninjaTools,

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -411,7 +411,7 @@ int PointInitializationInput::fetchStationByName(NinjaToolsH* ninjaTools,
 
     if (ninjaErr != NINJA_SUCCESS)
     {
-        qDebug() << "NinjaFetchStationFromBbox: ninjaErr =" << ninjaErr;
+        qDebug() << "NinjaFetchStationByName: ninjaErr =" << ninjaErr;
     }
 
     return ninjaErr;

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -909,10 +909,7 @@ int SurfaceInput::fetchDEMFile(QVector<double> boundingBox, std::string demFile,
         qDebug() << "NinjaSetToolsComMessageHandler(): ninjaErr =" << ninjaErr;
     }
 
-    ninjaErr = NinjaFetchDEMBBox(ninjaTools, boundingBox.data(), demFile.c_str(), resolution, strdup(fetchType.c_str()), papszOptions);  // some errors and warnings are caught, but only as error codes, not as messages. Would need to update how we do the messaging within the various SurfaceFetch calls themselves. CPLError( CE_Warning, ...); and CPLError( CE_Failure, ...); with return of an error code seems hard to try/catch with ninjaCom.
-    //ninjaErr = NinjaFetchDEMBBox(ninjaTools, boundingBox.data(), ".", resolution, strdup(fetchType.c_str()), papszOptions);  // error was caught, but message is not properly passed
-    //ninjaErr = NinjaFetchDEMBBox(ninjaTools, boundingBox.data(), demFile.c_str(), resolution, "fudge", papszOptions);  // actually catches this error, with a good message
-    //ninjaErr = NinjaFetchDEMBBox(ninjaTools, boundingBox.data(), demFile.c_str(), -10.0, strdup(fetchType.c_str()), papszOptions);  // error was caught, but not even a message to be passed around with this one
+    ninjaErr = NinjaFetchDEMBBox(ninjaTools, boundingBox.data(), demFile.c_str(), resolution, strdup(fetchType.c_str()), papszOptions);
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaFetchDEMBBox: ninjaErr =" << ninjaErr;

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -213,11 +213,7 @@ int WeatherModelInput::fetchForecastWeather(
     const char* modelIdentifier = modelIdentifierTemp.constData();
     const char* demFile = demFileTemp.constData();
 
-    NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, hours);  // some errors and warnings are caught, but only as error codes, not as messages, for instance "ERROR 1: HTTP error code : 404", "ERROR 1: Failed to download file.", "Warning 1: Failed to download forecast, stepping back one forecast run time step.". Would need to update how we do the messaging within the various wxModelInitialization fetch calls themselves. CPLError( CE_Warning, ...); and CPLError( CE_Failure, ...); with return of an error code seems hard to try/catch with ninjaCom.
-    //NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, "fudge", demFile, hours);  // works with proper error message, after non-caught message "ERROR 4: fudge: No such file or directory".
-    //NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, "fudge", hours);  // works with proper error message, after non-caught message "ERROR 4: fudge: No such file or directory".
-    ////NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, -1);  // um, this one somehow went forward as if it was a correct value? Stepped back one, but in the end I got a single weather model data file, not the usual 2 when it steps back like that.
-    //NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, 0);  // only works as a test for certain specific weather models, that have minimums of 3 or 6 hrs, like UCAR-NDFD-CONUS-2.5-KM (currently breaking as a model, even on qt4 gui), UCAR-NAM-CONUS-12-KM (this works great as a test)
+    NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, hours);
     if(ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaFetchWeatherData: ninjaErr =" << ninjaErr;
@@ -246,33 +242,7 @@ int WeatherModelInput::fetchPastcastWeather(
         ninjaTools, modelIdentifier, demFile, timeZone,
         startYear, startMonth, startDay, startHour,
         endYear, endMonth, endDay, endHour
-        );  // when run without authentication keys, I get the authentication key error when running this, which is correct. And now, with authentication keys set, it is no longer hanging. If the time is too late, it acts like it finishes while failing to download a file, no error message thrown. If using a good time, it downloads successfully. This was the old qt4 gui behavior.
-    //NinjaErr ninjaErr = NinjaFetchArchiveWeatherData(
-    //    ninjaTools, "fudge", demFile, timeZone,
-    //    startYear, startMonth, startDay, startHour,
-    //    endYear, endMonth, endDay, endHour
-    //    );  // works with proper error message.
-    //NinjaErr ninjaErr = NinjaFetchArchiveWeatherData(
-    //    ninjaTools, modelIdentifier, "fudge", timeZone,
-    //    startYear, startMonth, startDay, startHour,
-    //    endYear, endMonth, endDay, endHour
-    //    );  // works with proper error message, after non-caught message "ERROR 4: fudge: No such file or directory".
-    //NinjaErr ninjaErr = NinjaFetchArchiveWeatherData(
-    //    ninjaTools, modelIdentifier, demFile, "fudge",
-    //    startYear, startMonth, startDay, startHour,
-    //    endYear, endMonth, endDay, endHour
-    //    );  // no longer hangs, but it runs successfully, I guess maybe using the timezone of the dem, rather than throwing an error for having an incorrect timezone.
-    //NinjaErr ninjaErr = NinjaFetchArchiveWeatherData(
-    //    ninjaTools, modelIdentifier, demFile, timeZone,
-    //    startYear, startMonth, startDay, startHour,
-    //    startYear-1, startMonth, startDay, startHour
-    //    );  // it acts like it finishes while failing to download a file, no error message thrown.
-    //NinjaErr ninjaErr = NinjaFetchArchiveWeatherData(
-    //    ninjaTools, modelIdentifier, demFile, timeZone,
-    //    startYear, startMonth, startDay, startHour,
-    //    startYear, startMonth, startDay, startHour-1
-    //    );  // it acts like it finishes while failing to download a file, no error message thrown.
-
+    );
     if (ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaFetchArchiveWeatherData: ninjaErr =" << ninjaErr;


### PR DESCRIPTION
Pulled out the GUI test cases from the GUI, which works on issue #724.

Also cleaned up the various C-API autotest scripts, which is work related to issue #582. The various C-API autotest scripts now compile and run. The scripts could be a bit cleaner, especially with point initialization, but now it should be a bit easier to see what extra work is required on the C-API with the current methods.