### PR TITLE
Improved "Number of Available Processors" checks and allowable ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,16 @@ else()
     find_package(NetCDF)
 endif(MSVC)
 
+# Find hwloc
+find_path(HWLOC_INCLUDE_DIR hwloc.h)
+find_library(HWLOC_LIBRARY hwloc)
+if(NOT HWLOC_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not find hwloc.h")
+endif()
+if(NOT HWLOC_LIBRARY)
+    message(FATAL_ERROR "Could not find the hwloc library")
+endif()
+
 # Environment Variables for NSIS installer
 option(FIRELAB_PACKAGE "CMake options for installer environment variables" OFF)
 mark_as_advanced(FIRELAB_PACKAGE)

--- a/scripts/build_deps_ubuntu_2204.sh
+++ b/scripts/build_deps_ubuntu_2204.sh
@@ -25,6 +25,9 @@ sudo apt install -y \
     libproj-dev \
     libpoppler-dev
 
+# Install hwloc
+sudo apt install -y libhwloc-dev
+
 # Use OpenFOAM 9; OpenFOAM 8 not available for Ubuntu 22.04
 # add the dl.openfoam.org repo and install OpenFOAM 9
 sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key > /etc/apt/trusted.gpg.d/openfoam.asc"

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -27,7 +27,8 @@ include_directories(${PROJECT_SOURCE_DIR}/src
 set(LINK_LIBS ${Boost_LIBRARIES}
               ${GDAL_LIBRARY}
               ${NETCDF_LIBRARIES_C}
-              ${CURL_LIBRARIES})
+              ${CURL_LIBRARIES}
+              ${HWLOC_LIBRARY})
 
 if(WIN32 OR APPLE)
     set(LINK_LIBS ${LINK_LIBS} ${PROJECT_BINARY_DIR}/src/ninja/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}ninja${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -72,8 +72,14 @@ endif()
 
 find_package(GDAL REQUIRED)
 
+find_path(HWLOC_INCLUDE_DIR hwloc.h)
+find_library(HWLOC_LIBRARY hwloc)
+##find_package(hwloc REQUIRED)
+
+target_include_directories(WindNinja PRIVATE ${HWLOC_INCLUDE_DIR})
+
 if(WIN32)
-  target_link_libraries(WindNinja PRIVATE shapelib::shp)
+  target_link_libraries(WindNinja PRIVATE shapelib::shp ${HWLOC_LIBRARY})
 endif()
 
 target_link_libraries(WindNinja
@@ -83,7 +89,10 @@ target_link_libraries(WindNinja
     Qt6::Core
     PRIVATE ninja
     GDAL::GDAL
+    ${HWLOC_LIBRARY}
 )
+
+target_compile_definitions(WindNinja PRIVATE WITH_HWLOC)
 
 include(GNUInstallDirs)
 install(TARGETS WindNinja

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -72,14 +72,8 @@ endif()
 
 find_package(GDAL REQUIRED)
 
-find_path(HWLOC_INCLUDE_DIR hwloc.h)
-find_library(HWLOC_LIBRARY hwloc)
-##find_package(hwloc REQUIRED)
-
-target_include_directories(WindNinja PRIVATE ${HWLOC_INCLUDE_DIR})
-
 if(WIN32)
-  target_link_libraries(WindNinja PRIVATE shapelib::shp ${HWLOC_LIBRARY})
+  target_link_libraries(WindNinja PRIVATE shapelib::shp)
 endif()
 
 target_link_libraries(WindNinja
@@ -89,10 +83,7 @@ target_link_libraries(WindNinja
     Qt6::Core
     PRIVATE ninja
     GDAL::GDAL
-    ${HWLOC_LIBRARY}
 )
-
-target_compile_definitions(WindNinja PRIVATE WITH_HWLOC)
 
 include(GNUInstallDirs)
 install(TARGETS WindNinja

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -102,23 +102,28 @@ MainWindow::MainWindow(QWidget *parent)
     ui->treeWidget->blockSignals(false);
 
     nThreads = QThread::idealThreadCount();
+    nCores = countNumCores();
 
-    hwloc_topology_t topology;
-    hwloc_topology_init(&topology);
-    hwloc_topology_load(topology);
+    if(nProcessors == -1)
+    {
+        if(ui->momentumSolverCheckBox->isChecked())
+        {
+            nProcessors = nCores;
+        }
+        else
+        {
+            nProcessors = nThreads;
+        }
+    }
 
-    nCores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
-
-    hwloc_topology_destroy(topology);
+    ui->numberOfProcessorsSpinBox->setValue(nProcessors);
 
     ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
     ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
-    ui->numberOfProcessorsSpinBox->setValue(nThreads);
     if(ui->momentumSolverCheckBox->isChecked())
     {
         ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
         ui->numberOfProcessorsSpinBox->setMaximum(nCores);
-        ui->numberOfProcessorsSpinBox->setValue(nCores);
     }
 
     QString version(NINJA_VERSION_STRING);
@@ -329,6 +334,21 @@ void MainWindow::connectSignals()
     connect(mapBridge, &MapBridge::mapLayersLoadingFinishedSignal, menuBar, &MenuBar::mapVisualizationLoadFinished);
 }
 
+int MainWindow::countNumCores()
+{
+    int coresCount;
+
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    hwloc_topology_load(topology);
+
+    coresCount = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+
+    hwloc_topology_destroy(topology);
+
+    return coresCount;
+}
+
 void MainWindow::cancelSolve()
 {
     progressDialog->setLabelText("Canceling...");
@@ -367,9 +387,16 @@ void MainWindow::massSolverCheckBoxToggled()
     ui->pointInitializationGroupBox->setToolTip("");
     ui->ninjafoamCaseGroupBox->setVisible(false);
 
+    if(ui->numberOfProcessorsSpinBox->value() > nThreads)
+    {
+        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
+        if(nProcessors > nThreads)
+        {
+            ui->numberOfProcessorsSpinBox->setValue(nThreads);
+        }
+    }
     ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
     ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
-    ui->numberOfProcessorsSpinBox->setValue(nThreads);
 
     if(ui->momentumSolverCheckBox->isChecked())
     {
@@ -408,9 +435,16 @@ void MainWindow::momentumSolverCheckBoxToggled()
     ui->pointInitializationGroupBox->setToolTip("The point initialization option is not currently available for the momentum solver.");
     ui->ninjafoamCaseGroupBox->setVisible(true);
 
+    if(ui->numberOfProcessorsSpinBox->value() > nCores)
+    {
+        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
+        if(nProcessors > nCores)
+        {
+            ui->numberOfProcessorsSpinBox->setValue(nCores);
+        }
+    }
     ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
     ui->numberOfProcessorsSpinBox->setMaximum(nCores);
-    ui->numberOfProcessorsSpinBox->setValue(nCores);
 
     if(ui->massSolverCheckBox->isChecked())
     {
@@ -1616,7 +1650,8 @@ void MainWindow::readSettings()
     }
     if(settings.contains("nProcessors"))
     {
-        ui->numberOfProcessorsSpinBox->setValue(settings.value("nProcessors").toInt());
+        nProcessors = settings.value("nProcessors").toInt();
+        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
     }
 
     writeToConsole("Settings read successfully.", Qt::darkGreen);

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -108,22 +108,30 @@ MainWindow::MainWindow(QWidget *parent)
     {
         if(ui->momentumSolverCheckBox->isChecked())
         {
-            nProcessors = nCores;
+            ui->numberOfProcessorsSpinBox->setValue(nCores);
+            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
+            ui->numberOfProcessorsSpinBox->setMaximum(nCores);
         }
         else
         {
-            nProcessors = nThreads;
+            ui->numberOfProcessorsSpinBox->setValue(nThreads);
+            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
+            ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
         }
     }
-
-    ui->numberOfProcessorsSpinBox->setValue(nProcessors);
-
-    ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
-    ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
-    if(ui->momentumSolverCheckBox->isChecked())
+    else
     {
-        ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
-        ui->numberOfProcessorsSpinBox->setMaximum(nCores);
+        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
+        if(ui->momentumSolverCheckBox->isChecked())
+        {
+            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
+            ui->numberOfProcessorsSpinBox->setMaximum(nCores);
+        }
+        else
+        {
+            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
+            ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
+        }
     }
 
     QString version(NINJA_VERSION_STRING);

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -389,11 +389,7 @@ void MainWindow::massSolverCheckBoxToggled()
 
     if(ui->numberOfProcessorsSpinBox->value() > nThreads)
     {
-        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
-        if(nProcessors > nThreads)
-        {
-            ui->numberOfProcessorsSpinBox->setValue(nThreads);
-        }
+        ui->numberOfProcessorsSpinBox->setValue(nThreads);
     }
     ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
     ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
@@ -437,11 +433,7 @@ void MainWindow::momentumSolverCheckBoxToggled()
 
     if(ui->numberOfProcessorsSpinBox->value() > nCores)
     {
-        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
-        if(nProcessors > nCores)
-        {
-            ui->numberOfProcessorsSpinBox->setValue(nCores);
-        }
+        ui->numberOfProcessorsSpinBox->setValue(nCores);
     }
     ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
     ui->numberOfProcessorsSpinBox->setMaximum(nCores);

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -101,10 +101,25 @@ MainWindow::MainWindow(QWidget *parent)
     ui->inputsStackedWidget->setCurrentIndex(1);
     ui->treeWidget->blockSignals(false);
 
-    int nCPUs = QThread::idealThreadCount();
-    ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCPUs));
-    ui->numberOfProcessorsSpinBox->setMaximum(nCPUs);
-    ui->numberOfProcessorsSpinBox->setValue(nCPUs);
+    nThreads = QThread::idealThreadCount();
+
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    hwloc_topology_load(topology);
+
+    nCores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+
+    hwloc_topology_destroy(topology);
+
+    ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
+    ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
+    ui->numberOfProcessorsSpinBox->setValue(nThreads);
+    if(ui->momentumSolverCheckBox->isChecked())
+    {
+        ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
+        ui->numberOfProcessorsSpinBox->setMaximum(nCores);
+        ui->numberOfProcessorsSpinBox->setValue(nCores);
+    }
 
     QString version(NINJA_VERSION_STRING);
     version = "Welcome to WindNinja " + version;
@@ -352,6 +367,10 @@ void MainWindow::massSolverCheckBoxToggled()
     ui->pointInitializationGroupBox->setToolTip("");
     ui->ninjafoamCaseGroupBox->setVisible(false);
 
+    ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
+    ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
+    ui->numberOfProcessorsSpinBox->setValue(nThreads);
+
     if(ui->momentumSolverCheckBox->isChecked())
     {
         ui->momentumSolverCheckBox->setChecked(false);
@@ -388,6 +407,10 @@ void MainWindow::momentumSolverCheckBoxToggled()
     ui->pointInitializationGroupBox->setDisabled(true);
     ui->pointInitializationGroupBox->setToolTip("The point initialization option is not currently available for the momentum solver.");
     ui->ninjafoamCaseGroupBox->setVisible(true);
+
+    ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
+    ui->numberOfProcessorsSpinBox->setMaximum(nCores);
+    ui->numberOfProcessorsSpinBox->setValue(nCores);
 
     if(ui->massSolverCheckBox->isChecked())
     {

--- a/src/gui/mainWindow.cpp
+++ b/src/gui/mainWindow.cpp
@@ -104,34 +104,31 @@ MainWindow::MainWindow(QWidget *parent)
     nThreads = QThread::idealThreadCount();
     nCores = countNumCores();
 
-    if(nProcessors == -1)
+    if(nProcessors != -1)
+    {
+        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
+    }
+    else
     {
         if(ui->momentumSolverCheckBox->isChecked())
         {
             ui->numberOfProcessorsSpinBox->setValue(nCores);
-            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
-            ui->numberOfProcessorsSpinBox->setMaximum(nCores);
         }
         else
         {
             ui->numberOfProcessorsSpinBox->setValue(nThreads);
-            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
-            ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
         }
+    }
+
+    if(ui->momentumSolverCheckBox->isChecked())
+    {
+        ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
+        ui->numberOfProcessorsSpinBox->setMaximum(nCores);
     }
     else
     {
-        ui->numberOfProcessorsSpinBox->setValue(nProcessors);
-        if(ui->momentumSolverCheckBox->isChecked())
-        {
-            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nCores));
-            ui->numberOfProcessorsSpinBox->setMaximum(nCores);
-        }
-        else
-        {
-            ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
-            ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
-        }
+        ui->availableProcessorsLabel->setText("Available Processors:  " + QString::number(nThreads));
+        ui->numberOfProcessorsSpinBox->setMaximum(nThreads);
     }
 
     QString version(NINJA_VERSION_STRING);

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -141,9 +141,10 @@ private:
 
     QDir outputDir;
 
-    int nThreads;
-    int nCores;
+    int nThreads;  // max available
+    int nCores;  // max available
     int countNumCores();
+    int nProcessors = -1;  // settings value
 
     int startSolve(int numProcessors);
     void finishedSolve();

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -141,8 +141,8 @@ private:
 
     QDir outputDir;
 
-    int nThreads;  // max available
-    int nCores;  // max available
+    int nThreads;
+    int nCores;
     int countNumCores();
     int nProcessors = -1;  // settings value
 

--- a/src/gui/mainWindow.h
+++ b/src/gui/mainWindow.h
@@ -72,6 +72,8 @@
 #include <vector>
 #include <string>
 
+#include <hwloc.h>
+
 struct OutputPDFSize {
     double PDFHeight;
     double PDFWidth;
@@ -138,6 +140,10 @@ private:
     QFutureWatcher<int> *futureWatcher;
 
     QDir outputDir;
+
+    int nThreads;
+    int nCores;
+    int countNumCores();
 
     int startSolve(int numProcessors);
     void finishedSolve();

--- a/src/ninja/CMakeLists.txt
+++ b/src/ninja/CMakeLists.txt
@@ -27,6 +27,7 @@ set(NINJA_INCLUDES ${NETCDF_INCLUDES}
                    ${GDAL_SYSTEM_INCLUDE} ${GDAL_INCLUDE_DIR}
                    ${CURL_INCLUDE_DIRS}
                    ${Boost_INCLUDE_DIRS}
+                   ${HWLOC_INCLUDE_DIR}
                    ${PROJECT_SOURCE_DIR}/src)
 
 set(NINJA_SOURCES air.cpp
@@ -140,7 +141,8 @@ set(LINK_LIBS ${NETCDF_LIBRARIES_C}
               ${GDAL_LIBRARY} 
               ${CURL_LIBRARIES}
               ${Boost_LIBRARIES}
-              ${SHAPELIB_LIBRARY})
+              ${SHAPELIB_LIBRARY}
+              ${HWLOC_LIBRARY})
 
 
 include_directories(${NINJA_INCLUDES})

--- a/src/ninja/cli.cpp
+++ b/src/ninja/cli.cpp
@@ -137,6 +137,21 @@ const std::string* get_checked_elevation_file (po::variables_map& vm)
     }
 }
 
+int countNumCores()
+{
+    int coresCount;
+
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    hwloc_topology_load(topology);
+
+    coresCount = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+
+    hwloc_topology_destroy(topology);
+
+    return coresCount;
+}
+
 /**
  * Command line implementation (CLI) of WindNinja.  Can be run using command line args or
  * from an input file.
@@ -602,6 +617,41 @@ int windNinjaCLI(int argc, char* argv[])
                  }
             }
         }
+
+        #ifdef NINJAFOAM
+        if(vm["momentum_flag"].as<bool>())
+        {
+            int nMaxCores = countNumCores();
+            if(vm["num_threads"].as<int>() > nMaxCores)
+            {
+                ostringstream os;
+                os << "Option 'num_threads' '" << vm["num_threads"].as<int>() << "' is greater than maxNumCores '" << nMaxCores << "' when option 'momentum_flag' is set to 'true'.";
+                throw std::range_error(os.str());
+            }
+        }
+        else
+        {
+            #ifdef _OPENMP
+            int nMaxThreads = omp_get_num_procs();
+            if(vm["num_threads"].as<int>() > nMaxThreads)
+            {
+                ostringstream os;
+                os << "Option 'num_threads' '" << vm["num_threads"].as<int>() << "' is greater than maxNumThreads '" << nMaxThreads << "' when option 'momentum_flag' is set to 'false'.";
+                throw std::range_error(os.str());
+            }
+            #endif
+        }
+        #else // NINJAFOAM
+        #ifdef _OPENMP
+        int nMaxThreads = omp_get_num_procs();
+        if(vm["num_threads"].as<int>() > nMaxThreads)
+        {
+            ostringstream os;
+            os << "Option 'num_threads' '" << vm["num_threads"].as<int>() << "' is greater than maxNumThreads '" << nMaxThreads << "' when option 'momentum_flag' is set to 'false'.";
+            throw std::range_error(os.str());
+        }
+        #endif // NINJAFOAM
+        #endif // _OPENMP
 
         const std::string* elevation_file = get_checked_elevation_file(vm); // might either be NULL or set dynamically
         std::string output_path = vm.count("output_path") ? vm["output_path"].as<std::string>() : "";

--- a/src/ninja/cli.h
+++ b/src/ninja/cli.h
@@ -49,6 +49,8 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <iterator>
 
+#include <hwloc.h>
+
 //#include <QDateTime>
 
 int windNinjaCLI(int argc, char* argv[]);
@@ -73,5 +75,7 @@ inline T option_val (const po::variables_map& vm, const char* key) {
 }
 
 //bool checkArgs(string arg1, string arg2, string arg3);
+
+int countNumCores();
 
 #endif /* CLI_H */

--- a/src/ninja/ninja.cpp
+++ b/src/ninja/ninja.cpp
@@ -4712,12 +4712,24 @@ void ninja::set_position(double lat_degrees, double lat_minutes, double lat_seco
 void ninja::set_numberCPUs(int CPUs)
 {
     if(CPUs < 1)
+    {
         throw std::range_error("Number of CPUs is less than one in ninja::set_numberCPUs().");
+    }
+
+    #ifdef _OPENMP
+    int nMaxThreads = omp_get_num_procs();
+    if(CPUs > nMaxThreads)
+    {
+        ostringstream os;
+        os << "Number of CPUs '" << CPUs << "' is greater than maxNumThreads '" << nMaxThreads << "' in ninja::set_numberCPUs().";
+        throw std::range_error(os.str());
+    }
+    #endif
 
     input.numberCPUs = CPUs;
 
     #ifdef _OPENMP
-    omp_set_num_threads( input.numberCPUs );
+    omp_set_num_threads(input.numberCPUs);
     /*
         if(omp_in_parallel())
         {

--- a/src/ninja/ninja.h
+++ b/src/ninja/ninja.h
@@ -297,7 +297,7 @@ public:
 
     void set_position(double lat_degrees, double lat_minutes, double long_degrees, double long_minutes);	//input as degrees, decimal minutes
     void set_position(double lat_degrees, double lat_minutes, double lat_seconds, double long_degrees, double long_minutes, double long_seconds);	//input as degrees, minutes, seconds
-    void set_numberCPUs(int CPUs);
+    virtual void set_numberCPUs(int CPUs);
     void set_outputSpeedGridResolution(double resolution, lengthUnits::eLengthUnits units);
     void set_outputDirectionGridResolution(double resolution, lengthUnits::eLengthUnits units);
     double *get_outputSpeedGrid();

--- a/src/ninja/ninjafoam.cpp
+++ b/src/ninja/ninjafoam.cpp
@@ -108,6 +108,43 @@ NinjaFoam::~NinjaFoam()
     CPLFree( (void*)pszTurbulenceGridFilename );
 }
 
+int NinjaFoam::countNumCores()
+{
+    int coresCount;
+
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    hwloc_topology_load(topology);
+
+    coresCount = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+
+    hwloc_topology_destroy(topology);
+
+    return coresCount;
+}
+
+void NinjaFoam::set_numberCPUs(int CPUs)
+{
+    if(CPUs < 1)
+    {
+        throw std::range_error("Number of CPUs is less than one in ninjafoam::set_numberCPUs().");
+    }
+
+    int nMaxCores = countNumCores();
+    if(CPUs > nMaxCores)
+    {
+        ostringstream os;
+        os << "Number of CPUs '" << CPUs << "' is greater than maxNumCores '" << nMaxCores << "' in ninjafoam::set_numberCPUs().";
+        throw std::range_error(os.str());
+    }
+
+    input.numberCPUs = CPUs;
+
+    #ifdef _OPENMP
+    omp_set_num_threads(input.numberCPUs);
+    #endif
+}
+
 void NinjaFoam::set_meshResolution(double resolution, lengthUnits::eLengthUnits units)
 {
     //set mesh resolution, always stored in meters

--- a/src/ninja/ninjafoam.h
+++ b/src/ninja/ninjafoam.h
@@ -41,6 +41,8 @@
 #include "gdal_alg.h"
 #include "cpl_spawn.h"
 
+#include <hwloc.h>
+
 #define PIPE_BUFFER_SIZE 4096
 
 #define NINJA_FOAM_OGR_VRT "<OGRVRTDataSource>" \
@@ -76,6 +78,8 @@ public:
     virtual bool simulate_wind();
     inline virtual std::string identify() {return std::string("ninjafoam");}
 
+    int countNumCores();
+    virtual void set_numberCPUs(int CPUs);
     virtual void set_meshResolution(double resolution, lengthUnits::eLengthUnits units);
     virtual double get_meshResolution();
     static int GenerateFoamDirectory(std::string demName);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,9 @@
     },
     {
       "name": "shapelib"
+    },
+    {
+      "name": "hwloc"
     }
   ]
 }


### PR DESCRIPTION
added `hwloc` as a dependency, to be able to determine `numCores` instead of just `numThreads`, as OpenMPI for OpenFOAM fails for `numCores` instead of `numThreads`.

also tested the build on Windows.