### PR TITLE
more qt4 to qt6 GUI code migration

### DIFF
--- a/src/gui/appState.cpp
+++ b/src/gui/appState.cpp
@@ -829,6 +829,13 @@ void AppState::updateOverallState()
         ui->treeWidget->topLevelItem(3)->setIcon(0, tickIcon);
         ui->treeWidget->topLevelItem(3)->setToolTip(0, "You may start the solver");
     }
+    else if(!isSolverMethodologyValid)
+    {
+        ui->numberOfProcessorsSolveButton->setEnabled(false);
+        ui->numberOfProcessorsSolveButton->setToolTip("Check Solver Methodology");
+        ui->treeWidget->topLevelItem(3)->setIcon(0, crossIcon);
+        ui->treeWidget->topLevelItem(3)->setToolTip(0, "Check Solver Methodology");
+    }
     else if(!isSurfaceInputValid)
     {
         ui->numberOfProcessorsSolveButton->setEnabled(false);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -39,6 +39,11 @@ int main(int argc, char *argv[])
         w->setMinimumSize(800, 600);
         w->resize(800, 600);
     } catch (...) {
+        QMessageBox::critical(
+            nullptr,
+            QApplication::tr("Error"),
+            "WindNinja failed to initialize.\nMost likely cause is failure to find data dependencies.\nTry setting the environment variable WINDNINJA_DATA.\n"
+        );
         ninjaErr = NinjaFinalize(options);
         if(ninjaErr != NINJA_SUCCESS)
         {

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -316,8 +316,8 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
 void MainWindow::cancelSolve()
 {
     progressDialog->setLabelText("Canceling...");
-    //qDebug() << "Canceling...";
-    //writeToConsole( "Canceling...", QColor(255, 140, 0));
+    qDebug() << "Canceling...";
+    writeToConsole( "Canceling...", QColor(255, 140, 0));
 
     char **papszOptions = nullptr;
     ninjaErr  = NinjaCancel(ninjaArmy, papszOptions);
@@ -485,6 +485,43 @@ void MainWindow::solveButtonClicked()
     if(ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaSetArmyComMessageHandler(): ninjaErr =" << ninjaErr;
+    }
+
+    // do some pre-checks. Some of these could probably be moved to appState
+    if((ui->timeZoneComboBox->currentIndex() <= 0 || ui->timeZoneComboBox->currentText() == "") && (ui->diurnalCheckBox->isChecked() || ui->stabilityCheckBox->isChecked() || ui->weatherModelGroupBox->isChecked() || ui->pointInitializationGroupBox->isChecked()))
+    {
+        ninjaErr = NINJA_E_INVALID;
+        qCritical() << "ERROR: Could not auto-identify time zone, please specify one in Surface Input page.";
+        comMessageHandler("ERROR: Could not auto-identify time zone, please specify one in Surface Input page.", this);
+    }
+    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
+    {
+        ninjaErr = NINJA_E_INVALID;
+        qCritical() << "ERROR: invalid Output Directory specified in Solve page.";
+        comMessageHandler("ERROR: invalid Output Directory specified in Solve page.", this);
+    }
+    if(ninjaErr != NINJA_SUCCESS)
+    {
+        progressDialog->setValue(maxProgress);
+        progressDialog->setCancelButtonText("Close");
+
+        // do cleanup before the return, similar to finishedSolve()
+
+        //disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
+
+        char **papszOptions = nullptr;
+        int ninjaErr = NinjaDestroyArmy(ninjaArmy, papszOptions);
+        if(ninjaErr != NINJA_SUCCESS)
+        {
+            printf("NinjaDestroyRuns: ninjaErr = %d\n", ninjaErr);
+        }
+
+        // clear the progress values for the next set of runs
+        //runProgress.clear();
+
+        //futureWatcher->deleteLater();
+
+        return;
     }
 
     if(state.isDomainAverageInitializationValid)

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -340,6 +340,8 @@ void MainWindow::massSolverCheckBoxToggled()
 {
     if(!ui->massSolverCheckBox->isChecked())
     {
+        emit updateMetholodyState();
+        emit updateStabilityState();
         return;
     }
 
@@ -368,6 +370,13 @@ void MainWindow::momentumSolverCheckBoxToggled()
 {
     if(!ui->momentumSolverCheckBox->isChecked())
     {
+        ui->stabilityCheckBox->setDisabled(false);
+        ui->stabilityCheckBox->setToolTip("");
+        ui->pointInitializationGroupBox->setDisabled(false);
+        ui->pointInitializationGroupBox->setToolTip("");
+        ui->ninjafoamCaseGroupBox->setVisible(false);
+        emit updateMetholodyState();
+        emit updateStabilityState();
         return;
     }
 

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -339,9 +339,14 @@ void MainWindow::treeWidgetItemSelectionChanged()
 void MainWindow::massSolverCheckBoxToggled()
 {
     if(!ui->massSolverCheckBox->isChecked())
+    {
         return;
+    }
 
     ui->stabilityCheckBox->setDisabled(false);
+    ui->stabilityCheckBox->setToolTip("");
+    ui->pointInitializationGroupBox->setDisabled(false);
+    ui->pointInitializationGroupBox->setToolTip("");
     ui->ninjafoamCaseGroupBox->setVisible(false);
 
     if(ui->momentumSolverCheckBox->isChecked())
@@ -362,10 +367,16 @@ void MainWindow::massSolverCheckBoxToggled()
 void MainWindow::momentumSolverCheckBoxToggled()
 {
     if(!ui->momentumSolverCheckBox->isChecked())
+    {
         return;
+    }
 
     ui->stabilityCheckBox->setChecked(false);
     ui->stabilityCheckBox->setDisabled(true);
+    ui->stabilityCheckBox->setToolTip("The non-neutral stability option is not currently available for the momentum solver.");
+    ui->pointInitializationGroupBox->setChecked(false);
+    ui->pointInitializationGroupBox->setDisabled(true);
+    ui->pointInitializationGroupBox->setToolTip("The point initialization option is not currently available for the momentum solver.");
     ui->ninjafoamCaseGroupBox->setVisible(true);
 
     if(ui->massSolverCheckBox->isChecked())

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -488,12 +488,6 @@ void MainWindow::solveButtonClicked()
     }
 
     // do some pre-checks. Some of these could probably be moved to appState
-    if((ui->timeZoneComboBox->currentIndex() <= 0 || ui->timeZoneComboBox->currentText() == "") && (ui->diurnalCheckBox->isChecked() || ui->stabilityCheckBox->isChecked() || ui->weatherModelGroupBox->isChecked() || ui->pointInitializationGroupBox->isChecked()))
-    {
-        ninjaErr = NINJA_E_INVALID;
-        qCritical() << "ERROR: Could not auto-identify time zone, please specify one in Surface Input page.";
-        comMessageHandler("ERROR: Could not auto-identify time zone, please specify one in Surface Input page.", this);
-    }
     if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
     {
         ninjaErr = NINJA_E_INVALID;

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -487,37 +487,6 @@ void MainWindow::solveButtonClicked()
         qDebug() << "NinjaSetArmyComMessageHandler(): ninjaErr =" << ninjaErr;
     }
 
-    // do some pre-checks. Some of these could probably be moved to appState
-    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
-    {
-        ninjaErr = NINJA_E_INVALID;
-        qCritical() << "ERROR: invalid Output Directory specified in Solve page.";
-        comMessageHandler("ERROR: invalid Output Directory specified in Solve page.", this);
-    }
-    if(ninjaErr != NINJA_SUCCESS)
-    {
-        progressDialog->setValue(maxProgress);
-        progressDialog->setCancelButtonText("Close");
-
-        // do cleanup before the return, similar to finishedSolve()
-
-        //disconnect(progressDialog, SIGNAL(canceled()), this, SLOT(cancelSolve()));
-
-        char **papszOptions = nullptr;
-        int ninjaErr = NinjaDestroyArmy(ninjaArmy, papszOptions);
-        if(ninjaErr != NINJA_SUCCESS)
-        {
-            printf("NinjaDestroyRuns: ninjaErr = %d\n", ninjaErr);
-        }
-
-        // clear the progress values for the next set of runs
-        //runProgress.clear();
-
-        //futureWatcher->deleteLater();
-
-        return;
-    }
-
     if(state.isDomainAverageInitializationValid)
     {
         initializationMethod = "domain_average";

--- a/src/gui/mainWindow.ui
+++ b/src/gui/mainWindow.ui
@@ -2083,15 +2083,15 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <property name="cursor">
                       <cursorShape>PointingHandCursor</cursorShape>
                      </property>
+                     <property name="toolTip">
+                      <string>Clear all entries</string>
+                     </property>
                      <property name="text">
                       <string>Clear Table</string>
                      </property>
                      <property name="icon">
                       <iconset resource="../../wn-resources.qrc">
                        <normaloff>:/cancel.png</normaloff>:/cancel.png</iconset>
-                     </property>
-                     <property name="toolTip">
-                      <string>Clear all entries</string>
                      </property>
                     </widget>
                    </item>
@@ -2396,14 +2396,14 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        <verstretch>0</verstretch>
                       </sizepolicy>
                      </property>
-                     <property name="text">
-                      <string>Select Weather Stations</string>
-                     </property>
                      <property name="toolTip">
                       <string>Select Weather Stations from available files.
 Click a file to add it to the list of included stations.
 Click it again to remove it from the included stations.
 Available formats are time series and one step runs with time data.</string>
+                     </property>
+                     <property name="text">
+                      <string>Select Weather Stations</string>
                      </property>
                     </widget>
                    </item>
@@ -2437,15 +2437,15 @@ Available formats are time series and one step runs with time data.</string>
                      <property name="cursor">
                       <cursorShape>PointingHandCursor</cursorShape>
                      </property>
+                     <property name="toolTip">
+                      <string>Download weather station data from the Mesonet API</string>
+                     </property>
                      <property name="text">
                       <string>Download Data</string>
                      </property>
                      <property name="icon">
                       <iconset resource="../../wn-resources.qrc">
                        <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
-                     </property>
-                     <property name="toolTip">
-                      <string>Download weather station data from the Mesonet API</string>
                      </property>
                     </widget>
                    </item>
@@ -2623,14 +2623,14 @@ Available formats are time series and one step runs with time data.</string>
                        <property name="cursor">
                         <cursorShape>PointingHandCursor</cursorShape>
                        </property>
+                       <property name="toolTip">
+                        <string>Enter the simulation start time</string>
+                       </property>
                        <property name="displayFormat">
                         <string>MM/dd/yyyy HH:mm</string>
                        </property>
                        <property name="calendarPopup">
                         <bool>true</bool>
-                       </property>
-                       <property name="toolTip">
-                        <string>Enter the simulation start time</string>
                        </property>
                       </widget>
                      </item>
@@ -2652,6 +2652,9 @@ Available formats are time series and one step runs with time data.</string>
                        <property name="enabled">
                         <bool>false</bool>
                        </property>
+                       <property name="toolTip">
+                        <string>Enter the simulation stop time</string>
+                       </property>
                        <property name="dateTime">
                         <datetime>
                          <hour>0</hour>
@@ -2667,9 +2670,6 @@ Available formats are time series and one step runs with time data.</string>
                        </property>
                        <property name="calendarPopup">
                         <bool>true</bool>
-                       </property>
-                       <property name="toolTip">
-                        <string>Enter the simulation stop time</string>
                        </property>
                       </widget>
                      </item>
@@ -2691,6 +2691,9 @@ Available formats are time series and one step runs with time data.</string>
                        <property name="enabled">
                         <bool>false</bool>
                        </property>
+                       <property name="toolTip">
+                        <string>Enter the number of time steps</string>
+                       </property>
                        <property name="minimum">
                         <number>1</number>
                        </property>
@@ -2702,9 +2705,6 @@ Available formats are time series and one step runs with time data.</string>
                        </property>
                        <property name="value">
                         <number>24</number>
-                       </property>
-                       <property name="toolTip">
-                        <string>Enter the number of time steps</string>
                        </property>
                       </widget>
                      </item>
@@ -2791,16 +2791,16 @@ Available formats are time series and one step runs with time data.</string>
                    <property name="cursor">
                     <cursorShape>PointingHandCursor</cursorShape>
                    </property>
+                   <property name="toolTip">
+                    <string>Time Series: Writes a KML for each time step with time interpolated station data
+Single Step: Writes a KML of weather station data</string>
+                   </property>
                    <property name="text">
                     <string>Write Station KML</string>
                    </property>
                    <property name="icon">
                     <iconset resource="../../wn-resources.qrc">
                      <normaloff>:/weather_cloudy.png</normaloff>:/weather_cloudy.png</iconset>
-                   </property>
-                   <property name="toolTip">
-                    <string>Time Series: Writes a KML for each time step with time interpolated station data
-Single Step: Writes a KML of weather station data</string>
                    </property>
                   </widget>
                  </item>
@@ -3137,21 +3137,21 @@ Single Step: Writes a KML of weather station data</string>
                          </item>
                          <item>
                           <widget class="QPushButton" name="weatherModelTimeSelectAllButton">
-                           <property name="text">
-                            <string>Select All</string>
-                           </property>
                            <property name="toolTip">
                             <string>Select all forecast times</string>
+                           </property>
+                           <property name="text">
+                            <string>Select All</string>
                            </property>
                           </widget>
                          </item>
                          <item>
                           <widget class="QPushButton" name="weatherModelTimeSelectNoneButton">
-                           <property name="text">
-                            <string>Select None</string>
-                           </property>
                            <property name="toolTip">
                             <string>Select no forecast times</string>
+                           </property>
+                           <property name="text">
+                            <string>Select None</string>
                            </property>
                           </widget>
                          </item>
@@ -3586,11 +3586,11 @@ Single Step: Writes a KML of weather station data</string>
                     </item>
                     <item>
                      <widget class="QCheckBox" name="googleEarthLegendCheckBox">
-                      <property name="text">
-                       <string>Use Consistent Color Scale</string>
-                      </property>
                       <property name="toolTip">
                        <string>Use a consistent color scale across simulations</string>
+                      </property>
+                      <property name="text">
+                       <string>Use Consistent Color Scale</string>
                       </property>
                      </widget>
                     </item>
@@ -3665,11 +3665,11 @@ Single Step: Writes a KML of weather station data</string>
                     </item>
                     <item>
                      <widget class="QCheckBox" name="googleEarthVectorScalingCheckBox">
-                      <property name="text">
-                       <string>Apply Vector Scaling</string>
-                      </property>
                       <property name="toolTip">
                        <string>Enable vector scaling to increase line width with wind speed</string>
+                      </property>
+                      <property name="text">
+                       <string>Apply Vector Scaling</string>
                       </property>
                      </widget>
                     </item>
@@ -4749,11 +4749,11 @@ Single Step: Writes a KML of weather station data</string>
                     </item>
                     <item>
                      <widget class="QCheckBox" name="geospatialPDFFilesVectorsCheckBox">
-                      <property name="text">
-                       <string>Apply Vector Scaling</string>
-                      </property>
                       <property name="toolTip">
                        <string>Enable vector scaling to increase line width with wind speed</string>
+                      </property>
+                      <property name="text">
+                       <string>Apply Vector Scaling</string>
                       </property>
                      </widget>
                     </item>
@@ -5292,11 +5292,11 @@ Single Step: Writes a KML of weather station data</string>
                  </item>
                  <item>
                   <widget class="QCheckBox" name="mapVisualizationLegendCheckBox">
-                   <property name="text">
-                    <string>Use Consistent Color Scale</string>
-                   </property>
                    <property name="toolTip">
                     <string>Use a consistent color scale across simulations</string>
+                   </property>
+                   <property name="text">
+                    <string>Use Consistent Color Scale</string>
                    </property>
                   </widget>
                  </item>
@@ -5371,11 +5371,11 @@ Single Step: Writes a KML of weather station data</string>
                  </item>
                  <item>
                   <widget class="QCheckBox" name="mapVisualizationVectorScalingCheckBox">
-                   <property name="text">
-                    <string>Apply Vector Scaling</string>
-                   </property>
                    <property name="toolTip">
                     <string>Enable vector scaling to increase line width with wind speed</string>
+                   </property>
+                   <property name="text">
+                    <string>Apply Vector Scaling</string>
                    </property>
                   </widget>
                  </item>
@@ -6113,15 +6113,15 @@ Single Step: Writes a KML of weather station data</string>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
+              <property name="toolTip">
+               <string>Download the elevation file</string>
+              </property>
               <property name="text">
                <string>Download File</string>
               </property>
               <property name="icon">
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
-              </property>
-              <property name="toolTip">
-               <string>Download the elevation file</string>
               </property>
              </widget>
             </item>
@@ -6248,6 +6248,10 @@ Single Step: Writes a KML of weather station data</string>
                <property name="cursor">
                 <cursorShape>PointingHandCursor</cursorShape>
                </property>
+               <property name="toolTip">
+                <string>Download From DEM: Download all active weather stations with the bounds of the selected surface input.
+Download By Station ID: Manually enter weather station IDs separated by commas. e.g. KMSO,PNTM8</string>
+               </property>
                <item>
                 <property name="text">
                  <string>Download from DEM</string>
@@ -6258,10 +6262,6 @@ Single Step: Writes a KML of weather station data</string>
                  <string>Download by Station ID</string>
                 </property>
                </item>
-               <property name="toolTip">
-                <string>Download From DEM: Download all active weather stations with the bounds of the selected surface input.
-Download By Station ID: Manually enter weather station IDs separated by commas. e.g. KMSO,PNTM8</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -6439,6 +6439,10 @@ Download By Station ID: Manually enter weather station IDs separated by commas. 
                <property name="cursor">
                 <cursorShape>PointingHandCursor</cursorShape>
                </property>
+               <property name="toolTip">
+                <string>Download Most Recent Data: Download one time step of the latest data available in the mesowest API.
+Download Between Two Dates: Download all weather station data within a specified start and stop time.</string>
+               </property>
                <item>
                 <property name="text">
                  <string>Download Most Recent Data</string>
@@ -6449,10 +6453,6 @@ Download By Station ID: Manually enter weather station IDs separated by commas. 
                  <string>Download Between Two Dates</string>
                 </property>
                </item>
-               <property name="toolTip">
-                <string>Download Most Recent Data: Download one time step of the latest data available in the mesowest API.
-Download Between Two Dates: Download all weather station data within a specified start and stop time.</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -6607,15 +6607,15 @@ Download Between Two Dates: Download all weather station data within a specified
                 <height>16777215</height>
                </size>
               </property>
+              <property name="toolTip">
+               <string>Fetches weather data based on above specified parameters</string>
+              </property>
               <property name="text">
                <string>Download Data</string>
               </property>
               <property name="icon">
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
-              </property>
-              <property name="toolTip">
-               <string>Fetches weather data based on above specified parameters</string>
               </property>
              </widget>
             </item>
@@ -6633,15 +6633,15 @@ Download Between Two Dates: Download all weather station data within a specified
                 <height>16777215</height>
                </size>
               </property>
+              <property name="toolTip">
+               <string>Close Weather Station Data Download page</string>
+              </property>
               <property name="text">
                <string>Cancel</string>
               </property>
               <property name="icon">
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/cancel.png</normaloff>:/cancel.png</iconset>
-              </property>
-              <property name="toolTip">
-               <string>Close Weather Station Data Download page</string>
               </property>
              </widget>
             </item>

--- a/src/gui/mainWindow.ui
+++ b/src/gui/mainWindow.ui
@@ -4748,16 +4748,6 @@ Single Step: Writes a KML of weather station data</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="geospatialPDFFilesVectorsCheckBox">
-                      <property name="toolTip">
-                       <string>Enable vector scaling to increase line width with wind speed</string>
-                      </property>
-                      <property name="text">
-                       <string>Apply Vector Scaling</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
                      <spacer name="geospatialPDFFilesVectorsSpacer">
                       <property name="orientation">
                        <enum>Qt::Orientation::Horizontal</enum>

--- a/src/gui/mainWindow.ui
+++ b/src/gui/mainWindow.ui
@@ -806,7 +806,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Solver</string>
+          <string>Solve</string>
          </property>
         </item>
        </widget>
@@ -2090,6 +2090,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                       <iconset resource="../../wn-resources.qrc">
                        <normaloff>:/cancel.png</normaloff>:/cancel.png</iconset>
                      </property>
+                     <property name="toolTip">
+                      <string>Clear all entries</string>
+                     </property>
                     </widget>
                    </item>
                   </layout>
@@ -2396,6 +2399,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <property name="text">
                       <string>Select Weather Stations</string>
                      </property>
+                     <property name="toolTip">
+                      <string>Select Weather Stations from available files.
+Click a file to add it to the list of included stations.
+Click it again to remove it from the included stations.
+Available formats are time series and one step runs with time data.</string>
+                     </property>
                     </widget>
                    </item>
                    <item>
@@ -2434,6 +2443,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <property name="icon">
                       <iconset resource="../../wn-resources.qrc">
                        <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
+                     </property>
+                     <property name="toolTip">
+                      <string>Download weather station data from the Mesonet API</string>
                      </property>
                     </widget>
                    </item>
@@ -2617,6 +2629,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        <property name="calendarPopup">
                         <bool>true</bool>
                        </property>
+                       <property name="toolTip">
+                        <string>Enter the simulation start time</string>
+                       </property>
                       </widget>
                      </item>
                      <item row="1" column="1">
@@ -2653,6 +2668,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        <property name="calendarPopup">
                         <bool>true</bool>
                        </property>
+                       <property name="toolTip">
+                        <string>Enter the simulation stop time</string>
+                       </property>
                       </widget>
                      </item>
                      <item row="1" column="2">
@@ -2684,6 +2702,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        </property>
                        <property name="value">
                         <number>24</number>
+                       </property>
+                       <property name="toolTip">
+                        <string>Enter the number of time steps</string>
                        </property>
                       </widget>
                      </item>
@@ -2776,6 +2797,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
                    <property name="icon">
                     <iconset resource="../../wn-resources.qrc">
                      <normaloff>:/weather_cloudy.png</normaloff>:/weather_cloudy.png</iconset>
+                   </property>
+                   <property name="toolTip">
+                    <string>Time Series: Writes a KML for each time step with time interpolated station data
+Single Step: Writes a KML of weather station data</string>
                    </property>
                   </widget>
                  </item>
@@ -2942,7 +2967,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
                        <cursorShape>PointingHandCursor</cursorShape>
                       </property>
                       <property name="text">
-                       <string>Download</string>
+                       <string>Download Data</string>
                       </property>
                       <property name="icon">
                        <iconset resource="../../wn-resources.qrc">
@@ -3115,12 +3140,18 @@ li.checked::marker { content: &quot;\2612&quot;; }
                            <property name="text">
                             <string>Select All</string>
                            </property>
+                           <property name="toolTip">
+                            <string>Select all forecast times</string>
+                           </property>
                           </widget>
                          </item>
                          <item>
                           <widget class="QPushButton" name="weatherModelTimeSelectNoneButton">
                            <property name="text">
                             <string>Select None</string>
+                           </property>
+                           <property name="toolTip">
+                            <string>Select no forecast times</string>
                            </property>
                           </widget>
                          </item>
@@ -3558,6 +3589,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                       <property name="text">
                        <string>Use Consistent Color Scale</string>
                       </property>
+                      <property name="toolTip">
+                       <string>Use a consistent color scale across simulations</string>
+                      </property>
                      </widget>
                     </item>
                     <item>
@@ -3633,6 +3667,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      <widget class="QCheckBox" name="googleEarthVectorScalingCheckBox">
                       <property name="text">
                        <string>Apply Vector Scaling</string>
+                      </property>
+                      <property name="toolTip">
+                       <string>Enable vector scaling to increase line width with wind speed</string>
                       </property>
                      </widget>
                     </item>
@@ -4715,6 +4752,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                       <property name="text">
                        <string>Apply Vector Scaling</string>
                       </property>
+                      <property name="toolTip">
+                       <string>Enable vector scaling to increase line width with wind speed</string>
+                      </property>
                      </widget>
                     </item>
                     <item>
@@ -5255,6 +5295,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                    <property name="text">
                     <string>Use Consistent Color Scale</string>
                    </property>
+                   <property name="toolTip">
+                    <string>Use a consistent color scale across simulations</string>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -5330,6 +5373,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   <widget class="QCheckBox" name="mapVisualizationVectorScalingCheckBox">
                    <property name="text">
                     <string>Apply Vector Scaling</string>
+                   </property>
+                   <property name="toolTip">
+                    <string>Enable vector scaling to increase line width with wind speed</string>
                    </property>
                   </widget>
                  </item>
@@ -6074,6 +6120,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
               </property>
+              <property name="toolTip">
+               <string>Download the elevation file</string>
+              </property>
              </widget>
             </item>
             <item>
@@ -6209,6 +6258,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
                  <string>Download by Station ID</string>
                 </property>
                </item>
+               <property name="toolTip">
+                <string>Download From DEM: Download all active weather stations with the bounds of the selected surface input.
+Download By Station ID: Manually enter weather station IDs separated by commas. e.g. KMSO,PNTM8</string>
+               </property>
               </widget>
              </item>
              <item>
@@ -6268,6 +6321,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                   <widget class="QSpinBox" name="downloadFromDEMSpinBox">
                    <property name="cursor">
                     <cursorShape>PointingHandCursor</cursorShape>
+                   </property>
+                   <property name="toolTip">
+                    <string>Add a buffer to download stations outside the DEM</string>
                    </property>
                   </widget>
                  </item>
@@ -6393,6 +6449,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
                  <string>Download Between Two Dates</string>
                 </property>
                </item>
+               <property name="toolTip">
+                <string>Download Most Recent Data: Download one time step of the latest data available in the mesowest API.
+Download Between Two Dates: Download all weather station data within a specified start and stop time.</string>
+               </property>
               </widget>
              </item>
              <item>
@@ -6554,6 +6614,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/server_go.png</normaloff>:/server_go.png</iconset>
               </property>
+              <property name="toolTip">
+               <string>Fetches weather data based on above specified parameters</string>
+              </property>
              </widget>
             </item>
             <item>
@@ -6576,6 +6639,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
               <property name="icon">
                <iconset resource="../../wn-resources.qrc">
                 <normaloff>:/cancel.png</normaloff>:/cancel.png</iconset>
+              </property>
+              <property name="toolTip">
+               <string>Close Weather Station Data Download page</string>
               </property>
              </widget>
             </item>

--- a/src/gui/menuBar.cpp
+++ b/src/gui/menuBar.cpp
@@ -401,14 +401,6 @@ void MenuBar::enableConsoleOutputActionToggled(bool toggled)
 void MenuBar::loadMapVisualizationActionTriggered()
 {
     QString dir = ui->outputDirectoryLineEdit->text();
-    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
-    {
-        QMessageBox::critical(
-            nullptr,
-            QApplication::tr("Error"),
-            "ERROR: invalid Output Directory specified in Solve page.\n"
-        );
-    }
 
     QStringList files = QFileDialog::getOpenFileNames(
         ui->centralwidget,

--- a/src/gui/menuBar.cpp
+++ b/src/gui/menuBar.cpp
@@ -401,6 +401,14 @@ void MenuBar::enableConsoleOutputActionToggled(bool toggled)
 void MenuBar::loadMapVisualizationActionTriggered()
 {
     QString dir = ui->outputDirectoryLineEdit->text();
+    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
+    {
+        QMessageBox::critical(
+            nullptr,
+            QApplication::tr("Error"),
+            "ERROR: invalid Output Directory specified in Solve page.\n"
+        );
+    }
 
     QStringList files = QFileDialog::getOpenFileNames(
         ui->centralwidget,

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -243,6 +243,61 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
     QVector<int> minute = {start.time().minute(), end.time().minute()};
     QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);
 
+    bool fetchLatestFlag = ui->weatherStationDataTimeComboBox->currentIndex() ? 0 : 1;
+
+    if(fetchLatestFlag == false)
+    {
+        if(start.daysTo(end) > 365)
+        {
+            qCritical() << "Invalid Range: Selected Time Range is greater than 1 year! Input custom API KEY to remove limits.";
+            comMessageHandler("Invalid Range: Selected Time Range is greater than 1 year! Input custom API KEY to remove limits.", this);
+
+            progress->setWindowTitle(tr("Error"));
+            progress->setCancelButtonText("Close");
+            progress->setAutoClose(false);
+            progress->setAutoReset(false);
+            progress->setRange(0, 1);
+            progress->setValue(progress->maximum());
+
+            // do cleanup before the return, similar to finishedSolve()
+
+//            ninjaErr = NinjaDestroyTools(ninjaTools, papszOptions);
+//            if(ninjaErr != NINJA_SUCCESS)
+//            {
+//                printf("NinjaDestroyTools: ninjaErr = %d\n", ninjaErr);
+//            }
+
+            //futureWatcher->deleteLater();
+
+            return;
+        }
+    }
+
+    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
+    {
+        qCritical() << "ERROR: invalid Output Directory specified in Solve page.";
+        comMessageHandler("ERROR: invalid Output Directory specified in Solve page.", this);
+
+        progress->setWindowTitle(tr("Error"));
+        progress->setCancelButtonText("Close");
+        progress->setAutoClose(false);
+        progress->setAutoReset(false);
+        progress->setRange(0, 1);
+        progress->setValue(progress->maximum());
+
+        // do cleanup before the return, similar to finishedSolve()
+
+//        ninjaErr = NinjaDestroyTools(ninjaTools, papszOptions);
+//        if(ninjaErr != NINJA_SUCCESS)
+//        {
+//            printf("NinjaDestroyTools: ninjaErr = %d\n", ninjaErr);
+//        }
+
+        //futureWatcher->deleteLater();
+
+        return;
+    }
+
     ninjaErr = NinjaGetTimeList(
         ninjaTools,
         year.data(), month.data(), day.data(),
@@ -303,7 +358,6 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
         }
     }
 
-    bool fetchLatestFlag = ui->weatherStationDataTimeComboBox->currentIndex() ? 0 : 1;
     QString outputPath = ui->outputDirectoryLineEdit->text();
     QString elevationFile = ui->elevationInputFileLineEdit->property("fullpath").toString();
 

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -243,36 +243,6 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
     QVector<int> minute = {start.time().minute(), end.time().minute()};
     QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);
 
-    bool fetchLatestFlag = ui->weatherStationDataTimeComboBox->currentIndex() ? 0 : 1;
-
-    if(fetchLatestFlag == false)
-    {
-        if(start.daysTo(end) > 365)
-        {
-            qCritical() << "Invalid Range: Selected Time Range is greater than 1 year! Input custom API KEY to remove limits.";
-            comMessageHandler("Invalid Range: Selected Time Range is greater than 1 year! Input custom API KEY to remove limits.", this);
-
-            progress->setWindowTitle(tr("Error"));
-            progress->setCancelButtonText("Close");
-            progress->setAutoClose(false);
-            progress->setAutoReset(false);
-            progress->setRange(0, 1);
-            progress->setValue(progress->maximum());
-
-            // do cleanup before the return, similar to finishedSolve()
-
-//            ninjaErr = NinjaDestroyTools(ninjaTools, papszOptions);
-//            if(ninjaErr != NINJA_SUCCESS)
-//            {
-//                printf("NinjaDestroyTools: ninjaErr = %d\n", ninjaErr);
-//            }
-
-            //futureWatcher->deleteLater();
-
-            return;
-        }
-    }
-
     if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
     {
         qCritical() << "ERROR: invalid Output Directory specified in Solve page.";
@@ -358,6 +328,7 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
         }
     }
 
+    bool fetchLatestFlag = ui->weatherStationDataTimeComboBox->currentIndex() ? 0 : 1;
     QString outputPath = ui->outputDirectoryLineEdit->text();
     QString elevationFile = ui->elevationInputFileLineEdit->property("fullpath").toString();
 

--- a/src/gui/pointInitializationInput.cpp
+++ b/src/gui/pointInitializationInput.cpp
@@ -243,31 +243,6 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
     QVector<int> minute = {start.time().minute(), end.time().minute()};
     QVector<int> outYear(2), outMonth(2), outDay(2), outHour(2), outMinute(2);
 
-    if(ui->outputDirectoryLineEdit->text().isEmpty() || !QFileInfo(ui->outputDirectoryLineEdit->text()).exists())
-    {
-        qCritical() << "ERROR: invalid Output Directory specified in Solve page.";
-        comMessageHandler("ERROR: invalid Output Directory specified in Solve page.", this);
-
-        progress->setWindowTitle(tr("Error"));
-        progress->setCancelButtonText("Close");
-        progress->setAutoClose(false);
-        progress->setAutoReset(false);
-        progress->setRange(0, 1);
-        progress->setValue(progress->maximum());
-
-        // do cleanup before the return, similar to finishedSolve()
-
-//        ninjaErr = NinjaDestroyTools(ninjaTools, papszOptions);
-//        if(ninjaErr != NINJA_SUCCESS)
-//        {
-//            printf("NinjaDestroyTools: ninjaErr = %d\n", ninjaErr);
-//        }
-
-        //futureWatcher->deleteLater();
-
-        return;
-    }
-
     ninjaErr = NinjaGetTimeList(
         ninjaTools,
         year.data(), month.data(), day.data(),
@@ -329,8 +304,8 @@ void PointInitializationInput::weatherStationDataDownloadButtonClicked()
     }
 
     bool fetchLatestFlag = ui->weatherStationDataTimeComboBox->currentIndex() ? 0 : 1;
-    QString outputPath = ui->outputDirectoryLineEdit->text();
     QString elevationFile = ui->elevationInputFileLineEdit->property("fullpath").toString();
+    QString outputPath = QFileInfo(elevationFile).absolutePath();
 
     futureWatcher = new QFutureWatcher<int>(this);
     QFuture<int> future;

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -325,8 +325,8 @@ void SurfaceInput::surfaceInputDownloadButtonClicked()
 
     if(!isNorthValid || !isEastValid || !isSouthValid || !isWestValid)
     {
-        qCritical() << "ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool on the upper right corner of the map, entering a point and radius, or entering the bounding box coordinates.";
-        comMessageHandler("ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool on the upper right corner of the map, entering a point and radius, or entering the bounding box coordinates.", this);
+        qCritical() << "ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool, entering a point and radius, or entering the bounding box coordinates.";
+        comMessageHandler("ERROR: DEM bounding box not set. Select the DEM bounding box by using the bounding box drawing tool, entering a point and radius, or entering the bounding box coordinates.", this);
         return;
     }
 
@@ -697,7 +697,6 @@ void SurfaceInput::fetchDEMFinished()
         else
         {
             emit writeToConsoleSignal("Failed to download DEM file.");
-//            updateProgressMessage("The surface data download failed. \nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source.");
         }
 
         // delete the futureWatcher every time, whether success or failure

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -657,7 +657,7 @@ void SurfaceInput::fetchDEMFinished()
     {
         // get the return value of the QtConcurrent::run() function
         int result = futureWatcher->future().result();
-
+result = -1;
         if(result >= 0)  // returned NINJA_SUCCESS, or a nNoDataCount value
         {
             emit writeToConsoleSignal("Finished downloading DEM file.", Qt::darkGreen);
@@ -697,6 +697,7 @@ void SurfaceInput::fetchDEMFinished()
         else
         {
             emit writeToConsoleSignal("Failed to download DEM file.");
+//            updateProgressMessage("The surface data download failed. \nThis can happen when either the data source doesn't cover your region or the server that provides the surface data is down or under high usage. \nPlease try again later or try a different data source.");
         }
 
         // delete the futureWatcher every time, whether success or failure

--- a/src/gui/surfaceInput.cpp
+++ b/src/gui/surfaceInput.cpp
@@ -657,7 +657,7 @@ void SurfaceInput::fetchDEMFinished()
     {
         // get the return value of the QtConcurrent::run() function
         int result = futureWatcher->future().result();
-result = -1;
+
         if(result >= 0)  // returned NINJA_SUCCESS, or a nNoDataCount value
         {
             emit writeToConsoleSignal("Finished downloading DEM file.", Qt::darkGreen);

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -62,57 +62,6 @@ WeatherModelInput::WeatherModelInput(Ui::MainWindow* ui, QObject* parent)
     connect(this, &WeatherModelInput::updateProgressMessageSignal, this, &WeatherModelInput::updateProgressMessage, Qt::QueuedConnection);
 }
 
-void WeatherModelInput::weatherModelDownloadButtonClicked()
-{
-    emit writeToConsoleSignal("Downloading weather model data...");
-
-    progress = new QProgressDialog("Downloading Forecast Data...", QString(), 0, 0, ui->centralwidget);
-    progress->setWindowModality(Qt::WindowModal);
-    progress->setCancelButton(nullptr);
-    progress->setMinimumDuration(0);
-    progress->setAutoClose(true);
-    progress->show();
-
-    int hours = ui->weatherModelSpinBox->value();
-
-    futureWatcher = new QFutureWatcher<int>(this);
-    QFuture<int> future;
-
-    if (ui->weatherModelComboBox->currentText().contains("PASTCAST"))
-    {
-        progress->setLabelText("Downloading Pastcast Data...");
-
-        QDateTime start = ui->pastcastStartDateTimeEdit->dateTime();
-        QDateTime end   = ui->pastcastEndDateTimeEdit->dateTime();
-
-        future = QtConcurrent::run(
-            &WeatherModelInput::fetchPastcastWeather,
-            this,
-            ninjaTools,
-            ui->weatherModelComboBox->currentText(),
-            ui->elevationInputFileLineEdit->property("fullpath").toString(),
-            ui->timeZoneComboBox->currentText(),
-            start.date().year(), start.date().month(), start.date().day(), start.time().hour(),
-            end.date().year(),   end.date().month(),   end.date().day(),   end.time().hour());
-    }
-    else
-    {
-        future = QtConcurrent::run(
-            &WeatherModelInput::fetchForecastWeather,
-            this,
-            ninjaTools,
-            ui->weatherModelComboBox->currentText(),
-            ui->elevationInputFileLineEdit->property("fullpath").toString(),
-            hours);
-    }
-
-    futureWatcher->setFuture(future);
-
-    connect(futureWatcher, &QFutureWatcher<int>::finished,
-            this, &WeatherModelInput::weatherModelDownloadFinished);
-    connect(progress, &QProgressDialog::canceled, this, &WeatherModelInput::weatherModelDownloadFinished);
-}
-
 void WeatherModelInput::updateProgressMessage(const QString message)
 {
     if(progress)
@@ -200,6 +149,70 @@ static void comMessageHandler(const char *pszMessage, void *pUser)
         emit self->updateProgressMessageSignal(QString::fromStdString(msg));
         emit self->writeToConsoleSignal(QString::fromStdString(msg));
     }
+}
+
+void WeatherModelInput::weatherModelDownloadButtonClicked()
+{
+    emit writeToConsoleSignal("Downloading weather model data...");
+
+    progress = new QProgressDialog("Downloading Forecast Data...", QString(), 0, 0, ui->centralwidget);
+    progress->setWindowModality(Qt::WindowModal);
+    progress->setCancelButton(nullptr);
+    progress->setMinimumDuration(0);
+    progress->setAutoClose(true);
+    progress->show();
+
+    int hours = ui->weatherModelSpinBox->value();
+
+    futureWatcher = new QFutureWatcher<int>(this);
+    QFuture<int> future;
+
+    if (ui->weatherModelComboBox->currentText().contains("PASTCAST"))
+    {
+        progress->setLabelText("Downloading Pastcast Data...");
+
+        QDateTime start = ui->pastcastStartDateTimeEdit->dateTime();
+        QDateTime end   = ui->pastcastEndDateTimeEdit->dateTime();
+
+        if(start > end)
+        {
+            qCritical() << "Invalid Range: The start time must be before the stop time.";
+            comMessageHandler("Invalid Range: The start time must be before the stop time.", this);
+            return;
+        }
+        if(start.daysTo(end) > 14)
+        {
+            qCritical() << "Invalid Range: The time range cannot exceed 14 days.";
+            comMessageHandler("Invalid Range: The time range cannot exceed 14 days.", this);
+            return;
+        }
+
+        future = QtConcurrent::run(
+            &WeatherModelInput::fetchPastcastWeather,
+            this,
+            ninjaTools,
+            ui->weatherModelComboBox->currentText(),
+            ui->elevationInputFileLineEdit->property("fullpath").toString(),
+            ui->timeZoneComboBox->currentText(),
+            start.date().year(), start.date().month(), start.date().day(), start.time().hour(),
+            end.date().year(),   end.date().month(),   end.date().day(),   end.time().hour());
+    }
+    else
+    {
+        future = QtConcurrent::run(
+            &WeatherModelInput::fetchForecastWeather,
+            this,
+            ninjaTools,
+            ui->weatherModelComboBox->currentText(),
+            ui->elevationInputFileLineEdit->property("fullpath").toString(),
+            hours);
+    }
+
+    futureWatcher->setFuture(future);
+
+    connect(futureWatcher, &QFutureWatcher<int>::finished,
+            this, &WeatherModelInput::weatherModelDownloadFinished);
+    connect(progress, &QProgressDialog::canceled, this, &WeatherModelInput::weatherModelDownloadFinished);
 }
 
 int WeatherModelInput::fetchForecastWeather(

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -174,12 +174,6 @@ void WeatherModelInput::weatherModelDownloadButtonClicked()
         QDateTime start = ui->pastcastStartDateTimeEdit->dateTime();
         QDateTime end   = ui->pastcastEndDateTimeEdit->dateTime();
 
-        if(start > end)
-        {
-            qCritical() << "Invalid Range: The start time must be before the stop time.";
-            comMessageHandler("Invalid Range: The start time must be before the stop time.", this);
-            return;
-        }
         if(start.daysTo(end) > 14)
         {
             qCritical() << "Invalid Range: The time range cannot exceed 14 days.";


### PR DESCRIPTION
scoured the old qt4 GUI code, for any remaining `icons` and `toolTips`. Also scoured over the old qt4 GUI code, for any remaining solver checks, `QMessageBox`, and `QProgressDialog` methods.

this should have wrapped up any remaining work related to issue #711, should hopefully never need to do an overall look at the old qt4 GUI code ever again, just specific individual parts when/if they come up, which is a lot easier.