### PR TITLE
fix to the time zone info of the wxModel UCAR times

### DIFF
--- a/autotest/api/test_capi_fetching.c
+++ b/autotest/api/test_capi_fetching.c
@@ -131,8 +131,9 @@ int main()
      * NOMADS-RAP-NORTH-AMERICA-32-KM
     */
     const char * demFileForecast = demFileBBox; // input DEM file
+    const char* osTimeZone_forecast = "UTC";
     int numForecastHours = 1;
-    err = NinjaFetchWeatherData(ninjaTools, wx_model_type, demFileForecast, numForecastHours);//, papszOptions);
+    err = NinjaFetchWeatherData(ninjaTools, wx_model_type, demFileForecast, osTimeZone_forecast, numForecastHours);//, papszOptions);
     if(err != NINJA_SUCCESS)
     {
         printf("NinjaFetchWeatherData: err = %d\n", err);

--- a/src/gui/weatherModelInput.cpp
+++ b/src/gui/weatherModelInput.cpp
@@ -211,6 +211,7 @@ void WeatherModelInput::weatherModelDownloadButtonClicked()
             ninjaTools,
             ui->weatherModelComboBox->currentText(),
             ui->elevationInputFileLineEdit->property("fullpath").toString(),
+            ui->timeZoneComboBox->currentText(),
             hours);
     }
 
@@ -225,15 +226,18 @@ int WeatherModelInput::fetchForecastWeather(
     NinjaToolsH* ninjaTools,
     const QString& modelIdentifierStr,
     const QString& demFileStr,
+    const QString& timeZoneStr,
     int hours)
 {
     QByteArray modelIdentifierTemp = modelIdentifierStr.toUtf8();
     QByteArray demFileTemp = demFileStr.toUtf8();
+    QByteArray timeZoneTemp = timeZoneStr.toUtf8();
 
     const char* modelIdentifier = modelIdentifierTemp.constData();
     const char* demFile = demFileTemp.constData();
+    const char* timeZone = timeZoneTemp.constData();
 
-    NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, hours);
+    NinjaErr ninjaErr = NinjaFetchWeatherData(ninjaTools, modelIdentifier, demFile, timeZone, hours);
     if(ninjaErr != NINJA_SUCCESS)
     {
         qDebug() << "NinjaFetchWeatherData: ninjaErr =" << ninjaErr;

--- a/src/gui/weatherModelInput.h
+++ b/src/gui/weatherModelInput.h
@@ -103,6 +103,7 @@ private:
         NinjaToolsH* ninjaTools,
         const QString& modelIdentifierStr,
         const QString& demFileStr,
+        const QString& timeZoneStr,
         int hours);
 
     int fetchPastcastWeather(

--- a/src/hrrr_to_kmz/hrrr_to_kmz.cpp
+++ b/src/hrrr_to_kmz/hrrr_to_kmz.cpp
@@ -97,9 +97,9 @@ std::vector<std::string> getVariableList()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void checkForValidData( std::string wxModelFileName )
+void checkForValidData(std::string wxModelFileName, std::string timeZoneString="")
 {
-
+    (void)timeZoneString;
 }
 
 
@@ -157,7 +157,6 @@ GDALRasterBand* get10UBand (GDALDataset *srcDS) {
 std::vector<blt::local_date_time>
 getTimeList( const std::string &timeZoneString, const std::string &wxModelFileName )
 {
-
     const char *pszVariable = NULL;
 
     boost::local_time::time_zone_ptr timeZonePtr;
@@ -848,7 +847,7 @@ int main( int argc, char* argv[] )
         NinjaFinalize();
         throw badForecastFile("input input_hrrr_filename is not a valid hrrr file!!!");
     }
-    checkForValidData( input_hrrr_filename );
+    checkForValidData(input_hrrr_filename);
 
 
     std::string timeZoneString = getTimeZoneString( cenLat, cenLon );

--- a/src/ninja/cli.cpp
+++ b/src/ninja/cli.cpp
@@ -1071,7 +1071,7 @@ int windNinjaCLI(int argc, char* argv[])
                   if (model->getForecastIdentifier() != "PASTCAST-GCP-HRRR-CONUS-3-KM")
                   {
                     std::cout << "Downloading forecast data..." << std::endl;
-                    forecastFileName = model->fetchForecast(*elevation_file, vm["forecast_duration"].as<int>());
+                    forecastFileName = model->fetchForecast(*elevation_file, vm["forecast_duration"].as<int>(), osTimeZone);
                     std::cout << "Download complete." << std::endl;
                   }
                   else {
@@ -1175,7 +1175,7 @@ int windNinjaCLI(int argc, char* argv[])
                                                );
 
                     std::cout << "Downloading forecast data..." << std::endl;
-                    forecastFileName = model->fetchForecast(*elevation_file, 1);
+                    forecastFileName = model->fetchForecast(*elevation_file, 1, osTimeZone);
                     std::cout << "Download complete." << std::endl;
                   }
 

--- a/src/ninja/gcp_wx_init.cpp
+++ b/src/ninja/gcp_wx_init.cpp
@@ -157,8 +157,10 @@ GCPWxModel::getTimeList(const char *pszVariable, blt::time_zone_ptr timeZonePtr)
     return aoCachedTimes;
 }
 
-std::string GCPWxModel::fetchForecast(std::string demFile, int nhours)
+std::string GCPWxModel::fetchForecast(std::string demFile, int nhours, std::string timeZoneString)
 {
+    (void)timeZoneString;
+
     if(CPLGetConfigOption("GS_SECRET_ACCESS_KEY", NULL) == NULL || CPLGetConfigOption("GS_ACCESS_KEY_ID", NULL) == NULL)
     {
         if(CPLGetConfigOption("GS_OAUTH2_PRIVATE_KEY_FILE", NULL) == NULL || CPLGetConfigOption("GS_OAUTH2_CLIENT_EMAIL", NULL) == NULL)
@@ -832,8 +834,9 @@ char* GCPWxModel::FindForecast(const char* pszFilePath, time_t nTime)
     return NULL;
 }
 
-void GCPWxModel::checkForValidData()
+void GCPWxModel::checkForValidData(std::string timeZoneString)
 {
+    (void)timeZoneString;
     return;
 }
 

--- a/src/ninja/gcp_wx_init.h
+++ b/src/ninja/gcp_wx_init.h
@@ -57,7 +57,7 @@ public:
     GCPWxModel(GCPWxModel const&A);
     virtual ~GCPWxModel();
 
-    virtual std::string fetchForecast( std::string demFile, int nhours);
+    virtual std::string fetchForecast(std::string demFile, int nhours, std::string timeZoneString);
 
     virtual std::vector<blt::local_date_time>
     getTimeList(const char *pszVariable, blt::time_zone_ptr timeZonePtr);
@@ -71,7 +71,7 @@ public:
     virtual double getGridResolution();
     virtual int getStartHour();
     virtual int getEndHour();
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height() { return 10; }
     virtual void setSurfaceGrids( WindNinjaInputs &input,
                                AsciiGrid<double> &airGrid,

--- a/src/ninja/genericSurfInitialization.cpp
+++ b/src/ninja/genericSurfInitialization.cpp
@@ -134,7 +134,7 @@ int genericSurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void genericSurfInitialization::checkForValidData()
+void genericSurfInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -144,16 +144,24 @@ void genericSurfInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/genericSurfInitialization.h
+++ b/src/ninja/genericSurfInitialization.h
@@ -55,7 +55,7 @@ class genericSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepGfsSurfInitialization.cpp
+++ b/src/ninja/ncepGfsSurfInitialization.cpp
@@ -143,7 +143,7 @@ int ncepGfsSurfInitialization::getEndHour()
 * we don't have to check for the projection string, it is just hard coded in
 * the warp code.  So we don't check it here.
 */
-void ncepGfsSurfInitialization::checkForValidData()
+void ncepGfsSurfInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -153,16 +153,24 @@ void ncepGfsSurfInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/ncepGfsSurfInitialization.h
+++ b/src/ninja/ncepGfsSurfInitialization.h
@@ -53,7 +53,7 @@ class ncepGfsSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepHrrrSurfInitialization.cpp
+++ b/src/ninja/ncepHrrrSurfInitialization.cpp
@@ -135,9 +135,9 @@ int ncepHrrrSurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepHrrrSurfInitialization::checkForValidData()
+void ncepHrrrSurfInitialization::checkForValidData(std::string timeZoneString)
 {
-
+    (void)timeZoneString;
 }
 
 /**

--- a/src/ninja/ncepHrrrSurfInitialization.h
+++ b/src/ninja/ncepHrrrSurfInitialization.h
@@ -55,7 +55,7 @@ class ncepHrrrSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepNamAlaskaSurfInitialization.cpp
+++ b/src/ninja/ncepNamAlaskaSurfInitialization.cpp
@@ -127,7 +127,7 @@ int ncepNamAlaskaSurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepNamAlaskaSurfInitialization::checkForValidData()
+void ncepNamAlaskaSurfInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -137,16 +137,24 @@ void ncepNamAlaskaSurfInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/ncepNamAlaskaSurfInitialization.h
+++ b/src/ninja/ncepNamAlaskaSurfInitialization.h
@@ -53,7 +53,7 @@ class ncepNamAlaskaSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepNamGrib2SurfInitialization.cpp
+++ b/src/ninja/ncepNamGrib2SurfInitialization.cpp
@@ -136,9 +136,9 @@ int ncepNamGrib2SurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepNamGrib2SurfInitialization::checkForValidData()
+void ncepNamGrib2SurfInitialization::checkForValidData(std::string timeZoneString)
 {
-
+    (void)timeZoneString;
 }
 
 /**

--- a/src/ninja/ncepNamGrib2SurfInitialization.h
+++ b/src/ninja/ncepNamGrib2SurfInitialization.h
@@ -55,7 +55,7 @@ class ncepNamGrib2SurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepNamSurfInitialization.cpp
+++ b/src/ninja/ncepNamSurfInitialization.cpp
@@ -127,7 +127,7 @@ int ncepNamSurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepNamSurfInitialization::checkForValidData()
+void ncepNamSurfInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -137,16 +137,24 @@ void ncepNamSurfInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/ncepNamSurfInitialization.h
+++ b/src/ninja/ncepNamSurfInitialization.h
@@ -52,7 +52,7 @@ class ncepNamSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepNdfdInitialization.cpp
+++ b/src/ninja/ncepNdfdInitialization.cpp
@@ -153,7 +153,7 @@ int ncepNdfdInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepNdfdInitialization::checkForValidData()
+void ncepNdfdInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -163,19 +163,26 @@ void ncepNdfdInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
-    //std::vector<boost::local_time::local_date_time> timeListMax( getTempTimeList(max, zone) );
-    //std::vector<boost::local_time::local_date_time> timeListMin( getTempTimeList(min, zone) );
-
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
+    //std::vector<boost::local_time::local_date_time> timeListMax(getTempTimeList(max,timeZonePtr));
+    //std::vector<boost::local_time::local_date_time> timeListMin(getTempTimeList(min,timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/ncepNdfdInitialization.h
+++ b/src/ninja/ncepNdfdInitialization.h
@@ -54,7 +54,7 @@ class ncepNdfdInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ncepRapSurfInitialization.cpp
+++ b/src/ninja/ncepRapSurfInitialization.cpp
@@ -128,7 +128,7 @@ int ncepRapSurfInitialization::getEndHour()
 /**
 * Checks the downloaded data to see if it is all valid.
 */
-void ncepRapSurfInitialization::checkForValidData()
+void ncepRapSurfInitialization::checkForValidData(std::string timeZoneString)
 {
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
@@ -138,16 +138,24 @@ void ncepRapSurfInitialization::checkForValidData()
     }
     GDALClose((GDALDatasetH)srcDS);
 
-    //just make up a "dummy" timezone for use here
-    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("MST-07"));
+    boost::local_time::time_zone_ptr timeZonePtr;
+    timeZonePtr = globalTimeZoneDB.time_zone_from_region(timeZoneString.c_str());
+    if(timeZonePtr == NULL)
+    {
+        ostringstream os;
+        os << "The time zone string: " << timeZoneString.c_str()
+           << " does not match any in "
+           << "the time zone database file: date_time_zonespec.csv.";
+        throw std::runtime_error(os.str());
+    }
 
     //get time list
-    std::vector<boost::local_time::local_date_time> timeList( getTimeList(zone) );
+    std::vector<boost::local_time::local_date_time> timeList(getTimeList(timeZonePtr));
 
     boost::posix_time::ptime pt_low(boost::gregorian::date(1900,boost::gregorian::Jan,1), boost::posix_time::hours(12));
     boost::posix_time::ptime pt_high(boost::gregorian::date(2100,boost::gregorian::Jan,1), boost::posix_time::hours(12));
-    boost::local_time::local_date_time low_time(pt_low, zone);
-    boost::local_time::local_date_time high_time(pt_high, zone);
+    boost::local_time::local_date_time low_time(pt_low, timeZonePtr);
+    boost::local_time::local_date_time high_time(pt_high, timeZonePtr);
 
     //check times
     for(unsigned int i = 0; i < timeList.size(); i++)

--- a/src/ninja/ncepRapSurfInitialization.h
+++ b/src/ninja/ncepRapSurfInitialization.h
@@ -56,7 +56,7 @@ class ncepRapSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/ninjaArmy.cpp
+++ b/src/ninja/ninjaArmy.cpp
@@ -265,7 +265,7 @@ void ninjaArmy::makeWeatherModelArmy(std::string forecastFilename, std::string t
 
     try
     {
-        model->checkForValidData();
+        model->checkForValidData(timeZone);
     }
     catch(armyException &e)
     {

--- a/src/ninja/ninjaTools.cpp
+++ b/src/ninja/ninjaTools.cpp
@@ -276,7 +276,7 @@ int ninjaTools::fetchDEMPoint(double * adfPoint,double *adfBuff, const char* uni
     return NINJA_SUCCESS;
 }
 
-int ninjaTools::fetchWeatherModelData(const char* modelName, const char* demFile, int hours)
+int ninjaTools::fetchWeatherModelData(const char* modelName, const char* demFile, const char* timeZone, int hours)
 {
     try
     {
@@ -287,7 +287,7 @@ int ninjaTools::fetchWeatherModelData(const char* modelName, const char* demFile
             throw std::runtime_error(std::string("Weather model not found: ") + modelName);
         }
 
-        std::string forecastFileName = model->fetchForecast(demFile, hours);
+        std::string forecastFileName = model->fetchForecast(demFile, hours, timeZone);
         if(forecastFileName == "exception")
         {
             throw std::runtime_error("ninjaTools::fetchWeatherModelData() returned an invalid forecastFileName.");
@@ -355,7 +355,7 @@ int ninjaTools::fetchArchiveWeatherModelData(const char* modelName, const char* 
                                    boost::lexical_cast<std::string>(startUTC.time_of_day().hours()),
                                    boost::lexical_cast<std::string>(endUTC.time_of_day().hours()));
 
-        std::string forecastFileName = forecastModel->fetchForecast(demFile, hours);
+        std::string forecastFileName = forecastModel->fetchForecast(demFile, hours, timeZone);
         if(forecastFileName == "exception")
         {
             throw std::runtime_error("ninjaTools::fetchArchiveWeatherModelData() returned an invalid forecastFileName.");

--- a/src/ninja/ninjaTools.h
+++ b/src/ninja/ninjaTools.h
@@ -28,7 +28,7 @@ public:
     int fetchDEMBBox(double *boundsBox, const char *fileName, double resolution, const char* fetchType, char ** papszOptions=NULL );
     int fetchDEMPoint(double * adfPoint, double *adfBuff, const char* units, double dfCellSize, const char * pszDstFile, const char* fetchType, char ** papszOptions=NULL );
 
-    int fetchWeatherModelData(const char* modelName, const char* demFile, int hours);
+    int fetchWeatherModelData(const char* modelName, const char* demFile, const char* timeZone, int hours);
     int fetchArchiveWeatherModelData(const char* modelName, const char* demFile, const char* timeZone, int startYear, int startMonth, int startDay, int startHour, int endYear, int endMonth, int endDay, int endHour);
     std::vector<std::string> getForecastIdentifiers();
     std::vector<std::string> getTimeList(const char* modelName, std::string timeZone);

--- a/src/ninja/nomads_wx_init.cpp
+++ b/src/ninja/nomads_wx_init.cpp
@@ -222,7 +222,7 @@ double NomadsWxModel::getGridResolution()
     return resolution;
 }
 
-std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
+std::string NomadsWxModel::fetchForecast(std::string demFile, int nHours, std::string timeZoneString)
 {
     if( !ppszModelData )
     {
@@ -278,7 +278,7 @@ std::string NomadsWxModel::fetchForecast( std::string demFile, int nHours )
     }
     wxModelFileName = pszTmpFile;
     std::vector<blt::local_date_time> oTimes;
-    oTimes = wxModelInitialization::getTimeList();
+    oTimes = wxModelInitialization::getTimeList(timeZoneString);
     if( oTimes.size() < 1 )
     {
         throw badForecastFile("Could not get times from downloaded weather forecast file. Failed to download weather forecast.");
@@ -969,8 +969,9 @@ noCloudOK:
     GDALDestroyWarpOptions(psWarpOptions);
 }
 
-void NomadsWxModel::checkForValidData()
+void NomadsWxModel::checkForValidData(std::string timeZoneString)
 {
+    (void)timeZoneString;
     return;
 }
 

--- a/src/ninja/nomads_wx_init.h
+++ b/src/ninja/nomads_wx_init.h
@@ -43,7 +43,7 @@ public:
     NomadsWxModel( const char *pszModelKey );
     virtual ~NomadsWxModel();
 
-    virtual std::string fetchForecast( std::string demFile, int nHours );
+    virtual std::string fetchForecast(std::string demFile, int nHours, std::string timeZoneString);
 
     virtual std::vector<blt::local_date_time>
         getTimeList(const char *pszVariable, blt::time_zone_ptr timeZonePtr);
@@ -57,7 +57,7 @@ public:
     virtual double getGridResolution();
     virtual int getStartHour();
     virtual int getEndHour();
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height() { return 10; }
     virtual void setSurfaceGrids( WindNinjaInputs &input,
                                   AsciiGrid<double> &airGrid,

--- a/src/ninja/windninja.cpp
+++ b/src/ninja/windninja.cpp
@@ -269,14 +269,14 @@ WINDNINJADLL_EXPORT NinjaToolsH* NinjaMakeTools()
  * \return NINJA_SUCCESS on success, non-zero otherwise.
  */
 WINDNINJADLL_EXPORT NinjaErr NinjaFetchWeatherData
-    (NinjaToolsH* tools, const char* modelName, const char* demFile, int hours)
+    (NinjaToolsH* tools, const char* modelName, const char* demFile, const char* timeZone, int hours)
 {
     if(!tools)
     {
         return NINJA_E_NULL_PTR;
     }
 
-    return reinterpret_cast<ninjaTools*>( tools )->fetchWeatherModelData(modelName, demFile, hours);
+    return reinterpret_cast<ninjaTools*>( tools )->fetchWeatherModelData(modelName, demFile, timeZone, hours);
 }
 
 WINDNINJADLL_EXPORT NinjaErr NinjaFetchArchiveWeatherData

--- a/src/ninja/windninja.h
+++ b/src/ninja/windninja.h
@@ -106,10 +106,10 @@ typedef int  NinjaErr;
     WINDNINJADLL_EXPORT NinjaToolsH * NinjaMakeTools();
 
     WINDNINJADLL_EXPORT NinjaErr NinjaFetchWeatherData
-        (NinjaToolsH* tools, const char* modelName, const char* demFile, int hours);
+        (NinjaToolsH* tools, const char* modelName, const char* demFile, const char* timeZone, int hours);
 
     WINDNINJADLL_EXPORT NinjaErr NinjaFetchArchiveWeatherData
-        (NinjaToolsH* tools, const char* modelName, const char* demFile, const char * timeZone, int startYear, int startMonth, int startDay, int startHour, int endYear, int endMonth, int endDay, int endHour);
+        (NinjaToolsH* tools, const char* modelName, const char* demFile, const char* timeZone, int startYear, int startMonth, int startDay, int startHour, int endYear, int endMonth, int endDay, int endHour);
 
     WINDNINJADLL_EXPORT const char** NinjaGetAllWeatherModelIdentifiers(NinjaToolsH* tools, int* count);
 

--- a/src/ninja/wrfSurfInitialization.cpp
+++ b/src/ninja/wrfSurfInitialization.cpp
@@ -212,8 +212,10 @@ temperatureUnits::eTempUnits wrfSurfInitialization::processTemperatureUnits(std:
 * Checks the downloaded data to see if it is all valid.
 * May not be functional yet for this class...
 */
-void wrfSurfInitialization::checkForValidData()
+void wrfSurfInitialization::checkForValidData(std::string timeZoneString)
 {
+    (void)timeZoneString;
+
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
     if(srcDS == NULL)

--- a/src/ninja/wrfSurfInitialization.h
+++ b/src/ninja/wrfSurfInitialization.h
@@ -54,7 +54,7 @@ class wrfSurfInitialization : public wxModelInitialization
     virtual int getStartHour();
     virtual int getEndHour();
 
-    virtual void checkForValidData();
+    virtual void checkForValidData(std::string timeZoneString);
     virtual double Get_Wind_Height();
 
  protected:

--- a/src/ninja/wxModelInitialization.cpp
+++ b/src/ninja/wxModelInitialization.cpp
@@ -163,12 +163,14 @@ std::string wxModelInitialization::getPath()
  * @return a base file name, or an empty string if a filename cannot be
  * generated
  */
-std::string wxModelInitialization::generateForecastName()
+std::string wxModelInitialization::generateForecastName(std::string timeZoneString)
 {
-    if( wxModelFileName.empty() )
+    if(wxModelFileName.empty())
+    {
         return wxModelFileName;
+    }
     std::vector<boost::local_time::local_date_time>timeList;
-    timeList = getTimeList();
+    timeList = getTimeList(timeZoneString);
     std::string filename;
     filename =  bpt::to_iso_string(timeList[0].utc_time());
     //remove trailing seconds
@@ -368,8 +370,7 @@ double wxModelInitialization::GetWxModelBuffer(double delta)
  *          return string
  *
  */
-std::string wxModelInitialization::fetchForecast( std::string demFile,
-                          int nHours )
+std::string wxModelInitialization::fetchForecast(std::string demFile, int nHours, std::string timeZoneString)
 {
     /*
      * Get the bounds of the dem
@@ -500,7 +501,7 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
      */
     wxModelFileName = tempFileName;
     try{
-        checkForValidData();    //throws a badForecastFile on fail
+        checkForValidData(timeZoneString);    //throws a badForecastFile on fail
     }catch (badForecastFile& e) {   //catch a badForecastFile
         if( !bSaveForecast )
         {
@@ -520,10 +521,10 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     VSIMkdir( newPath.c_str(), 0777 );
 
     wxModelFileName = tempFileName;
-    std::string outputPath = newPath + std::string(CPLGetBasename(generateForecastName().c_str())) + "/";
+    std::string outputPath = newPath + std::string(CPLGetBasename(generateForecastName(timeZoneString).c_str())) + "/";
     VSIMkdir( outputPath.c_str(), 0777 );
 
-    std::string newFileName( outputPath + generateForecastName() );
+    std::string newFileName(outputPath + generateForecastName(timeZoneString));
 
     /*
      * check for file existance? if the file is already there, this fails on
@@ -540,7 +541,7 @@ std::string wxModelInitialization::fetchForecast( std::string demFile,
     }
     wxModelFileName = newFileName;
     try{
-        checkForValidData();
+        checkForValidData(timeZoneString);
     }
     catch( badForecastFile &e ) {
         if(!bSaveForecast)

--- a/src/ninja/wxModelInitialization.h
+++ b/src/ninja/wxModelInitialization.h
@@ -108,8 +108,8 @@ class wxModelInitialization : public initialize
                            wn_3dScalarField& w0, AsciiGrid<double>& cloud );
 
     //virtual time list functions
-    virtual std::vector<blt::local_date_time> getTimeList(std::string timeZoneString = "Africa/Timbuktu");    //Africa/Timbuktu is GMT with no daylight savings
-    virtual std::vector<blt::local_date_time> getTimeList(const char *pszVariable, std::string timeZoneString = "Africa/Timbuktu");    //Africa/Timbuktu is GMT with no daylight savings
+    virtual std::vector<blt::local_date_time> getTimeList(std::string timeZoneString);
+    virtual std::vector<blt::local_date_time> getTimeList(const char *pszVariable, std::string timeZoneString);
     virtual std::vector<blt::local_date_time> getTimeList(blt::time_zone_ptr timeZonePtr);
     virtual std::vector<blt::local_date_time> getTimeList(const char *pszVariable, blt::time_zone_ptr timeZonePtr);
 
@@ -132,7 +132,7 @@ class wxModelInitialization : public initialize
     virtual std::string getPath();
     virtual int getStartHour() = 0;
     virtual int getEndHour() = 0;
-    virtual void checkForValidData() = 0;
+    virtual void checkForValidData(std::string timeZoneString) = 0;
     virtual double Get_Wind_Height() = 0;
 
     int ComputeWxModelBuffer(GDALDataset *poDS, double buffer[4]);
@@ -140,8 +140,8 @@ class wxModelInitialization : public initialize
 
     std::string generateUrl( double north, double west, double east,
                              double south, int hours);
-    virtual std::string fetchForecast( std::string demFile, int nHours );
-    std::string generateForecastName();
+    virtual std::string fetchForecast(std::string demFile, int nHours, std::string timeZoneString);
+    std::string generateForecastName(std::string timeZoneString);
 
     void setModelFileName( std::string filename ) {wxModelFileName = filename;}
 

--- a/src/wrf_to_kmz/wrf_to_kmz.cpp
+++ b/src/wrf_to_kmz/wrf_to_kmz.cpp
@@ -190,8 +190,10 @@ std::vector<std::string> getVariableList()
 * @param wxModelFileName wrf netcdf weather model filename.
 * Comment From WindNinja code: May not be functional yet for this class...
 */
-void checkForValidData( std::string wxModelFileName )
+void checkForValidData(std::string wxModelFileName, std::string timeZoneString="")
 {
+    (void)timeZoneString;
+
     GDALDataset *srcDS;
     srcDS = (GDALDataset*)GDALOpen(wxModelFileName.c_str(), GA_ReadOnly);
     if(srcDS == NULL)


### PR DESCRIPTION
Fixes not only the wxModel UCAR times, to have the proper time zone information, but all instances of functions calling `wxModelInitialization::getTimeList()` that were being done without a proper time zone.

We originally discovered this bug, when noticing a discrepancy in the run times and the output file times, between the NOMADS and UCAR wxModel runs, in both the cli and the GUI. Upon further inspection, `wxModelInitialization::getTimeList()` was being fed proper time zone information, but was returning times that were losing their DST information. This turned out to be because earlier calls to `wxModelInitialization::getTimeList()` within other wxModelInitialization function calls, especially in the UCAR models, were being done without proper time zones. These earlier `getTimeList()` calls were cacheing these malformed times for later `getTimeList()` calls.

An example of what was happening before this fix:
1. ninjaArmy called `wxModelInitialization::checkForValidData()`: [here](https://github.com/firelab/windninja/blob/master/src/ninja/ninjaArmy.cpp#L268).
2. The `checkForValidData()` function called `wxModelInitialization::getTimeList()` without a proper time zone: [here](https://github.com/firelab/windninja/blob/master/src/ninja/genericSurfInitialization.cpp#L147-L151).
3. The `getTimeList()` function cached the malformed times, to be returned instead of recalculating fresh times with the newly input time zone on subsequent function calls: [here](https://github.com/firelab/windninja/blob/master/src/ninja/wxModelInitialization.cpp#L627-L630).
4. Then `getTimeList()` was called again in `ninjaArmy`, it used the cached malformed times. These malformed times were then used for subsequent steps like setting the runTime of the simulation and the output filename time information: [here](https://github.com/firelab/windninja/blob/master/src/ninja/ninjaArmy.cpp#L275-L278).